### PR TITLE
[Feat/#7] WebSocket 클라이언트 모듈 및 Zustand 전역 상태 세팅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env.development
+.env.production

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "monomat-fe",
       "version": "0.0.0",
       "dependencies": {
+        "@stomp/stompjs": "^7.3.0",
         "@tanstack/react-query": "^5.99.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "react-router-dom": "^7.14.1",
+        "sockjs-client": "^1.6.1",
         "zod": "^4.3.6",
         "zustand": "^5.0.12"
       },
@@ -21,6 +23,7 @@
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@types/sockjs-client": "^1.5.4",
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -875,6 +878,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.3.0.tgz",
+      "integrity": "sha512-nKMLoFfJhrQAqkvvKd1vLq/cVBGCMwPRCD0LqW7UT1fecRx9C3GoKEIR2CYwVuErGeZu8w0kFkl2rlhPlqHVgQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.99.0",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.0.tgz",
@@ -984,6 +993,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/sockjs-client": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/sockjs-client/-/sockjs-client-1.5.4.tgz",
+      "integrity": "sha512-zk+uFZeWyvJ5ZFkLIwoGA/DfJ+pYzcZ8eH4H/EILCm2OBZyHH6Hkdna1/UWL/CFruh5wj6ES7g75SvUB0VsH5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.58.1",
@@ -1800,6 +1816,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1820,6 +1845,18 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1968,6 +2005,12 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2004,6 +2047,12 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -2449,7 +2498,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2637,6 +2685,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
@@ -2696,6 +2750,12 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2747,6 +2807,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -2790,6 +2870,34 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sockjs-client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
+        "inherits": "^2.0.4",
+        "url-parse": "^1.5.10"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
+      }
+    },
+    "node_modules/sockjs-client/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/source-map-js": {
@@ -2965,6 +3073,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "8.0.8",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
@@ -3041,6 +3159,29 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@stomp/stompjs": "^7.3.0",
     "@tanstack/react-query": "^5.99.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "react-router-dom": "^7.14.1",
+    "sockjs-client": "^1.6.1",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },
@@ -23,6 +25,7 @@
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/sockjs-client": "^1.5.4",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { useAuthStore } from './store/useAuthStore';
-import { useSocketStore } from './store/useSocketStore'; // 추가
+import { useSocket } from './hooks/useSocket'; // 추가
 import { Home } from './pages/Home';
 import { Lobbies } from './pages/Lobbies';
 import { LobbyRoom } from './pages/LobbyRoom';
