### PR TITLE
[Feat/#3] 사용자 세션 관리 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@tanstack/react-query": "^5.99.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
+        "react-router-dom": "^7.14.1",
+        "zod": "^4.3.6",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -1514,6 +1516,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2643,6 +2658,44 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.1.tgz",
+      "integrity": "sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.1.tgz",
+      "integrity": "sha512-ZkrQuwwhGibjQLqH1eCdyiZyLWglPxzxdl5tgwgKEyCSGC76vmAjleGocRe3J/MLfzMUIKwaFJWpFVJhK3d2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2709,6 +2762,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -3034,7 +3093,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@tanstack/react-query": "^5.99.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
+    "react-router-dom": "^7.14.1",
+    "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,36 +1,66 @@
 import { useEffect } from 'react';
-import { Home } from './pages/Home';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { useAuthStore } from './store/useAuthStore';
-// import { Lobbies } from './pages/Lobbies';
+import { Home } from './pages/Home';
+import { Lobbies } from './pages/Lobbies';
+import { LobbyRoom } from './pages/LobbyRoom'; // 개별 게임 방
 
-function App() {
-    const initializeSession = useAuthStore((state) => state.initializeSession);
+/**
+ * [아키텍처 패턴: Route Guard (라우트 가드)]
+ * @description 권한이 없는 사용자(초기 방문자)가 로그인 없이 특정 URL로 직접 접근하는 것을 막는 래퍼(Wrapper) 컴포넌트입니다.
+ */
+
+function ProtectedRoute({ children }: { children: React.ReactNode }) {
+    // Zustand 스토어에서 현재 사용자의 세션(게스트 또는 정식 회원) 존재 여부를 확인합니다.
     const isGuest = useAuthStore((state) => state.isGuest);
 
-    // 컴포넌트 마운트 시 정확히 1번만 세션 복구 로직 실행
+    // [보안 및 UX 처리]
+    // 세션이 있다면(isGuest === true), 요청한 화면(children)을 그대로 보여줍니다.
+    // 세션이 없다면, <Navigate>를 통해 즉시 "/" (홈 화면)으로 강제 이동(리다이렉트) 시킵니다.
+    // 'replace' 속성: 브라우저 뒤로 가기 기록에 이 경로를 남기지 않아, 뒤로 가기를 눌렀을 때 무한 루프에 빠지는 것을 방지합니다.
+    return isGuest ? <>{children}</> : <Navigate to="/" replace />;
+}
+
+function App() {
+    // 앱 진입 시 localStorage의 UUID를 읽어와 세션을 복구하는 로직
+    const initializeSession = useAuthStore((state) => state.initializeSession);
+
+    // 컴포넌트 마운트 시 정확히 1번만 실행됨
     useEffect(() => {
         initializeSession();
     }, [initializeSession]);
 
     return (
         <div className="w-full min-h-screen bg-black text-white">
-            {/* 세션(isGuest)이 있으면 로비 목록 등으로 보내고,
-        없으면 닉네임 입력 화면(Home)을 보여주는 라우팅 처리 예시입니다.
-      */}
-            {isGuest ? (
-                // <Lobbies />
-                <div className="p-10">
-                    <h2 className="text-2xl text-blue-400">환영합니다, 게임 로비 대기실입니다!</h2>
-                    <button
-                        onClick={() => useAuthStore.getState().clearSession()}
-                        className="mt-4 px-4 py-2 bg-red-600 rounded"
-                    >
-                        로그아웃(세션 초기화)
-                    </button>
-                </div>
-            ) : (
-                <Home />
-            )}
+            {/* [SPA 라우팅의 핵심]
+                BrowserRouter: 브라우저의 주소창 URL과 React 앱을 동기화합니다. 페이지 새로고침 없이 화면을 전환할 수 있게 해줍니다.
+            */}
+            <BrowserRouter>
+                <Routes>
+                    {/* 1. 공개 경로 (Public Route)
+                        기본 진입점: 세션이 없는 사용자가 닉네임을 입력하는 화면
+                    */}
+                    <Route path="/" element={<Home />} />
+
+                    {/* 2. 보호된 경로 (Protected Route)
+                        세션이 있어야만 접근 가능한 로비 목록 화면
+                    */}
+                    <Route
+                        path="/lobbies"
+                        element={<ProtectedRoute><Lobbies /></ProtectedRoute>}
+                    />
+
+                    {/* 3. 딥링크를 지원하는 보호된 경로 (Dynamic Route)
+                        기능명세서의 "초대 코드 발급 및 딥링크 지원" 요구사항을 충족하는 핵심 라우트입니다.
+                        예: 클립보드에 복사된 "https://domain.com/lobby/A1B2C3" 링크를 타고 들어올 때,
+                        A1B2C3가 inviteCode 파라미터로 매핑됩니다.
+                    */}
+                    <Route
+                        path="/lobby/:inviteCode"
+                        element={<ProtectedRoute><LobbyRoom /></ProtectedRoute>}
+                    />
+                </Routes>
+            </BrowserRouter>
         </div>
     );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,38 @@
-// src/App.tsx
-import { useStore } from './store/useStore';
+import { useEffect } from 'react';
+import { Home } from './pages/Home';
+import { useAuthStore } from './store/useAuthStore';
+// import { Lobbies } from './pages/Lobbies';
 
 function App() {
-  const { count, increment } = useStore();
+    const initializeSession = useAuthStore((state) => state.initializeSession);
+    const isGuest = useAuthStore((state) => state.isGuest);
 
-  return (
-      <div style={{ padding: '20px', textAlign: 'center' }}>
-        <h1>🕹️ Monomat Project Foundation</h1>
-        <p>Zustand Count: <strong>{count}</strong></p>
-        <button onClick={increment} style={{ padding: '10px 20px', fontSize: '16px', cursor: 'pointer' }}>
-          Increment Test
-        </button>
-        <div style={{ marginTop: '20px', color: '#666' }}>
-          {/* TanStack Query가 정상이라면 개발자 도구(F12)에서 에러가 없어야 합니다. */}
-          <small>TanStack Query & Zustand 뼈대 구성 완료</small>
+    // 컴포넌트 마운트 시 정확히 1번만 세션 복구 로직 실행
+    useEffect(() => {
+        initializeSession();
+    }, [initializeSession]);
+
+    return (
+        <div className="w-full min-h-screen bg-black text-white">
+            {/* 세션(isGuest)이 있으면 로비 목록 등으로 보내고,
+        없으면 닉네임 입력 화면(Home)을 보여주는 라우팅 처리 예시입니다.
+      */}
+            {isGuest ? (
+                // <Lobbies />
+                <div className="p-10">
+                    <h2 className="text-2xl text-blue-400">환영합니다, 게임 로비 대기실입니다!</h2>
+                    <button
+                        onClick={() => useAuthStore.getState().clearSession()}
+                        className="mt-4 px-4 py-2 bg-red-600 rounded"
+                    >
+                        로그아웃(세션 초기화)
+                    </button>
+                </div>
+            ) : (
+                <Home />
+            )}
         </div>
-      </div>
-  );
+    );
 }
 
 export default App;

--- a/src/components/common/MonomatInput.tsx
+++ b/src/components/common/MonomatInput.tsx
@@ -1,0 +1,58 @@
+import React, { type InputHTMLAttributes, forwardRef } from 'react';
+
+export interface MonomatInputProps extends InputHTMLAttributes<HTMLInputElement> {
+    /**
+     * 엔터 키가 눌렸을 때 실행될 콜백 함수입니다.
+     * isComposing(한글 조합 중) 상태가 아닐 때만 안전하게 호출됩니다.
+     */
+    onEnter?: (value: string) => void;
+
+    /**
+     * 엔터 키 입력 시 HTML Form의 기본 제출(submit) 동작 및
+     * 화면 새로고침을 방지할지 여부를 결정합니다.
+     * 실시간 게임(WebSocket 유지) 환경을 위해 기본값은 true로 설정합니다.
+     */
+    preventEnterSubmit?: boolean;
+}
+
+export const MonomatInput = forwardRef<HTMLInputElement, MonomatInputProps>(
+    ({ onKeyDown, onEnter, preventEnterSubmit = true, ...props }, ref) => {
+
+        const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+            // 한글 IME 조합 중(예: ㄱ+ㅏ=가) 발생한 이벤트는 무시하여 2중 제출 방지
+            if (e.nativeEvent.isComposing) {
+                return;
+            }
+
+            // 엔터 키 입력 처리
+            if (e.key === 'Enter') {
+                // 부모의 설정에 따라 폼 기본 제출 방지 동작 제어
+                if (preventEnterSubmit) {
+                    e.preventDefault();
+                }
+
+                // onEnter 콜백이 전달된 경우 현재 입력값을 파라미터로 실행
+                if (onEnter) {
+                    onEnter(e.currentTarget.value);
+                }
+            }
+
+            // 외부에서 전달된 기존 onKeyDown 이벤트가 있다면 유지하여 확장성 보장
+            if (onKeyDown) {
+                onKeyDown(e);
+            }
+        };
+
+        return (
+            <input
+                ref={ref}
+                onKeyDown={handleKeyDown}
+                className="monomat-default-input" // 필요에 따라 Tailwind 등 디자인 클래스 적용
+                {...props}
+            />
+        );
+    }
+);
+
+// 디버깅 용이성을 위해 컴포넌트 표시 이름 설정
+MonomatInput.displayName = 'MonomatInput';

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,11 +1,26 @@
 import { useRef } from 'react';
 import { MonomatInput } from '../components/common/MonomatInput';
-import { useAuthStore } from '../store/useAuthStore'; // ✅ 1. Zustand 스토어 import
+import { useAuthStore } from '../store/useAuthStore'; // Zustand 전역 스토어 연결
 
 /**
- * 보안 컨텍스트가 없는 환경(HTTP 등)을 위한 UUID Fallback 함수
+ * [아키텍처 지식: UUID Fallback 생성기]
+ * @description 브라우저 환경에 따라 최적의 UUID를 생성하는 유틸리티 함수입니다.
+ * 보안 컨텍스트(HTTPS)가 아니거나 구형 브라우저에서는 crypto API가 없을 수 있으므로,
+ * 서비스의 호환성을 높이기 위해 수동으로 난수를 조합하는 방어 로직입니다.
  */
+
 const generateFallbackUUID = () => {
+    // 1. Web Crypto API를 지원하는 환경 (최우선)
+    if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+            const r = crypto.getRandomValues(new Uint8Array(1))[0] % 16;
+            const v = c === 'x' ? r : (r & 0x3) | 0x8;
+            return v.toString(16);
+        });
+    }
+
+    // 2. 극단적인 레거시 환경을 위한 최후의 보루 (Math.random 활용)
+    // 백엔드 게스트 발급 API가 완성되면 지워질 로직
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
         const r = (Math.random() * 16) | 0;
         const v = c === 'x' ? r : (r & 0x3) | 0x8;
