### PR TITLE
[Refactor/#14] 상수 & 타입 분리

### DIFF
--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -1,0 +1,20 @@
+// 서버와 통신할 때 사용하는 주소 (URL)를 관리한다.
+// 개발 환경과 실제 배포 환경의 주소가 다르기 때문에
+// .env.development / .env.production 파일에 주소를 따로 저장해두고 여기서 불러온다.
+
+// import.meta.env는 Vite가 제공하는 환경변수 접근 방법이다.
+// VITE_WS_URL은 .env 파일에 정의된 WebSocket 서버 주소이다.
+const rawWsUrl = import.meta.env.VITE_WS_URL as string | undefined;
+
+// 환경변수가 설정되지 않은 채로 앱이 실행되면 즉시 에러를 발생시킨다.
+// 소켓 연결을 시도한 후 실패하는 것보다, 앱 시작 시점에 바로 발견하는 것이 훨씬 좋다.
+// 이를 Fail-Fast (빠른 실패) 원칙이라고 한다.
+if (!rawWsUrl) {
+    throw new Error(
+        '[Endpoints] VITE_WS_URL 환경변수가 설정되지 않았습니다.\n' +
+        '.env.development 또는 .env.production 파일을 확인해주세요.',
+    );
+}
+
+// 검증을 통과한 안전한 값만 외부로 내보낸다.
+export const WS_ENDPOINT = rawWsUrl;

--- a/src/constants/socketEvents.ts
+++ b/src/constants/socketEvents.ts
@@ -1,0 +1,33 @@
+// 서버와 실시간 통신 (WebSocket)에 사용하는 채널 경로를 모아둔 파일이다.
+// STOMP 프로토콜은 채팅방처럼 '채널'이라는 개념을 사용한다.
+// 특정 채널에 '발행 (메시지 보내기)'하거나 '구독 (메시지 받기)' 하는 방식으로 동작한다.
+
+// BE 기준 :
+//   - WebSocketConfig.java : /app (발행 prefix), /topic (구독 prefix)
+//   - ChatController.java  : /topic/chat/global, /topic/lobby/{code}
+
+// 발행 경로 (클라이언트 → 서버)
+// 클라이언트가 서버로 메시지를 보낼 때 사용하는 경로이다.
+// Spring의 @MessageMapping이 /app prefix를 제거한 뒤 경로를 매핑한다.
+export const SOCKER_PUBLISH = {
+    // 모든 사용자가 보는 전체 채팅에 메시지를 보낼 때 사용한다.
+    CHAT_GLOBAL: '/app/chat/global',
+
+    // 특정 로비 (방)의 채팅에 메시지를 보낼 때 사용한다.
+    // code는 로비의 6자리 초대 코드이다.
+    // 예 : SOCKET_PUBLISH.CHAT_LOBBY('ABC123') → '/app/chat/lobby/ABC123'
+    CHAT_LOBBY: (code: string) => `/app/chat/lobby/${code}`,
+} as const;
+
+// 구독 경로 (서버 → 클라이언트)
+// 서버에서 클라이언트로 메시지가 전달되는 경로이다.
+// 이 경로를 구독하면 해당 채널에 새 메시지가 올 때마다 자동으로 수신한다.
+export const SOCKET_SUBSCRIBE = {
+    // 전체 채팅 메시지를 수신할 때 사용한다.
+    CHAT_GLOBAL: '/app/chat/global',
+
+    // 특정 로비 (방)의 메시지를 수신할 때 사용한다.
+    // 채팅 메시지뿐 아니라 게임 이벤트 (라운드 시작/종료, 정답 알림 등)도
+    // 이 채널로 수신하며, 메시지 안에 type 필드로 어떤 종류인지 구분한다.
+    LOBBY: (code: string) => `/topic/lobby/${code}`,
+} as const;

--- a/src/constants/socketEvents.ts
+++ b/src/constants/socketEvents.ts
@@ -9,7 +9,7 @@
 // 발행 경로 (클라이언트 → 서버)
 // 클라이언트가 서버로 메시지를 보낼 때 사용하는 경로이다.
 // Spring의 @MessageMapping이 /app prefix를 제거한 뒤 경로를 매핑한다.
-export const SOCKER_PUBLISH = {
+export const SOCKET_PUBLISH = {
     // 모든 사용자가 보는 전체 채팅에 메시지를 보낼 때 사용한다.
     CHAT_GLOBAL: '/app/chat/global',
 
@@ -24,7 +24,7 @@ export const SOCKER_PUBLISH = {
 // 이 경로를 구독하면 해당 채널에 새 메시지가 올 때마다 자동으로 수신한다.
 export const SOCKET_SUBSCRIBE = {
     // 전체 채팅 메시지를 수신할 때 사용한다.
-    CHAT_GLOBAL: '/app/chat/global',
+    CHAT_GLOBAL: '/topic/chat/global',
 
     // 특정 로비 (방)의 메시지를 수신할 때 사용한다.
     // 채팅 메시지뿐 아니라 게임 이벤트 (라운드 시작/종료, 정답 알림 등)도

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -1,0 +1,16 @@
+// 브라우저의 로컬 저장소 (localStorage)와 관련된 고정값들을 모아둔 파일이다.
+// 고정값을 한 곳에서 관리하면, 나중에 값을 바꿀 때 이 파일 하나만 수정하면 된다.
+
+// localStorage 키
+// localStorage는 브라우저에 데이터를 저장할 때 이름표 (key)와 값 (value)을 쌍으로 저장한다.
+// 예 : localStorage.setItem('monomat_guest_session', {"nickname":"홍길동"}')
+// 이 이름표 문자열을 코드 여러 곳에 직접 쓰면, 오타가 나도 에러가 발생하지 않아 찾기 어렵다.
+// 상수로 정의해두면 오타 시 TypeScript가 즉시 에러를 알려준다.
+export const STORAGE_KEYS = {
+    GUEST_SESSION: 'monomat_guest_session', // 게스트 세션 정보 저장 키
+} as const;
+
+// 세션 만료 기간
+// 게스트 유저가 30일 동안 접속하지 않으면 세션을 만료시킨다.
+// 밀리초 (ms) 단위로 계산한다. (30일 × 24시간 × 60분 × 60초 × 1000밀리초)
+export const SESSION_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { MonomatInput } from '../components/common/MonomatInput';
 import { useAuthStore } from '../store/useAuthStore'; // Zustand 전역 스토어 연결
+import { STORAGE_KEYS } from '../constants/storage';
 
 /**
  * [아키텍처 지식: UUID Fallback 생성기]
@@ -59,7 +60,7 @@ export const Home = () => {
         // 2. localStorage 세션 저장 및 예외 처리 (Graceful Degradation)
         try {
             // 정상적인 상황: 브라우저 스토리지에 데이터를 영구 저장하여 새로고침(Graceful Reconnect) 대비
-            localStorage.setItem('monomat_guest_session', JSON.stringify(sessionData));
+            localStorage.setItem(STORAGE_KEYS.GUEST_SESSION, JSON.stringify(sessionData));
             console.log('게스트 세션 생성 완료:', sessionData);
         } catch (error) {
             // 예외 상황: iOS Safari 시크릿 모드 등에서는 스토리지 할당량이 0일 수 있어 에러가 발생함

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,40 +1,32 @@
 import { create } from 'zustand';
 import { z } from 'zod';
 
-// [아키텍처 지식: 매직 넘버(Magic Number) 제거]
-// 시간과 관련된 하드코딩된 숫자는 가독성을 떨어뜨리고 버그를 유발합니다.
-// 상수화를 통해 '게스트 세션 30일 만료 정책'이라는 도메인 규칙을 코드 레벨에서 명확히 선언합니다.
-const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+import { STORAGE_KEYS, SESSION_EXPIRY_MS } from '../constants/storage';
 
-/**
- * [아키텍처 지식: 부패 방지 계층(Anti-Corruption Layer) 및 Zod v4 적용]
- * localStorage와 같은 클라이언트 스토리지는 사용자나 악성 스크립트에 의해 언제든 변조될 수 있습니다.
- * 이 스키마는 외부의 오염된 데이터가 애플리케이션의 핵심 로직으로 침투하지 못하게 막는 방어막입니다.
- */
+import type { GuestSession } from '../types/auth';
 
+// localStorage에서 읽어온 데이터가 올바른 구조인지 검증하는 스키마
+// 사용자가 localStorage 값을 임의로 수정했거나, 형식이 맞지 않을 때를 대비한다.
+// satisfies는 이 스키마가 GuestSession 타입과 일치하는지 TypeScript가 확인하도록 한다.
+// 스키마 구조와 타입 정의가 서로 어긋나면 이 줄에서 바로 에러가 발생한다.
 const guestSessionSchema = z.object({
-    // Zod v4 스펙: 최상위 식별자 검증기(z.uuid)와 통합 에러 프로퍼티({ error: "..." })를 활용하여
-    // 직관적이고 일관된 에러 컨트랙트를 구성합니다.
-    uuid: z.uuid({ error: "유효하지 않은 UUID 형식입니다." }),
-    nickname: z.string()
-        .min(1, { error: "닉네임은 최소 1자 이상이어야 합니다." })
-        .max(12, { error: "닉네임은 12자 이내여야 합니다." }),
-
-    // 비즈니스 로직 캡슐화: 만료 검증 로직을 스키마 내부에 응집시킵니다.
-    // 이 검증을 통과한 데이터는 '형식이 올바르고 기한이 유효한 안전한 데이터'임을 시스템 전체가 신뢰할 수 있습니다.
-    createdAt: z.number().refine((time) => {
-        const isExpired = (Date.now() - time) > THIRTY_DAYS_MS;
-        return !isExpired;
-    }, { error: "세션이 30일을 초과하여 만료되었습니다." })
-});
+    uuid: z.uuid({ error: '유효하지 않은 UUID 형식입니다.' }),
+    nickname: z
+        .string()
+        .min(1, { error: '닉네임은 최소 1자 이상이어야 합니다.' })
+        .max(12, { error: '닉네임은 12자 이내여야 합니다.' }),
+    createdAt: z.number().refine(
+        (time) => Date.now() - time <= SESSION_EXPIRY_MS,
+        { error: `세션이 만료되었습니다. (기준: ${SESSION_EXPIRY_MS / (1000 * 60 * 60 * 24)}일)` },
+    ),
+}) satisfies z.ZodType<GuestSession>;
 
 interface AuthState {
     uuid: string | null;
     nickname: string | null;
     isGuest: boolean;
-    // [아키텍처 지식: Hydration 동기화 플래그]
-    // React 19 환경에서 스토리지 데이터 로드 전과 후의 렌더링 불일치(Hydration Mismatch)를 방지합니다.
-    // UI 계층은 이 값이 true가 된 이후에만 게임 진입 화면이나 로그인 폼을 렌더링해야 안전합니다.
+    // localStorage 데이터를 읽어오기 전과 후를 구분하는 플래그
+    // 이 값이 true가 되기 전에 화면을 렌더링하면 로그인 상태가 깜빡이는 현상이 발생한다.
     isHydrated: boolean;
     setSession: (uuid: string, nickname: string) => void;
     clearSession: () => void;
@@ -45,57 +37,52 @@ export const useAuthStore = create<AuthState>((set) => ({
     uuid: null,
     nickname: null,
     isGuest: false,
-    isHydrated: false, // 최초 로드 시점에는 스토리지 확인 전이므로 무조건 false
+    isHydrated: false,
 
     setSession: (uuid, nickname) => {
-        // [로직 안전성 보장] 신규 유저가 진입하여 세션을 생성할 때도 동기화가 완료된 것으로 간주합니다.
         set({ uuid, nickname, isGuest: true, isHydrated: true });
     },
 
     clearSession: () => {
-        localStorage.removeItem('monomat_guest_session');
-        // 세션 데이터는 지워지지만 "스토리지가 비어있음을 확인한 상태"이므로 isHydrated는 true를 유지합니다.
+        // STORAGE_KEYS.GUEST_SESSION을 사용하므로 문자열 오타 위험이 없다.
+        localStorage.removeItem(STORAGE_KEYS.GUEST_SESSION);
         set({ uuid: null, nickname: null, isGuest: false, isHydrated: true });
     },
 
     initializeSession: () => {
         try {
-            const storedData = localStorage.getItem('monomat_guest_session');
+            const storedData = localStorage.getItem(STORAGE_KEYS.GUEST_SESSION);
 
-            // 신규 방문자거나 스토리지가 비어있는 경우
+            // 저장된 데이터가 없으면 신규 방문자이다.
             if (!storedData) {
                 set({ isHydrated: true });
                 return;
             }
 
-            const parsed = JSON.parse(storedData);
-            // safeParse를 통해 검증 실패 시 예외를 던지지 않고 분기 처리
-            const validationResult = guestSessionSchema.safeParse(parsed);
+            const parsed = JSON.parse(storedData) as unknown;
+            // safeParse는 검증 실패 시 예외를 던지지 않고 성공/실패 결과를 반환한다.
+            const result = guestSessionSchema.safeParse(parsed);
 
-            if (validationResult.success) {
-                // 메모리(Zustand)에 안전성이 검증된 상태만 적재합니다.
+            if (result.success) {
                 set({
-                    uuid: validationResult.data.uuid,
-                    nickname: validationResult.data.nickname,
+                    uuid: result.data.uuid,
+                    nickname: result.data.nickname,
                     isGuest: true,
-                    isHydrated: true
+                    isHydrated: true,
                 });
-                console.log('세션 복구 완료:', validationResult.data.nickname);
+                console.log('세션 복구 완료:', result.data.nickname);
             } else {
-                // [아키텍처 지식: Observability 극대화 및 Fail-Fast]
-                // Zod v4의 z.treeifyError를 사용하여 복잡한 에러 객체를 구조화된 트리 형태로 포맷팅합니다.
-                // 이는 개발 환경의 디버깅 효율을 높이고, Sentry 등의 로깅 시스템에서 컨텍스트를 파악하기 좋게 만듭니다.
-                console.warn('세션 무효화 (오염 또는 만료):', z.treeifyError(validationResult.error));
-
-                // 오염되거나 만료된 데이터는 즉시 파기하여 잘못된 상태로 앱이 동작하는 것을 선제적으로 차단합니다(자가 치유).
-                localStorage.removeItem('monomat_guest_session');
+                // 데이터가 오염되었거나 만료된 경우 즉시 삭제한다.
+                // z.treeifyError는 Zod v4의 기능으로, 에러를 보기 좋은 트리 형태로 출력한다.
+                console.warn('세션 무효화 (오염 또는 만료):', z.treeifyError(result.error));
+                localStorage.removeItem(STORAGE_KEYS.GUEST_SESSION);
                 set({ isHydrated: true });
             }
         } catch (error) {
-            // JSON.parse 실패 등 예기치 못한 치명적 예외가 발생할 경우를 대비한 최후의 보루(Fallback)입니다.
+            // JSON.parse 실패 등 예기치 못한 에러를 대비한 최후의 처리이다.
             console.error('세션 파싱 중 오류 발생:', error);
-            localStorage.removeItem('monomat_guest_session');
+            localStorage.removeItem(STORAGE_KEYS.GUEST_SESSION);
             set({ isHydrated: true });
         }
-    }
+    },
 }));

--- a/src/store/useSocketStore.ts
+++ b/src/store/useSocketStore.ts
@@ -2,155 +2,90 @@ import { create } from 'zustand';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
 
-// ── 상수 ──────────────────────────────────────────────────────────────────────
-// 환경별 WebSocket 엔드포인트를 .env 파일에서 가져옵니다.
-// 개발: .env.development / 배포: .env.production
-const WS_ENDPOINT = import.meta.env.VITE_WS_URL;
+// useSocketStore는 소켓 연결 관리라는 단일 책임만 갖는다.
+import { WS_ENDPOINT } from '../constants/endpoints';
 
-// [엔드포인트 유효성 검증]
-// 앱 초기화 시점에 환경변수 누락을 즉시 감지합니다.
-if (!WS_ENDPOINT) {
-    throw new Error(
-        '[Socket] VITE_WS_URL 환경변수가 설정되지 않았습니다.\n' +
-        '.env.development 또는 .env.production 파일을 확인해주세요.'
-    );
-}
-
-// ── 타입 정의 ─────────────────────────────────────────────────────────────────
-// 소켓 연결 상태를 3단계로 구분합니다.
-// - disconnected : 연결 끊김 또는 초기 상태
-// - connecting   : 연결 시도 중 (이 상태에서 connect() 재호출 차단)
-// - connected    : STOMP 세션 수립 완료
+// 소켓 연결 상태를 세 단계로 구분한다.
+// UI에서 "연결 중...", "연결됨", "연결 끊김" 표시에 활용할 수 있다.
 type ConnectionStatus = 'disconnected' | 'connecting' | 'connected';
 
-// 이 스토어가 관리할 상태(State)와 액션(Action)의 타입을 정의합니다.
 interface SocketState {
-    // STOMP 클라이언트 인스턴스. 연결 전에는 null입니다.
     stompClient: Client | null;
-
-    // 소켓 연결 상태. UI에서 "연결 중..." 표시나 버튼 활성화 여부 등에 활용합니다.
     connectionStatus: ConnectionStatus;
-
-    // uuid를 받아 WebSocket 연결을 시작하는 액션
     connect: (uuid: string) => void;
-
-    // 소켓 연결을 종료하는 액션
     disconnect: () => Promise<void>;
 }
 
-// ── 스토어 생성 ───────────────────────────────────────────────────────────────
-// create<타입>((set, get) => ({ ... })) 형태가 Zustand의 기본 패턴입니다.
-// - set: 상태를 변경할 때 사용
-// - get: 현재 상태를 읽을 때 사용 (액션 내부에서 현재 상태 확인 시 필요)
 export const useSocketStore = create<SocketState>((set, get) => ({
-
-    // ── 초기 상태 ──────────────────────────────────────────────────────────────
     stompClient: null,
     connectionStatus: 'disconnected',
 
-    // ── connect 액션 ───────────────────────────────────────────────────────────
     connect: (uuid: string) => {
         const { connectionStatus, stompClient: existingClient } = get();
 
-        // [멱등성 보장]
-        // connecting 또는 connected 상태면 중복 실행을 막습니다.
-        // 기존 stompClient?.active 체크보다 명확하게 상태값으로 판단합니다.
+        // 이미 연결 중이거나 연결된 상태라면 중복 실행을 막는다.
         if (connectionStatus === 'connecting' || connectionStatus === 'connected') {
             console.warn('[Socket] 이미 연결 중이거나 연결된 상태입니다.');
             return;
         }
 
-        // [인스턴스 누수 방지]
-        // disconnected 상태지만 이전 인스턴스가 남아있는 경우 (연결 실패 등)
-        // 새 클라이언트를 만들기 전에 기존 인스턴스를 먼저 정리합니다.
+        // 이전에 연결이 실패하는 등의 이유로 인스턴스가 남아있을 경우 먼저 정리한다.
         if (existingClient) {
             void existingClient.deactivate();
             set({ stompClient: null, connectionStatus: 'disconnected' });
         }
 
         const client = new Client({
-            // [SockJS 주입]
-            // brokerURL('ws://...') 대신 webSocketFactory를 쓰는 이유:
-            // Spring 서버가 SockJS 방식으로 열려 있기 때문입니다.
-            // SockJS는 WebSocket 연결이 실패할 경우 HTTP 폴링 등으로
-            // 자동 대체(fallback)하여 방화벽 환경에서도 안정적으로 동작합니다.
-            webSocketFactory: () => new SockJS(WS_ENDPOINT),
+            // SockJS는 WebSocket 연결이 불가능한 환경(일부 방화벽 등)에서
+            // HTTP 폴링 등으로 자동 대체하여 안정적으로 동작하게 해준다.
+            webSocketFactory: () => new SockJS(WS_ENDPOINT) as WebSocket,
 
-            // [인증 헤더]
-            // STOMP CONNECT 프레임에 UUID를 포함합니다.
-            // 추후 Spring Security에서 이 헤더를 읽어 게스트 세션을 검증할 예정입니다.
-            connectHeaders: {
-                'uuid': uuid,
-            },
+            // STOMP 연결 시 UUID를 헤더에 포함한다.
+            // Spring Security에서 이 값으로 게스트 세션을 식별한다.
+            connectHeaders: { uuid },
 
-            // [재연결 정책]
-            // 네트워크 일시 단절 시 5초 간격으로 자동 재연결을 시도합니다.
-            // 0으로 설정하면 자동 재연결을 하지 않습니다.
+            // 연결이 끊어지면 5초 후 자동으로 재연결을 시도
             reconnectDelay: 5000,
 
-            // [연결 성공 콜백]
-            // STOMP 세션이 정상적으로 맺어지면 실행됩니다.
             onConnect: () => {
                 console.info('[Socket] 연결 성공');
                 set({ connectionStatus: 'connected' });
             },
 
-            // [연결 종료 콜백]
-            // 정상 종료 또는 예기치 않은 단절 시 실행됩니다.
-            // reconnectDelay가 설정되어 있으므로 단절 시 5초 후 자동 재연결을 시도합니다.
             onDisconnect: () => {
                 console.info('[Socket] 연결 종료 - 5초 후 재연결 시도');
                 set({ connectionStatus: 'disconnected' });
             },
 
-            // [STOMP 에러 핸들링]
-            // 서버가 STOMP ERROR 프레임을 보낼 때 실행됩니다.
-            // 예 : 인증 실패, 잘못된 구독 경로 등
             onStompError: (frame) => {
                 console.error('[Socket] STOMP 에러 발생:', frame.headers['message']);
                 set({ connectionStatus: 'disconnected' });
             },
 
-            // [WebSocket 에러 핸들링]
-            // WebSocket 연결 자체가 실패하거나 끊어질 때 실행됩니다.
-            // 예 : 네트워크 단절, 서버 다운
             onWebSocketError: (event) => {
                 console.error('[Socket] WebSocket 에러 발생:', event);
                 set({ connectionStatus: 'disconnected' });
             },
         });
 
-        // connecting 상태로 먼저 변경 후 activate() 호출합니다.
-        // 이 순서가 중요한 이유: activate() 이후 onConnect가 오기 전까지
-        // 다른 곳에서 connect()를 재호출하는 것을 차단하기 위함입니다.
         set({ connectionStatus: 'connecting' });
         client.activate();
-
-        // 생성된 클라이언트 인스턴스를 스토어에 저장합니다.
         set({ stompClient: client });
     },
 
-    // ── disconnect 액션 ────────────────────────────────────────────────────────
     disconnect: async () => {
         const { stompClient } = get();
-
         if (!stompClient) return;
 
-        // [타이밍 제어]
-        // deactivate() 전에 reconnectDelay를 0으로 설정하여
-        // 진행 중인 재연결 시도를 즉시 차단합니다.
+        // 재연결 시도를 먼저 차단한 뒤 연결을 끊는다.
+        // 이 순서가 바뀌면 deactivate() 도중 재연결을 시도하는 경합 상태가 발생할 수 있다.
         stompClient.reconnectDelay = 0;
 
-        // [불필요 호출 방지]
-        // active 상태일 때만 deactivate()를 호출합니다.
-        // active가 false인 상태에서 deactivate()를 호출하면 불필요한 비동기 작업이 발생할 수 있습니다.
         if (stompClient.active) {
             await stompClient.deactivate();
         }
 
         set({ stompClient: null, connectionStatus: 'disconnected' });
-
         console.info('[Socket] 소켓 연결 해제 완료');
     },
-
 }));

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,24 @@
+// 인증 (로그인)과 관련된 타입 (데이터 구조)을 정의한다.
+// TypeScript의 타입은 "이 데이터는 어떤 모양이어야 한다"는 약속이다.
+// 타입을 미리 정의해두면 잘못된 구조의 데이터를 사용할 때 코드 작성 시점에 바로 에러가 난다.
+
+// 사용자 종류를 정의한다.
+// DB의 user 테이블 user_type 컬럼과 동일한 값을 사용한다.
+// REGISTERED : 아이디/비밀번호로 가입한 정식 회원
+// GUEST : 닉네임만 입력하고 바로 참여한 게스트
+export type UserType = 'REGISTERED' | 'GUEST';
+
+// 게스트 세션 데이터의 구조를 정의한다.
+// 게스트가 브라우저를 닫았다가 다시 열어도 닉네임이 유지되도록 localStorge에 이 구조로 저장한다.
+export interface GuestSession {
+    // 게스트를 식별하는 고유 ID이다. (예: '550e8400-e29b-41d4-a716-446655440000')
+    // UUID (Universally Unique Identifier) 형식으로, 전 세계에서 중복될 확률이 거의 없다.
+    uuid: string;
+
+    // 게임에서 표시되는 닉네임이다. (1~12자)
+    nickname: string;
+
+    // 세션이 처음 만들어진 시각이다. (밀리초 단위 Unix 타임스탬프)
+    // 현재 시각과 비교해서 30일이 지나면 세션을 만료시키는 데 사용한다.
+    createdAt: number;
+}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,0 +1,25 @@
+// 채팅 메시지와 관련된 타입을 정의한다.
+// BE의 ChatMessageDto와 동일한 구조를 유지한다.
+
+// 채팅 메시지의 종류를 정의한다.
+// 서버에서 오는 메시지가 어떤 종류인지에 따라 UI 표시 방식이 달라진다.
+export type ChatMessageType =
+    | 'CHAT'     // 일반 채팅 메시지 — 흰색 말풍선으로 표시
+    | 'SYSTEM'   // 시스템 알림 — 예: "홍길동님이 입장했습니다" (회색으로 표시)
+    | 'CORRECT'; // 정답 알림 — 예: "홍길동님이 정답을 맞혔습니다!" (강조 표시)
+
+// 채팅 메시지 하나의 구조를 정의한다.
+// 서버에서 WebSocket으로 이 구조의 JSON 데이터가 전달된다.
+export interface ChatMessage {
+    // 메시지 종류 : 이 값에 따라 UI 렌더링 방식이 달라진다.
+    type: ChatMessageType;
+
+    // 메시지를 보낸 사람의 닉네임이다.
+    nickname: string;
+
+    // 메시지 내용이다.
+    content: string;
+
+    // 서버 기준 메시지 발신 시각이다. (ISO 8601 형식, 예: '2026-04-25T12:00:00Z')
+    timestamp: string;
+}

--- a/src/types/lobby.ts
+++ b/src/types/lobby.ts
@@ -1,0 +1,44 @@
+// 게임 로비 (대기방)와 관련된 타입을 정의한다.
+// DB의 GAME_LOBBY 테이블 구조를 기반으로 한다.
+
+// 로비의 현재 상태를 정의한다.
+// DBD의 GAME_LOBBY 테이블 status 컬럼과 동일한 값을 사용한다.
+export type LobbyStatus =
+    | 'WAITING'  // 게임 시작 전 대기 중인 상태
+    | 'PLAYING'  // 게임이 진행 중인 상태
+    | 'RESULT';  // 게임이 끝나고 결과를 보여주는 상태
+                 // (기능명세서: 게임 종료 후 로비로 복귀 시 RESULT 상태로 UI 렌더링)
+
+// 로비 하나의 구조를 정의한다.
+// 로비 목록 조회 및 로비 입장 시 서버로부터 이 구조의 데이터를 받는다.
+export interface Lobby {
+    // 로비 고유 번호
+    id: number;
+
+    // 로비 이름 : 방장이 로비를 만들 때 설정
+    name: string;
+
+    // 방장의 닉네임
+    hostNickname: string;
+
+    // 현재 로비에 참여 중인 인원 수
+    currentPlayers: number;
+
+    // 로비에 참여할 수 있는 최대 인원 수
+    maxPlayers: number;
+
+    // 로비의 현재 상태
+    status: LobbyStatus;
+
+    // 비공개 여부
+    // true이면 로비 목록에 표시되지 않고, 초대 코드로만 입장할 수 있다.
+    isPrivate: boolean;
+
+    // 로비 입장에 사용하는 6자리 고유 초대 코드
+    // 예: 'ABC123' → 입장 URL: /lobby/ABC123
+    inviteCode: string;
+
+    // 선택된 퀴즈 맵의 이름
+    // 방장이 아직 맵을 선택하지 않은 경우 null
+    mapTitle: string | null;
+}


### PR DESCRIPTION
## 📣 Related Issue

- #14 

## 📝 Summary

- `src/constants/storage.ts` 생성 — `localStorage` 키, 세션 만료 기간 상수화
- `src/constants/endpoints.ts` 생성 — `VITE_WS_URL` 환경변수 검증 및 `WS_ENDPOINT` 분리
- `src/constants/socketEvents.ts` 생성 — STOMP 발행/구독 채널 경로 상수화
- `src/types/auth.ts` 생성 — `GuestSession`, `UserType` 타입 정의
- `src/types/chat.ts` 생성 — `ChatMessage`, `ChatMessageType` 타입 정의 (BE `ChatMessageDto` 대응)
- `src/types/lobby.ts` 생성 — `Lobby`, `LobbyStatus` 타입 정의
- `src/store/useAuthStore.ts` 수정 — 하드코딩된 문자열/숫자를 상수 및 타입 파일 참조로 교체
- `src/store/useSocketStore.ts` 수정 — `WS_ENDPOINT`를 `constants/endpoints`에서 `import`로 교체
- `src/pages/Home.tsx` 수정 — `localStorage` 키를 `STORAGE_KEYS` 상수로 교체

## 🙏PR point

- `useSocketStore`의 `WS_ENDPOINT` 수정이 이슈 #15 작업 내용과 중복됩니다. 해당 항목은 본 PR에서 처리했으므로 #15 진행 시 스킵하면 됩니다.
- 세션 만료 기간(30일)은 백엔드 Redis TTL 정책 확인 후 조정이 필요할 수 있습니다.

## 📬 Reference

- 유틸 & 커스텀 훅 분리 #15 (선행 완료 후 진행)