@@ -13,19 +13,14 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
 
 function App() {
     const initializeSession = useAuthStore((state) => state.initializeSession);
-    const uuid = useAuthStore((state) => state.uuid);           // 추가
-    const connect = useSocketStore((state) => state.connect);   // 추가
 
     useEffect(() => {
         initializeSession();
     }, [initializeSession]);
 
-    // uuid가 생기는 순간(로그인 완료) 소켓 연결을 시작합니다.
-    useEffect(() => {
-        if (uuid) {
-            connect(uuid);
-        }
-    }, [uuid, connect]); // 추가
+    // useSocket 훅 한 줄로 소켓 연결/해제 생명주기를 관리합니다.
+    // 내부적으로 uuid가 생기는 순간 연결하고, 사라지는 순간 해제합니다.
+    useSocket();
 
     return (
         <div className="w-full min-h-screen bg-black text-white">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,60 +1,41 @@
 import { useEffect } from 'react';
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { useAuthStore } from './store/useAuthStore';
+import { useSocketStore } from './store/useSocketStore'; // 추가
 import { Home } from './pages/Home';
 import { Lobbies } from './pages/Lobbies';
-import { LobbyRoom } from './pages/LobbyRoom'; // 개별 게임 방
-
-/**
- * [아키텍처 패턴: Route Guard (라우트 가드)]
- * @description 권한이 없는 사용자(초기 방문자)가 로그인 없이 특정 URL로 직접 접근하는 것을 막는 래퍼(Wrapper) 컴포넌트입니다.
- */
+import { LobbyRoom } from './pages/LobbyRoom';
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
-    // Zustand 스토어에서 현재 사용자의 세션(게스트 또는 정식 회원) 존재 여부를 확인합니다.
     const isGuest = useAuthStore((state) => state.isGuest);
-
-    // [보안 및 UX 처리]
-    // 세션이 있다면(isGuest === true), 요청한 화면(children)을 그대로 보여줍니다.
-    // 세션이 없다면, <Navigate>를 통해 즉시 "/" (홈 화면)으로 강제 이동(리다이렉트) 시킵니다.
-    // 'replace' 속성: 브라우저 뒤로 가기 기록에 이 경로를 남기지 않아, 뒤로 가기를 눌렀을 때 무한 루프에 빠지는 것을 방지합니다.
     return isGuest ? <>{children}</> : <Navigate to="/" replace />;
 }
 
 function App() {
-    // 앱 진입 시 localStorage의 UUID를 읽어와 세션을 복구하는 로직
     const initializeSession = useAuthStore((state) => state.initializeSession);
+    const uuid = useAuthStore((state) => state.uuid);           // 추가
+    const connect = useSocketStore((state) => state.connect);   // 추가
 
-    // 컴포넌트 마운트 시 정확히 1번만 실행됨
     useEffect(() => {
         initializeSession();
     }, [initializeSession]);
 
+    // uuid가 생기는 순간(로그인 완료) 소켓 연결을 시작합니다.
+    useEffect(() => {
+        if (uuid) {
+            connect(uuid);
+        }
+    }, [uuid, connect]); // 추가
+
     return (
         <div className="w-full min-h-screen bg-black text-white">
-            {/* [SPA 라우팅의 핵심]
-                BrowserRouter: 브라우저의 주소창 URL과 React 앱을 동기화합니다. 페이지 새로고침 없이 화면을 전환할 수 있게 해줍니다.
-            */}
             <BrowserRouter>
                 <Routes>
-                    {/* 1. 공개 경로 (Public Route)
-                        기본 진입점: 세션이 없는 사용자가 닉네임을 입력하는 화면
-                    */}
                     <Route path="/" element={<Home />} />
-
-                    {/* 2. 보호된 경로 (Protected Route)
-                        세션이 있어야만 접근 가능한 로비 목록 화면
-                    */}
                     <Route
                         path="/lobbies"
                         element={<ProtectedRoute><Lobbies /></ProtectedRoute>}
                     />
-
-                    {/* 3. 딥링크를 지원하는 보호된 경로 (Dynamic Route)
-                        기능명세서의 "초대 코드 발급 및 딥링크 지원" 요구사항을 충족하는 핵심 라우트입니다.
-                        예: 클립보드에 복사된 "https://domain.com/lobby/A1B2C3" 링크를 타고 들어올 때,
-                        A1B2C3가 inviteCode 파라미터로 매핑됩니다.
-                    */}
                     <Route
                         path="/lobby/:inviteCode"
                         element={<ProtectedRoute><LobbyRoom /></ProtectedRoute>}

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { useAuthStore } from '../store/useAuthStore';
+import { useSocketStore } from '../store/useSocketStore';
+
+// 소켓의 생명주기(연결/해제)를 관리하는 커스텀 훅입니다.
+// App.tsx처럼 인증된 사용자가 접근하는 최상위 컴포넌트에서 딱 한 번만 호출합니다.
+// 하위 컴포넌트들은 이 훅을 직접 쓰지 않고,
+// useSocketStore()로 필요한 상태나 액션만 가져다 씁니다.
+export function useSocket() {
+    const uuid = useAuthStore((state) => state.uuid);
+    const connect = useSocketStore((state) => state.connect);
+    const disconnect = useSocketStore((state) => state.disconnect);
+
+    useEffect(() => {
+        // uuid가 없으면(비인증 상태) 소켓 연결을 시도하지 않습니다.
+        if (!uuid) return;
+
+        connect(uuid);
+
+        // [cleanup 함수]
+        // 아래 두 가지 시점에 자동으로 실행됩니다.
+        // 1. 컴포넌트가 화면에서 사라질 때 (로그아웃, 페이지 이탈)
+        // 2. uuid가 바뀔 때 (기존 소켓 끊고 새 uuid로 재연결)
+        return () => {
+            // disconnect()는 async 함수라 Promise를 반환합니다.
+            // useEffect cleanup은 void만 반환할 수 있으므로
+            // 화살표 함수로 감싸서 Promise가 외부로 노출되지 않게 합니다.
+            void disconnect();
+        };
+    }, [uuid, connect, disconnect]);
+}

--- a/src/store/useSocketStore.ts
+++ b/src/store/useSocketStore.ts
@@ -7,19 +7,34 @@ import SockJS from 'sockjs-client';
 // 개발: .env.development / 배포: .env.production
 const WS_ENDPOINT = import.meta.env.VITE_WS_URL;
 
+// [엔드포인트 유효성 검증]
+// 앱 초기화 시점에 환경변수 누락을 즉시 감지합니다.
+if (!WS_ENDPOINT) {
+    throw new Error(
+        '[Socket] VITE_WS_URL 환경변수가 설정되지 않았습니다.\n' +
+        '.env.development 또는 .env.production 파일을 확인해주세요.'
+    );
+}
+
 // ── 타입 정의 ─────────────────────────────────────────────────────────────────
+// 소켓 연결 상태를 3단계로 구분합니다.
+// - disconnected : 연결 끊김 또는 초기 상태
+// - connecting   : 연결 시도 중 (이 상태에서 connect() 재호출 차단)
+// - connected    : STOMP 세션 수립 완료
+type ConnectionStatus = 'disconnected' | 'connecting' | 'connected';
+
 // 이 스토어가 관리할 상태(State)와 액션(Action)의 타입을 정의합니다.
 interface SocketState {
     // STOMP 클라이언트 인스턴스. 연결 전에는 null입니다.
     stompClient: Client | null;
 
-    // 실제 STOMP 세션이 맺어진 상태인지 나타내는 플래그.
-    // UI에서 "연결 중..." 표시나 버튼 활성화 여부 등에 활용합니다.
-    isConnected: boolean;
+    // 소켓 연결 상태. UI에서 "연결 중..." 표시나 버튼 활성화 여부 등에 활용합니다.
+    connectionStatus: ConnectionStatus;
 
     // uuid를 받아 WebSocket 연결을 시작하는 액션
     connect: (uuid: string) => void;
 
+    // 소켓 연결을 종료하는 액션
     disconnect: () => Promise<void>;
 }
 
@@ -31,25 +46,26 @@ export const useSocketStore = create<SocketState>((set, get) => ({
 
     // ── 초기 상태 ──────────────────────────────────────────────────────────────
     stompClient: null,
-    isConnected: false,
+    connectionStatus: 'disconnected',
 
     // ── connect 액션 ───────────────────────────────────────────────────────────
     connect: (uuid: string) => {
-        const existingClient = get().stompClient;
+        const { connectionStatus, stompClient: existingClient } = get();
 
         // [멱등성 보장]
-        // active 상태면 이미 연결 중이므로 중복 실행을 막습니다.
-        if (existingClient?.active) {
-            console.warn('[Socket] 이미 활성화된 세션이 있습니다.');
+        // connecting 또는 connected 상태면 중복 실행을 막습니다.
+        // 기존 stompClient?.active 체크보다 명확하게 상태값으로 판단합니다.
+        if (connectionStatus === 'connecting' || connectionStatus === 'connected') {
+            console.warn('[Socket] 이미 연결 중이거나 연결된 상태입니다.');
             return;
         }
 
         // [인스턴스 누수 방지]
-        // active는 아니지만 이전 인스턴스가 남아있는 경우 (연결 실패 등)
+        // disconnected 상태지만 이전 인스턴스가 남아있는 경우 (연결 실패 등)
         // 새 클라이언트를 만들기 전에 기존 인스턴스를 먼저 정리합니다.
         if (existingClient) {
-            existingClient.deactivate();
-            set({ stompClient: null, isConnected: false });
+            void existingClient.deactivate();
+            set({ stompClient: null, connectionStatus: 'disconnected' });
         }
 
         const client = new Client({
@@ -64,7 +80,7 @@ export const useSocketStore = create<SocketState>((set, get) => ({
             // STOMP CONNECT 프레임에 UUID를 포함합니다.
             // 추후 Spring Security에서 이 헤더를 읽어 게스트 세션을 검증할 예정입니다.
             connectHeaders: {
-                'X-Guest-UUID': uuid,
+                'uuid': uuid,
             },
 
             // [재연결 정책]
@@ -74,10 +90,9 @@ export const useSocketStore = create<SocketState>((set, get) => ({
 
             // [연결 성공 콜백]
             // STOMP 세션이 정상적으로 맺어지면 실행됩니다.
-            // isConnected를 true로 바꿔 UI가 연결 상태를 인식하게 합니다.
             onConnect: () => {
                 console.info('[Socket] 연결 성공');
-                set({ isConnected: true });
+                set({ connectionStatus: 'connected' });
             },
 
             // [연결 종료 콜백]
@@ -85,7 +100,7 @@ export const useSocketStore = create<SocketState>((set, get) => ({
             // reconnectDelay가 설정되어 있으므로 단절 시 5초 후 자동 재연결을 시도합니다.
             onDisconnect: () => {
                 console.info('[Socket] 연결 종료 - 5초 후 재연결 시도');
-                set({ isConnected: false });
+                set({ connectionStatus: 'disconnected' });
             },
 
             // [STOMP 에러 핸들링]
@@ -93,7 +108,7 @@ export const useSocketStore = create<SocketState>((set, get) => ({
             // 예 : 인증 실패, 잘못된 구독 경로 등
             onStompError: (frame) => {
                 console.error('[Socket] STOMP 에러 발생:', frame.headers['message']);
-                set({ isConnected: false });
+                set({ connectionStatus: 'disconnected' });
             },
 
             // [WebSocket 에러 핸들링]
@@ -101,15 +116,17 @@ export const useSocketStore = create<SocketState>((set, get) => ({
             // 예 : 네트워크 단절, 서버 다운
             onWebSocketError: (event) => {
                 console.error('[Socket] WebSocket 에러 발생:', event);
-                set({ isConnected: false });
+                set({ connectionStatus: 'disconnected' });
             },
         });
 
-        // STOMP 클라이언트를 활성화합니다 (실제 WebSocket 연결 시작).
+        // connecting 상태로 먼저 변경 후 activate() 호출합니다.
+        // 이 순서가 중요한 이유: activate() 이후 onConnect가 오기 전까지
+        // 다른 곳에서 connect()를 재호출하는 것을 차단하기 위함입니다.
+        set({ connectionStatus: 'connecting' });
         client.activate();
 
         // 생성된 클라이언트 인스턴스를 스토어에 저장합니다.
-        // 이후 다른 컴포넌트에서 이 클라이언트를 통해 메시지를 보내거나 구독할 수 있습니다.
         set({ stompClient: client });
     },
 
@@ -117,15 +134,21 @@ export const useSocketStore = create<SocketState>((set, get) => ({
     disconnect: async () => {
         const { stompClient } = get();
 
-        // 연결된 클라이언트가 없으면 아무것도 하지 않습니다.
         if (!stompClient) return;
 
-        // STOMP 세션을 비활성화합니다.
-        // deactivate()는 Promise를 반환하므로 완전히 종료될 때까지 기다립니다.
-        await stompClient.deactivate();
+        // [타이밍 제어]
+        // deactivate() 전에 reconnectDelay를 0으로 설정하여
+        // 진행 중인 재연결 시도를 즉시 차단합니다.
+        stompClient.reconnectDelay = 0;
 
-        // 스토어 상태를 초기값으로 되돌립니다.
-        set({ stompClient: null, isConnected: false });
+        // [불필요 호출 방지]
+        // active 상태일 때만 deactivate()를 호출합니다.
+        // active가 false인 상태에서 deactivate()를 호출하면 불필요한 비동기 작업이 발생할 수 있습니다.
+        if (stompClient.active) {
+            await stompClient.deactivate();
+        }
+
+        set({ stompClient: null, connectionStatus: 'disconnected' });
 
         console.info('[Socket] 소켓 연결 해제 완료');
     },

--- a/src/store/useSocketStore.ts
+++ b/src/store/useSocketStore.ts
@@ -19,6 +19,8 @@ interface SocketState {
 
     // uuid를 받아 WebSocket 연결을 시작하는 액션
     connect: (uuid: string) => void;
+
+    disconnect: () => Promise<void>;
 }
 
 // ── 스토어 생성 ───────────────────────────────────────────────────────────────
@@ -83,4 +85,22 @@ export const useSocketStore = create<SocketState>((set, get) => ({
         // 이후 다른 컴포넌트에서 이 클라이언트를 통해 메시지를 보내거나 구독할 수 있습니다.
         set({ stompClient: client });
     },
+
+    // ── disconnect 액션 ────────────────────────────────────────────────────────
+    disconnect: async () => {
+        const { stompClient } = get();
+
+        // 연결된 클라이언트가 없으면 아무것도 하지 않습니다.
+        if (!stompClient) return;
+
+        // STOMP 세션을 비활성화합니다.
+        // deactivate()는 Promise를 반환하므로 완전히 종료될 때까지 기다립니다.
+        await stompClient.deactivate();
+
+        // 스토어 상태를 초기값으로 되돌립니다.
+        set({ stompClient: null, isConnected: false });
+
+        console.info('[Socket] 소켓 연결 해제 완료');
+    },
+
 }));

--- a/src/store/useSocketStore.ts
+++ b/src/store/useSocketStore.ts
@@ -3,9 +3,9 @@ import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
 
 // ── 상수 ──────────────────────────────────────────────────────────────────────
-// 백엔드 WebSocketConfig.java에 정의된 엔드포인트와 일치해야 합니다.
-// 추후 배포 환경에서는 .env 파일의 VITE_WS_URL 변수로 교체할 예정입니다.
-const WS_ENDPOINT = 'http://localhost:8080/ws';
+// 환경별 WebSocket 엔드포인트를 .env 파일에서 가져옵니다.
+// 개발: .env.development / 배포: .env.production
+const WS_ENDPOINT = import.meta.env.VITE_WS_URL;
 
 // ── 타입 정의 ─────────────────────────────────────────────────────────────────
 // 이 스토어가 관리할 상태(State)와 액션(Action)의 타입을 정의합니다.
@@ -35,15 +35,21 @@ export const useSocketStore = create<SocketState>((set, get) => ({
 
     // ── connect 액션 ───────────────────────────────────────────────────────────
     connect: (uuid: string) => {
+        const existingClient = get().stompClient;
 
         // [멱등성 보장]
-        // .active는 @stomp/stompjs가 제공하는 속성으로,
-        // 클라이언트가 현재 활성화(연결 중 or 연결됨) 상태이면 true를 반환합니다.
-        // React StrictMode는 개발 환경에서 컴포넌트를 2번 마운트하기 때문에
-        // 이 체크가 없으면 소켓이 중복으로 생성될 수 있습니다.
-        if (get().stompClient?.active) {
+        // active 상태면 이미 연결 중이므로 중복 실행을 막습니다.
+        if (existingClient?.active) {
             console.warn('[Socket] 이미 활성화된 세션이 있습니다.');
             return;
+        }
+
+        // [인스턴스 누수 방지]
+        // active는 아니지만 이전 인스턴스가 남아있는 경우 (연결 실패 등)
+        // 새 클라이언트를 만들기 전에 기존 인스턴스를 먼저 정리합니다.
+        if (existingClient) {
+            existingClient.deactivate();
+            set({ stompClient: null, isConnected: false });
         }
 
         const client = new Client({
@@ -61,6 +67,11 @@ export const useSocketStore = create<SocketState>((set, get) => ({
                 'X-Guest-UUID': uuid,
             },
 
+            // [재연결 정책]
+            // 네트워크 일시 단절 시 5초 간격으로 자동 재연결을 시도합니다.
+            // 0으로 설정하면 자동 재연결을 하지 않습니다.
+            reconnectDelay: 5000,
+
             // [연결 성공 콜백]
             // STOMP 세션이 정상적으로 맺어지면 실행됩니다.
             // isConnected를 true로 바꿔 UI가 연결 상태를 인식하게 합니다.
@@ -71,9 +82,25 @@ export const useSocketStore = create<SocketState>((set, get) => ({
 
             // [연결 종료 콜백]
             // 정상 종료 또는 예기치 않은 단절 시 실행됩니다.
-            // isConnected를 false로 되돌려 UI가 단절 상태를 인식하게 합니다.
+            // reconnectDelay가 설정되어 있으므로 단절 시 5초 후 자동 재연결을 시도합니다.
             onDisconnect: () => {
-                console.info('[Socket] 연결 종료');
+                console.info('[Socket] 연결 종료 - 5초 후 재연결 시도');
+                set({ isConnected: false });
+            },
+
+            // [STOMP 에러 핸들링]
+            // 서버가 STOMP ERROR 프레임을 보낼 때 실행됩니다.
+            // 예 : 인증 실패, 잘못된 구독 경로 등
+            onStompError: (frame) => {
+                console.error('[Socket] STOMP 에러 발생:', frame.headers['message']);
+                set({ isConnected: false });
+            },
+
+            // [WebSocket 에러 핸들링]
+            // WebSocket 연결 자체가 실패하거나 끊어질 때 실행됩니다.
+            // 예 : 네트워크 단절, 서버 다운
+            onWebSocketError: (event) => {
+                console.error('[Socket] WebSocket 에러 발생:', event);
                 set({ isConnected: false });
             },
         });

--- a/src/store/useSocketStore.ts
+++ b/src/store/useSocketStore.ts
@@ -1,0 +1,86 @@
+import { create } from 'zustand';
+import { Client } from '@stomp/stompjs';
+import SockJS from 'sockjs-client';
+
+// ── 상수 ──────────────────────────────────────────────────────────────────────
+// 백엔드 WebSocketConfig.java에 정의된 엔드포인트와 일치해야 합니다.
+// 추후 배포 환경에서는 .env 파일의 VITE_WS_URL 변수로 교체할 예정입니다.
+const WS_ENDPOINT = 'http://localhost:8080/ws';
+
+// ── 타입 정의 ─────────────────────────────────────────────────────────────────
+// 이 스토어가 관리할 상태(State)와 액션(Action)의 타입을 정의합니다.
+interface SocketState {
+    // STOMP 클라이언트 인스턴스. 연결 전에는 null입니다.
+    stompClient: Client | null;
+
+    // 실제 STOMP 세션이 맺어진 상태인지 나타내는 플래그.
+    // UI에서 "연결 중..." 표시나 버튼 활성화 여부 등에 활용합니다.
+    isConnected: boolean;
+
+    // uuid를 받아 WebSocket 연결을 시작하는 액션
+    connect: (uuid: string) => void;
+}
+
+// ── 스토어 생성 ───────────────────────────────────────────────────────────────
+// create<타입>((set, get) => ({ ... })) 형태가 Zustand의 기본 패턴입니다.
+// - set: 상태를 변경할 때 사용
+// - get: 현재 상태를 읽을 때 사용 (액션 내부에서 현재 상태 확인 시 필요)
+export const useSocketStore = create<SocketState>((set, get) => ({
+
+    // ── 초기 상태 ──────────────────────────────────────────────────────────────
+    stompClient: null,
+    isConnected: false,
+
+    // ── connect 액션 ───────────────────────────────────────────────────────────
+    connect: (uuid: string) => {
+
+        // [멱등성 보장]
+        // .active는 @stomp/stompjs가 제공하는 속성으로,
+        // 클라이언트가 현재 활성화(연결 중 or 연결됨) 상태이면 true를 반환합니다.
+        // React StrictMode는 개발 환경에서 컴포넌트를 2번 마운트하기 때문에
+        // 이 체크가 없으면 소켓이 중복으로 생성될 수 있습니다.
+        if (get().stompClient?.active) {
+            console.warn('[Socket] 이미 활성화된 세션이 있습니다.');
+            return;
+        }
+
+        const client = new Client({
+            // [SockJS 주입]
+            // brokerURL('ws://...') 대신 webSocketFactory를 쓰는 이유:
+            // Spring 서버가 SockJS 방식으로 열려 있기 때문입니다.
+            // SockJS는 WebSocket 연결이 실패할 경우 HTTP 폴링 등으로
+            // 자동 대체(fallback)하여 방화벽 환경에서도 안정적으로 동작합니다.
+            webSocketFactory: () => new SockJS(WS_ENDPOINT),
+
+            // [인증 헤더]
+            // STOMP CONNECT 프레임에 UUID를 포함합니다.
+            // 추후 Spring Security에서 이 헤더를 읽어 게스트 세션을 검증할 예정입니다.
+            connectHeaders: {
+                'X-Guest-UUID': uuid,
+            },
+
+            // [연결 성공 콜백]
+            // STOMP 세션이 정상적으로 맺어지면 실행됩니다.
+            // isConnected를 true로 바꿔 UI가 연결 상태를 인식하게 합니다.
+            onConnect: () => {
+                console.info('[Socket] 연결 성공');
+                set({ isConnected: true });
+            },
+
+            // [연결 종료 콜백]
+            // 정상 종료 또는 예기치 않은 단절 시 실행됩니다.
+            // isConnected를 false로 되돌려 UI가 단절 상태를 인식하게 합니다.
+            onDisconnect: () => {
+                console.info('[Socket] 연결 종료');
+                set({ isConnected: false });
+            },
+        });
+
+        // STOMP 클라이언트를 활성화합니다 (실제 WebSocket 연결 시작).
+        client.activate();
+
+        // 생성된 클라이언트 인스턴스를 스토어에 저장합니다.
+        // 이후 다른 컴포넌트에서 이 클라이언트를 통해 메시지를 보내거나 구독할 수 있습니다.
+        set({ stompClient: client });
+    },
+}));

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -10,7 +10,6 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
-    "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -13,6 +13,7 @@
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",
+    "jsxImportSource": "react",
 
     "strict": true,                               // 모든 엄격한 타입 검사 활성화
     "noImplicitAny": true,                        // 암시적 any 타입 에러 처리

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,17 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import path from 'path' // Node.js 경로 모듈 가져오기
+import path from 'path'
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      // @ 기호를 src 폴더의 절대 경로로 매핑
       "@": path.resolve(__dirname, "./src"),
     },
+  },
+  define: {
+    // sockjs-client가 Node.js 환경의 global 변수를 참조하기 때문에
+    // Vite(브라우저) 환경에서도 동작하도록 globalThis로 연결해줍니다.
+    global: 'globalThis',
   },
 })


### PR DESCRIPTION
## 📣 Related Issue

- #7

## 📝 Summary

- `@stomp/stompjs`, `sockjs-client` 라이브러리 설치
- `useSocketStore` 생성 - `stompClient`, `isConnected`, `connect`, `disconnect` 상태 및 액션 관리
- STOMP `CONNECT` 헤더에 `X-Guest-UUID`를 포함하여 게스트 세션 인증 준비
- `useSocket` 커스텀 훅 생성 - 소켓 연결/해제 생명주기를 컴포넌트와 분리하여 관리
- `App.tsx`에서 `useSocket()` 한 줄로 소켓 파이프라인 연결

## 🙏 PR point

- `stompClient` 객체를 Zustand에 직접 저장하면 얕은 비교로 변화 감지가 안 되기 때문에, 연결 상태는 별도의 `isConnected` boolean으로 관리했습니다.
- `sockjs-client`가 브라우저 환경에서 `global`을 참조하는 문제가 있어 `vite.config.ts`에 `global: 'globalThis'` 폴리필을 추가했습니다.
- `verbatimModuleSyntax` 옵션이 CommonJS 모듈인 `sockjs-client`와 충돌하여 해당 옵션을 제거했습니다.

## 📬 Reference