@@ -15,9 +30,11 @@ const generateFallbackUUID = () => {
 
 export const Home = () => {
     const inputRef = useRef<HTMLInputElement>(null);
-
-    // 2. Zustand 상태 업데이트 함수(Action) 가져오기
     const setSession = useAuthStore((state) => state.setSession);
+
+    /**
+     * @description 사용자가 닉네임을 입력하고 게임 입장을 시도할 때 실행되는 함수
+     */
 
     const handleNicknameSubmit = (nickname: string) => {
         const trimmedName = nickname.trim();
@@ -27,29 +44,36 @@ export const Home = () => {
             return;
         }
 
-        // UUID 발급 (Secure Context 체크 및 Fallback 적용)
+        // 1. UUID 발급 (클라이언트 임시 발급)
         const guestUuid =
             typeof crypto !== 'undefined' && crypto.randomUUID
                 ? crypto.randomUUID()
                 : generateFallbackUUID();
 
-        // localStorage 세션 저장
         const sessionData = {
             uuid: guestUuid,
             nickname: trimmedName,
             createdAt: Date.now(),
         };
 
-        localStorage.setItem('monomat_guest_session', JSON.stringify(sessionData));
-        console.log('게스트 세션 생성 완료:', sessionData);
+        // 2. localStorage 세션 저장 및 예외 처리 (Graceful Degradation)
+        try {
+            // 정상적인 상황: 브라우저 스토리지에 데이터를 영구 저장하여 새로고침(Graceful Reconnect) 대비
+            localStorage.setItem('monomat_guest_session', JSON.stringify(sessionData));
+            console.log('게스트 세션 생성 완료:', sessionData);
+        } catch (error) {
+            // 예외 상황: iOS Safari 시크릿 모드 등에서는 스토리지 할당량이 0일 수 있어 에러가 발생함
+            console.error('로컬 스토리지 저장 실패:', error);
+            // 아키텍처 전략: 입장을 차단하지 않고, 유저에게 현재 상황(새로고침 시 데이터 증발)만 명확히 고지합니다.
+            alert('브라우저의 시크릿 모드이거나 저장 공간이 부족합니다. 게임은 진행할 수 있으나 새로고침 시 접속이 끊어질 수 있습니다.');
+        }
 
-        // Zustand 스토어 업데이트
-        // 이 함수가 호출되는 순간 isGuest 상태가 true로 바뀌며,
-        // App.tsx의 라우팅 로직에 의해 즉시 로비 대기실 화면으로 자동 전환됩니다.
+        // 3. Zustand 스토어 업데이트 (메모리 상태 변경)
+        // 스토리지가 실패했더라도, Zustand 스토어(메모리)에 값을 세팅하면
+        // App.tsx의 <ProtectedRoute>가 열리며 현재 브라우저 탭에서는 정상적으로 게임 플레이가 가능합니다.
         setSession(guestUuid, trimmedName);
     };
 
-    // 버튼 클릭 시 Input의 현재 값을 가져와 제출 처리
     const onButtonClick = () => {
         if (inputRef.current) {
             handleNicknameSubmit(inputRef.current.value);
@@ -77,7 +101,6 @@ export const Home = () => {
                         className="w-full px-5 py-4 text-xl bg-gray-900 border-2 border-gray-800 rounded-2xl outline-none focus:border-blue-500 transition-all text-white placeholder-gray-600"
                     />
 
-                    {/* 모바일 접근성을 위한 '입장' 버튼 (데스크톱에서는 엔터로, 모바일에서는 터치로) */}
                     <button
                         onClick={onButtonClick}
                         className="absolute right-3 top-1/2 -translate-y-1/2 px-4 py-2 bg-blue-600 hover:bg-blue-500 active:scale-95 rounded-xl font-bold transition-all"

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,96 @@
+import { useRef } from 'react';
+import { MonomatInput } from '../components/common/MonomatInput';
+import { useAuthStore } from '../store/useAuthStore'; // ✅ 1. Zustand 스토어 import
+
+/**
+ * 보안 컨텍스트가 없는 환경(HTTP 등)을 위한 UUID Fallback 함수
+ */
+const generateFallbackUUID = () => {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+        const r = (Math.random() * 16) | 0;
+        const v = c === 'x' ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+    });
+};
+
+export const Home = () => {
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    // ✅ 2. Zustand 상태 업데이트 함수(Action) 가져오기
+    const setSession = useAuthStore((state) => state.setSession);
+
+    const handleNicknameSubmit = (nickname: string) => {
+        const trimmedName = nickname.trim();
+
+        if (!trimmedName) {
+            alert('닉네임을 입력해주세요.');
+            return;
+        }
+
+        // 1️⃣ UUID 발급 (Secure Context 체크 및 Fallback 적용)
+        const guestUuid =
+            typeof crypto !== 'undefined' && crypto.randomUUID
+                ? crypto.randomUUID()
+                : generateFallbackUUID();
+
+        // 2️⃣ localStorage 세션 저장
+        const sessionData = {
+            uuid: guestUuid,
+            nickname: trimmedName,
+            createdAt: Date.now(),
+        };
+
+        localStorage.setItem('monomat_guest_session', JSON.stringify(sessionData));
+        console.log('게스트 세션 생성 완료:', sessionData);
+
+        // 3️⃣ Zustand 스토어 업데이트
+        // ✅ 이 함수가 호출되는 순간 isGuest 상태가 true로 바뀌며,
+        // App.tsx의 라우팅 로직에 의해 즉시 로비 대기실 화면으로 자동 전환됩니다.
+        setSession(guestUuid, trimmedName);
+    };
+
+    // 버튼 클릭 시 Input의 현재 값을 가져와 제출 처리
+    const onButtonClick = () => {
+        if (inputRef.current) {
+            handleNicknameSubmit(inputRef.current.value);
+        }
+    };
+
+    return (
+        <div className="flex flex-col items-center justify-center min-h-screen bg-black text-white px-4">
+            <div className="text-center mb-10">
+                <h1 className="text-6xl font-black mb-4 tracking-tighter text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-purple-500">
+                    MONOMAT
+                </h1>
+                <p className="text-gray-400 text-lg">YouTube 음악 퀴즈를 실시간으로 즐기세요.</p>
+            </div>
+
+            <div className="w-full max-w-md flex flex-col gap-3">
+                <div className="relative group">
+                    <MonomatInput
+                        ref={inputRef}
+                        type="text"
+                        placeholder="닉네임을 입력하세요"
+                        maxLength={12}
+                        autoFocus
+                        onEnter={handleNicknameSubmit}
+                        className="w-full px-5 py-4 text-xl bg-gray-900 border-2 border-gray-800 rounded-2xl outline-none focus:border-blue-500 transition-all text-white placeholder-gray-600"
+                    />
+
+                    {/* 모바일 접근성을 위한 '입장' 버튼 (데스크톱에서는 엔터로, 모바일에서는 터치로) */}
+                    <button
+                        onClick={onButtonClick}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 px-4 py-2 bg-blue-600 hover:bg-blue-500 active:scale-95 rounded-xl font-bold transition-all"
+                        aria-label="게임 입장"
+                    >
+                        입장
+                    </button>
+                </div>
+
+                <p className="text-center text-xs text-gray-500 mt-2">
+                    별도의 회원가입 없이 즉시 플레이가 가능합니다.
+                </p>
+            </div>
+        </div>
+    );
+};

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -16,7 +16,7 @@ const generateFallbackUUID = () => {
 export const Home = () => {
     const inputRef = useRef<HTMLInputElement>(null);
 
-    // ✅ 2. Zustand 상태 업데이트 함수(Action) 가져오기
+    // 2. Zustand 상태 업데이트 함수(Action) 가져오기
     const setSession = useAuthStore((state) => state.setSession);
 
     const handleNicknameSubmit = (nickname: string) => {
@@ -27,13 +27,13 @@ export const Home = () => {
             return;
         }
 
-        // 1️⃣ UUID 발급 (Secure Context 체크 및 Fallback 적용)
+        // UUID 발급 (Secure Context 체크 및 Fallback 적용)
         const guestUuid =
             typeof crypto !== 'undefined' && crypto.randomUUID
                 ? crypto.randomUUID()
                 : generateFallbackUUID();
 
-        // 2️⃣ localStorage 세션 저장
+        // localStorage 세션 저장
         const sessionData = {
             uuid: guestUuid,
             nickname: trimmedName,
@@ -43,8 +43,8 @@ export const Home = () => {
         localStorage.setItem('monomat_guest_session', JSON.stringify(sessionData));
         console.log('게스트 세션 생성 완료:', sessionData);
 
-        // 3️⃣ Zustand 스토어 업데이트
-        // ✅ 이 함수가 호출되는 순간 isGuest 상태가 true로 바뀌며,
+        // Zustand 스토어 업데이트
+        // 이 함수가 호출되는 순간 isGuest 상태가 true로 바뀌며,
         // App.tsx의 라우팅 로직에 의해 즉시 로비 대기실 화면으로 자동 전환됩니다.
         setSession(guestUuid, trimmedName);
     };

--- a/src/pages/Lobbies.tsx
+++ b/src/pages/Lobbies.tsx
@@ -1,0 +1,34 @@
+export function Lobbies() {
+    /**
+     * [아키텍처 예정 사항: 상태 관리 및 데이터 페칭]
+     * 이곳에는 앞으로 TanStack Query를 활용하여 서버(Spring Boot)에서
+     * 활성화된 로비 목록을 주기적으로, 혹은 실시간으로 가져오는 로직이 추가될 예정입니다.
+     * * 서버 성능 최적화: 백엔드에서는 MySQL을 거치지 않고,
+     * Redis에서 is_private=false 조건으로 필터링하여 공개 로비만 초고속으로 응답을 내려줍니다.
+     */
+
+    return (
+        // 전체 화면을 채우고 요소들을 중앙에 배치하는 레이아웃입니다.
+        <div className="flex flex-col items-center min-h-screen bg-black text-white p-6">
+            <h1 className="text-3xl font-bold text-blue-400 mb-6 w-full max-w-5xl text-left">
+                🌐 로비 목록
+            </h1>
+
+            {/* 로비 리스트 렌더링 영역 */}
+            <div className="w-full max-w-5xl bg-gray-900 border border-gray-800 rounded-xl p-6 min-h-[500px] flex flex-col items-center justify-center shadow-lg">
+                <p className="text-gray-400">
+                    현재 활성화된 게임 방 리스트가 여기에 표시됩니다.
+                    {/* 추후 여기에 배열의 map() 함수를 사용하여
+                        로비 카드(방 제목, 현재 인원/최대 인원, 방장 닉네임 등) 리스트를 렌더링할 예정입니다.
+                    */}
+                </p>
+            </div>
+
+            {/* [아키텍처 참고: 전체 채팅 영역]
+                기능명세서에 따라, 로비 리스트 화면 하단에는 고정 배치되는 '전체 채널 채팅 UI'가 들어갈 자리입니다.
+                로그인 여부와 무관하게 게스트/회원 모두 참여할 수 있으며,
+                별도의 WebSocket 채널(/topic/global)을 통해 통신하게 됩니다.
+            */}
+        </div>
+    );
+}

--- a/src/pages/LobbyRoom.tsx
+++ b/src/pages/LobbyRoom.tsx
@@ -1,0 +1,45 @@
+import { useParams } from 'react-router-dom';
+
+/**
+ * @description 실제 게임이 시작되기 전, 플레이어들이 모이는 '로비(방)' 컴포넌트입니다.
+ * 6자리의 고유 초대 코드를 기반으로 특정 방을 식별합니다.
+ */
+
+export function LobbyRoom() {
+    /**
+     * [React Router: useParams 활용]
+     * App.tsx에서 정의된 Route 경로가 "/lobby/:inviteCode"일 때,
+     * URL에 입력된 실제 값(예: /lobby/XK32WL -> XK32WL)을 객체 형태로 가져옵니다.
+     * * 기능명세서에 명시된 '6자리 고유 코드 기반 입장' 기능을 구현하는 핵심 훅입니다.
+     */
+    const { inviteCode } = useParams<{ inviteCode: string }>();
+
+    return (
+        // 레이아웃: 화면 중앙 정렬 및 게임 서비스 특유의 다크 테마 적용
+        <div className="flex flex-col items-center justify-center min-h-screen bg-black text-white">
+            <h1 className="text-3xl font-bold text-green-400 mb-4">
+                🎮 게임 대기실
+            </h1>
+
+            <div className="bg-gray-900 p-6 rounded-xl border border-gray-800 shadow-2xl">
+                <p className="text-gray-300">
+                    현재 입장한 방의 초대 코드:
+                    {/* font-mono: 코드의 가독성을 높이기 위해 고정폭 글꼴 사용 */}
+                    <span className="ml-2 font-mono text-yellow-400 bg-gray-800 px-3 py-1 rounded-md border border-yellow-400/30">
+                        {inviteCode}
+                    </span>
+                </p>
+
+                {/* [아키텍처 참고]
+                    실제 구현 시에는 이 inviteCode를 사용하여
+                    1. 백엔드 API로 방 정보를 조회(TanStack Query)
+                    2. WebSocket 채널(/topic/lobby/{inviteCode})에 접속하는 로직이 추가됩니다.
+                */}
+            </div>
+
+            <p className="mt-8 text-sm text-gray-500">
+                친구들에게 초대 코드를 공유하여 함께 게임을 즐겨보세요!
+            </p>
+        </div>
+    );
+}

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,0 +1,50 @@
+import { create } from 'zustand';
+
+interface AuthState {
+    uuid: string | null;
+    nickname: string | null;
+    isGuest: boolean;
+
+    // 상태 변경 액션
+    setSession: (uuid: string, nickname: string) => void;
+    clearSession: () => void;
+
+    // 초기 로드 시 localStorage를 확인하여 스토어를 업데이트하는 함수
+    initializeSession: () => void;
+}
+
+export const useAuthStore = create<AuthState>((set) => ({
+    uuid: null,
+    nickname: null,
+    isGuest: false,
+
+    setSession: (uuid, nickname) =>
+        set({ uuid, nickname, isGuest: true }),
+
+    clearSession: () => {
+        localStorage.removeItem('monomat_guest_session');
+        set({ uuid: null, nickname: null, isGuest: false });
+    },
+
+    initializeSession: () => {
+        try {
+            const storedData = localStorage.getItem('monomat_guest_session');
+            if (storedData) {
+                const parsed = JSON.parse(storedData);
+                // 저장된 데이터가 유효한지 검증
+                if (parsed.uuid && parsed.nickname) {
+                    set({
+                        uuid: parsed.uuid,
+                        nickname: parsed.nickname,
+                        isGuest: true
+                    });
+                    console.log('세션 복구 완료:', parsed.nickname);
+                }
+            }
+        } catch (error) {
+            console.error('세션 파싱 중 오류 발생:', error);
+            // 데이터가 오염되었을 경우 초기화
+            localStorage.removeItem('monomat_guest_session');
+        }
+    }
+}));

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,49 +1,81 @@
 import { create } from 'zustand';
+import { z } from 'zod';
+
+/**
+ * [아키텍처 지식: 런타임 타입 검증 (Runtime Type Validation)]
+ * @description TypeScript의 타입(interface)은 컴파일 후 사라지기 때문에,
+ * 실제 브라우저가 실행될 때(Runtime) localStorage에 들어있는 값이 정말 올바른 형태인지 보장하지 못합니다.
+ * Zod를 사용하면 데이터가 스키마에 맞는지 실행 중에 검사하고, 오염된 데이터를 걸러낼 수 있습니다.
+ */
+
+const guestSessionSchema = z.object({
+    // UUID 형식이 맞는지 정규식 수준으로 깐깐하게 검증합니다.
+    uuid: z.string().uuid("유효하지 않은 UUID 형식입니다."),
+
+    // Home.tsx의 입력창 제한(maxLength={12})과 동일한 비즈니스 룰을 적용합니다.
+    nickname: z.string().min(1).max(12, "닉네임은 1~12자 이내여야 합니다."),
+
+    // 기능명세서의 '게스트 세션 만료 정책(예: 30일)' 구현 시
+    // 클라이언트 측에서 먼저 만료 여부를 판별하기 위해 사용할 타임스탬프입니다.
+    createdAt: z.number().optional()
+});
 
 interface AuthState {
     uuid: string | null;
     nickname: string | null;
     isGuest: boolean;
-
-    // 상태 변경 액션
     setSession: (uuid: string, nickname: string) => void;
     clearSession: () => void;
-
-    // 초기 로드 시 localStorage를 확인하여 스토어를 업데이트하는 함수
     initializeSession: () => void;
 }
 
+// Zustand를 이용해 전역 상태 스토어를 생성합니다.
 export const useAuthStore = create<AuthState>((set) => ({
     uuid: null,
     nickname: null,
     isGuest: false,
 
+    // 메모리에만 세션을 설정합니다. (localStorage 저장은 Home.tsx 등 컴포넌트 레벨에서 처리됨)
     setSession: (uuid, nickname) =>
         set({ uuid, nickname, isGuest: true }),
 
+    // 로그아웃 또는 세션 만료 시 호출되어 로컬 스토리지와 메모리 상태를 모두 비웁니다.
     clearSession: () => {
         localStorage.removeItem('monomat_guest_session');
         set({ uuid: null, nickname: null, isGuest: false });
     },
 
+    /**
+     * @description App.tsx가 켜질 때 딱 한 번 실행되어 "조용한 로그인(Silent Auth)"을 수행합니다.
+     */
+
     initializeSession: () => {
         try {
             const storedData = localStorage.getItem('monomat_guest_session');
-            if (storedData) {
-                const parsed = JSON.parse(storedData);
-                // 저장된 데이터가 유효한지 검증
-                if (parsed.uuid && parsed.nickname) {
-                    set({
-                        uuid: parsed.uuid,
-                        nickname: parsed.nickname,
-                        isGuest: true
-                    });
-                    console.log('세션 복구 완료:', parsed.nickname);
-                }
+            if (!storedData) return; // 첫 방문자: 그냥 넘어갑니다.
+
+            const parsed = JSON.parse(storedData);
+
+            // [방어적 프로그래밍]
+            // parse() 대신 safeParse()를 사용하여, 검증 실패 시 앱이 뻗어버리는(Crash) 것을 막습니다.
+            const validationResult = guestSessionSchema.safeParse(parsed);
+
+            if (validationResult.success) {
+                // 데이터가 완벽히 깨끗함: Zustand 상태에 밀어넣고 앱을 '로그인 된 상태(isGuest: true)'로 만듭니다.
+                set({
+                    uuid: validationResult.data.uuid,
+                    nickname: validationResult.data.nickname,
+                    isGuest: true
+                });
+                console.log('세션 복구 완료:', validationResult.data.nickname);
+            } else {
+                // 누군가 개발자 도구를 열고 localStorage 값을 임의로 수정했거나 데이터가 깨진 상황
+                console.warn('세션 데이터 오염 감지. 스토리지를 초기화합니다:', validationResult.error.format());
+                localStorage.removeItem('monomat_guest_session'); // 오염된 데이터 삭제
             }
         } catch (error) {
+            // JSON 형식이 아닌 엉뚱한 문자열이 들어있어 JSON.parse() 자체가 터진 경우
             console.error('세션 파싱 중 오류 발생:', error);
-            // 데이터가 오염되었을 경우 초기화
             localStorage.removeItem('monomat_guest_session');
         }
     }

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -2,32 +2,40 @@ import { create } from 'zustand';
 import { z } from 'zod';
 
 // [아키텍처 지식: 매직 넘버(Magic Number) 제거]
-// 30일을 하드코딩하지 않고 상수로 빼두면, 나중에 기획이 "15일로 줄입시다"라고 했을 때 유지보수가 매우 쉬워집니다.
-
+// 시간과 관련된 하드코딩된 숫자는 가독성을 떨어뜨리고 버그를 유발합니다.
+// 상수화를 통해 '게스트 세션 30일 만료 정책'이라는 도메인 규칙을 코드 레벨에서 명확히 선언합니다.
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
 /**
- * [아키텍처 지식: 런타임 타입 검증 및 비즈니스 룰 캡슐화]
- * @description Zod 스키마 내부에 데이터의 형태(Type)뿐만 아니라,
- * "30일 만료 정책"이라는 핵심 비즈니스 로직(Business Rule)까지 캡슐화합니다.
+ * [아키텍처 지식: 부패 방지 계층(Anti-Corruption Layer) 및 Zod v4 적용]
+ * localStorage와 같은 클라이언트 스토리지는 사용자나 악성 스크립트에 의해 언제든 변조될 수 있습니다.
+ * 이 스키마는 외부의 오염된 데이터가 애플리케이션의 핵심 로직으로 침투하지 못하게 막는 방어막입니다.
  */
 
 const guestSessionSchema = z.object({
-    uuid: z.string().uuid("유효하지 않은 UUID 형식입니다."),
-    nickname: z.string().min(1).max(12, "닉네임은 1~12자 이내여야 합니다."),
+    // Zod v4 스펙: 최상위 식별자 검증기(z.uuid)와 통합 에러 프로퍼티({ error: "..." })를 활용하여
+    // 직관적이고 일관된 에러 컨트랙트를 구성합니다.
+    uuid: z.uuid({ error: "유효하지 않은 UUID 형식입니다." }),
+    nickname: z.string()
+        .min(1, { error: "닉네임은 최소 1자 이상이어야 합니다." })
+        .max(12, { error: "닉네임은 12자 이내여야 합니다." }),
 
-    // refine(): Zod의 강력한 기능 중 하나로, 커스텀 검증 로직을 작성할 수 있습니다.
-    // 기존의 optional()을 제거하여 createdAt을 필수로 만들고, 현재 시간과 비교합니다.
+    // 비즈니스 로직 캡슐화: 만료 검증 로직을 스키마 내부에 응집시킵니다.
+    // 이 검증을 통과한 데이터는 '형식이 올바르고 기한이 유효한 안전한 데이터'임을 시스템 전체가 신뢰할 수 있습니다.
     createdAt: z.number().refine((time) => {
         const isExpired = (Date.now() - time) > THIRTY_DAYS_MS;
-        return !isExpired; // true면 검증 통과(유효함), false면 검증 실패(만료됨)
-    }, { message: "세션이 30일을 초과하여 만료되었습니다." })
+        return !isExpired;
+    }, { error: "세션이 30일을 초과하여 만료되었습니다." })
 });
 
 interface AuthState {
     uuid: string | null;
     nickname: string | null;
     isGuest: boolean;
+    // [아키텍처 지식: Hydration 동기화 플래그]
+    // React 19 환경에서 스토리지 데이터 로드 전과 후의 렌더링 불일치(Hydration Mismatch)를 방지합니다.
+    // UI 계층은 이 값이 true가 된 이후에만 게임 진입 화면이나 로그인 폼을 렌더링해야 안전합니다.
+    isHydrated: boolean;
     setSession: (uuid: string, nickname: string) => void;
     clearSession: () => void;
     initializeSession: () => void;
@@ -37,42 +45,57 @@ export const useAuthStore = create<AuthState>((set) => ({
     uuid: null,
     nickname: null,
     isGuest: false,
+    isHydrated: false, // 최초 로드 시점에는 스토리지 확인 전이므로 무조건 false
 
-    setSession: (uuid, nickname) =>
-        set({ uuid, nickname, isGuest: true }),
+    setSession: (uuid, nickname) => {
+        // [로직 안전성 보장] 신규 유저가 진입하여 세션을 생성할 때도 동기화가 완료된 것으로 간주합니다.
+        set({ uuid, nickname, isGuest: true, isHydrated: true });
+    },
 
     clearSession: () => {
         localStorage.removeItem('monomat_guest_session');
-        set({ uuid: null, nickname: null, isGuest: false });
+        // 세션 데이터는 지워지지만 "스토리지가 비어있음을 확인한 상태"이므로 isHydrated는 true를 유지합니다.
+        set({ uuid: null, nickname: null, isGuest: false, isHydrated: true });
     },
 
     initializeSession: () => {
         try {
             const storedData = localStorage.getItem('monomat_guest_session');
-            if (!storedData) return; // 저장된 데이터가 없으면 즉시 종료 (초기 방문자)
+
+            // 신규 방문자거나 스토리지가 비어있는 경우
+            if (!storedData) {
+                set({ isHydrated: true });
+                return;
+            }
 
             const parsed = JSON.parse(storedData);
-
-            // [프론트엔드 문지기 역할]
-            // safeParse가 실행되는 순간, 데이터 오염 여부뿐만 아니라 30일 경과 체크까지 한 번에 수행됩니다.
+            // safeParse를 통해 검증 실패 시 예외를 던지지 않고 분기 처리
             const validationResult = guestSessionSchema.safeParse(parsed);
 
             if (validationResult.success) {
+                // 메모리(Zustand)에 안전성이 검증된 상태만 적재합니다.
                 set({
                     uuid: validationResult.data.uuid,
                     nickname: validationResult.data.nickname,
-                    isGuest: true
+                    isGuest: true,
+                    isHydrated: true
                 });
                 console.log('세션 복구 완료:', validationResult.data.nickname);
             } else {
-                // 누군가 데이터를 조작했거나, 접속한 지 30일이 지나 만료된 경우 모두 이곳으로 빠집니다.
-                console.warn('세션 무효화 (오염 또는 만료):', validationResult.error.format());
-                // 만료된 세션을 깔끔하게 청소하여 다음 접속 시 닉네임 입력을 유도합니다.
+                // [아키텍처 지식: Observability 극대화 및 Fail-Fast]
+                // Zod v4의 z.treeifyError를 사용하여 복잡한 에러 객체를 구조화된 트리 형태로 포맷팅합니다.
+                // 이는 개발 환경의 디버깅 효율을 높이고, Sentry 등의 로깅 시스템에서 컨텍스트를 파악하기 좋게 만듭니다.
+                console.warn('세션 무효화 (오염 또는 만료):', z.treeifyError(validationResult.error));
+
+                // 오염되거나 만료된 데이터는 즉시 파기하여 잘못된 상태로 앱이 동작하는 것을 선제적으로 차단합니다(자가 치유).
                 localStorage.removeItem('monomat_guest_session');
+                set({ isHydrated: true });
             }
         } catch (error) {
+            // JSON.parse 실패 등 예기치 못한 치명적 예외가 발생할 경우를 대비한 최후의 보루(Fallback)입니다.
             console.error('세션 파싱 중 오류 발생:', error);
             localStorage.removeItem('monomat_guest_session');
+            set({ isHydrated: true });
         }
     }
 }));

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,23 +1,27 @@
 import { create } from 'zustand';
 import { z } from 'zod';
 
+// [아키텍처 지식: 매직 넘버(Magic Number) 제거]
+// 30일을 하드코딩하지 않고 상수로 빼두면, 나중에 기획이 "15일로 줄입시다"라고 했을 때 유지보수가 매우 쉬워집니다.
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
 /**
- * [아키텍처 지식: 런타임 타입 검증 (Runtime Type Validation)]
- * @description TypeScript의 타입(interface)은 컴파일 후 사라지기 때문에,
- * 실제 브라우저가 실행될 때(Runtime) localStorage에 들어있는 값이 정말 올바른 형태인지 보장하지 못합니다.
- * Zod를 사용하면 데이터가 스키마에 맞는지 실행 중에 검사하고, 오염된 데이터를 걸러낼 수 있습니다.
+ * [아키텍처 지식: 런타임 타입 검증 및 비즈니스 룰 캡슐화]
+ * @description Zod 스키마 내부에 데이터의 형태(Type)뿐만 아니라,
+ * "30일 만료 정책"이라는 핵심 비즈니스 로직(Business Rule)까지 캡슐화합니다.
  */
 
 const guestSessionSchema = z.object({
-    // UUID 형식이 맞는지 정규식 수준으로 깐깐하게 검증합니다.
     uuid: z.string().uuid("유효하지 않은 UUID 형식입니다."),
-
-    // Home.tsx의 입력창 제한(maxLength={12})과 동일한 비즈니스 룰을 적용합니다.
     nickname: z.string().min(1).max(12, "닉네임은 1~12자 이내여야 합니다."),
 
-    // 기능명세서의 '게스트 세션 만료 정책(예: 30일)' 구현 시
-    // 클라이언트 측에서 먼저 만료 여부를 판별하기 위해 사용할 타임스탬프입니다.
-    createdAt: z.number().optional()
+    // refine(): Zod의 강력한 기능 중 하나로, 커스텀 검증 로직을 작성할 수 있습니다.
+    // 기존의 optional()을 제거하여 createdAt을 필수로 만들고, 현재 시간과 비교합니다.
+    createdAt: z.number().refine((time) => {
+        const isExpired = (Date.now() - time) > THIRTY_DAYS_MS;
+        return !isExpired; // true면 검증 통과(유효함), false면 검증 실패(만료됨)
+    }, { message: "세션이 30일을 초과하여 만료되었습니다." })
 });
 
 interface AuthState {
@@ -29,39 +33,31 @@ interface AuthState {
     initializeSession: () => void;
 }
 
-// Zustand를 이용해 전역 상태 스토어를 생성합니다.
 export const useAuthStore = create<AuthState>((set) => ({
     uuid: null,
     nickname: null,
     isGuest: false,
 
-    // 메모리에만 세션을 설정합니다. (localStorage 저장은 Home.tsx 등 컴포넌트 레벨에서 처리됨)
     setSession: (uuid, nickname) =>
         set({ uuid, nickname, isGuest: true }),
 
-    // 로그아웃 또는 세션 만료 시 호출되어 로컬 스토리지와 메모리 상태를 모두 비웁니다.
     clearSession: () => {
         localStorage.removeItem('monomat_guest_session');
         set({ uuid: null, nickname: null, isGuest: false });
     },
 
-    /**
-     * @description App.tsx가 켜질 때 딱 한 번 실행되어 "조용한 로그인(Silent Auth)"을 수행합니다.
-     */
-
     initializeSession: () => {
         try {
             const storedData = localStorage.getItem('monomat_guest_session');
-            if (!storedData) return; // 첫 방문자: 그냥 넘어갑니다.
+            if (!storedData) return; // 저장된 데이터가 없으면 즉시 종료 (초기 방문자)
 
             const parsed = JSON.parse(storedData);
 
-            // [방어적 프로그래밍]
-            // parse() 대신 safeParse()를 사용하여, 검증 실패 시 앱이 뻗어버리는(Crash) 것을 막습니다.
+            // [프론트엔드 문지기 역할]
+            // safeParse가 실행되는 순간, 데이터 오염 여부뿐만 아니라 30일 경과 체크까지 한 번에 수행됩니다.
             const validationResult = guestSessionSchema.safeParse(parsed);
 
             if (validationResult.success) {
-                // 데이터가 완벽히 깨끗함: Zustand 상태에 밀어넣고 앱을 '로그인 된 상태(isGuest: true)'로 만듭니다.
                 set({
                     uuid: validationResult.data.uuid,
                     nickname: validationResult.data.nickname,
@@ -69,12 +65,12 @@ export const useAuthStore = create<AuthState>((set) => ({
                 });
                 console.log('세션 복구 완료:', validationResult.data.nickname);
             } else {
-                // 누군가 개발자 도구를 열고 localStorage 값을 임의로 수정했거나 데이터가 깨진 상황
-                console.warn('세션 데이터 오염 감지. 스토리지를 초기화합니다:', validationResult.error.format());
-                localStorage.removeItem('monomat_guest_session'); // 오염된 데이터 삭제
+                // 누군가 데이터를 조작했거나, 접속한 지 30일이 지나 만료된 경우 모두 이곳으로 빠집니다.
+                console.warn('세션 무효화 (오염 또는 만료):', validationResult.error.format());
+                // 만료된 세션을 깔끔하게 청소하여 다음 접속 시 닉네임 입력을 유도합니다.
+                localStorage.removeItem('monomat_guest_session');
             }
         } catch (error) {
-            // JSON 형식이 아닌 엉뚱한 문자열이 들어있어 JSON.parse() 자체가 터진 경우
             console.error('세션 파싱 중 오류 발생:', error);
             localStorage.removeItem('monomat_guest_session');
         }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -27,7 +27,6 @@
     "noFallthroughCasesInSwitch": true,
 
     /* Path Alias */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## 📣 Related Issue

- #3

## 📝 Summary

사용자의 무마찰 진입 (Frictionless Entry)을 위한 게스트 인증 및 초기 진입 로직을 구현했습니다.
- **React 19 `inComposing` 기반 공통 `Input` 개발** : 한글 입력 시 엔터 키가 2중 제출되는 이슈를 해결한 `MonomatInput` 컴포넌트를 구현했습니다.
- **홈 화면 (Home) 닉네임 입력 UI** : Tailwind CSS를 활용하여 다크 모드 기반의 직관적인 입력 폼과 모바일 접근성을 고려한 입장 버튼을 추가했습니다.
- **게스트 세션 발급 로직** : `crypto.randomUUID()`와 보안 컨텍스트 (HTTP)를 고려한 `Fallback` 함수를 통해 고유 `UUID`를 생성하고 `localStorage`에 저장합니다.
- **Zustand 기반 세션 동기화** : 앱 로드 시 `localStorage`를 확인하여 기존 세션을 복구하고 전역 상태에 반영하는 로직을 구축했습니다.

## 🙏PR point

- `MonomatInput` 컴포넌트에서 `preventEnterSubmit` 프롭을 통해 폼의 기본 제출 동작을 제어할 수 있도록 설계했습니다. 게임 환경에서 의도치 않은 페이지 새로고침을 방지하기 위함입니다.
- `App.tsx`에서 `useEffect`를 통해 `initializeSession`을 호출하고 있습니다. 이를 통해 사용자가 새로고침을 하더라도 `isGuest` 상태가 유지되어 즉시 이전 화면(로비 등)으로 진입할 수 있습니다.

### ✅ Test Plan

1. 한글 2중 제출 방지 테스트
- 방법: 닉네임 입력창에 '한글' 입력 후, 글자 아래 밑줄이 있는 상태에서 엔터 키 입력.
- 예상 결과: 브라우저 콘솔에 "게스트 세션 생성 완료" 로그가 정확히 1번만 찍혀야 함.

2. 세션 유지 및 복구 테스트
- 방법: 닉네임 입력 후 입장 -> 브라우저 새로고침(F5) 실행.
- 예상 결과: 다시 닉네임 입력창이 뜨지 않고, `Zustand` 상태가 복구되어 로비 대기 화면(환영 메시지)이 유지되어야 함.

3. 로컬 스토리지 확인
- 방법: 개발자 도구(F12) -> `Application` -> `Local Storage` 확인.
- 예상 결과: `monomat_guest_session` 키에 `uuid`, `nickname`, `createdAt` 정보가 `JSON` 형태로 정상 저장되어야 함.


## 📬 Reference

[React & MDN `isComposing` Documentation](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing)
[Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID)