### PR TITLE
[Refactor/#16] 컴포넌트 단일 책임 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,39 +1,72 @@
-import React, { useEffect } from 'react';
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+// 애플리케이션의 라우팅 구조 정의 및 앱 전역 생명주기 훅 (세션 초기화, 소켓 연결) 실행
+
+import { useEffect } from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { useAuthStore } from './store/useAuthStore';
-import { useSocket } from './hooks/useSocket'; // 추가
+import { useSocket } from './hooks/useSocket';
+
+// 인라인에서 독립 파일로 분리된 라우트 가드 컴포넌트
+import { ProtectedRoute } from './components/common/ProtectedRoute';
+
 import { Home } from './pages/Home';
 import { Lobbies } from './pages/Lobbies';
 import { LobbyRoom } from './pages/LobbyRoom';
 
-function ProtectedRoute({ children }: { children: React.ReactNode }) {
-    const isGuest = useAuthStore((state) => state.isGuest);
-    return isGuest ? <>{children}</> : <Navigate to="/" replace />;
-}
+/**
+ * [애플리케이션 루트 컴포넌트]
+ *
+ * 이 컴포넌트의 책임:
+ *   1. 앱 최초 진입 시 localStorage에서 게스트 세션을 복구 (initializeSession)
+ *   2. 세션이 확인된 후 WebSocket 연결 시작 (useSocket)
+ *   3. URL 경로에 따라 적절한 페이지 컴포넌트를 렌더링 (Routes/Route)
+ *
+ * 이 컴포넌트가 하지 않는 것:
+ *   - 인증 가드 로직 → ProtectedRoute가 담당
+ *   - 소켓 연결/해제 세부 로직 → useSocket, useSocketStore가 담당
+ */
 
 function App() {
+    // 앱 시작 시 localStorage에서 세션 데이터를 읽어 Zustand에 복원한다.
+    // useEffect dependency로 전달하기 위해 함수 참조를 가져온다.
     const initializeSession = useAuthStore((state) => state.initializeSession);
 
     useEffect(() => {
+        // 컴포넌트 최초 마운트 시 단 한 번만 실행한다.
+        // initializeSession은 Zustand 액션이므로 참조가 변하지 않아
+        // dependency 배열에 넣어도 무한 루프가 발생하지 않는다.
         initializeSession();
     }, [initializeSession]);
 
-    // useSocket 훅 한 줄로 소켓 연결/해제 생명주기를 관리합니다.
-    // 내부적으로 uuid가 생기는 순간 연결하고, 사라지는 순간 해제합니다.
+    // WebSocket 연결 생명주기를 관리하는 훅
+    // 내부적으로 uuid가 생기는 순간 연결하고, 사라지는 순간 해제한다.
+    // App 최상단에서 한 번만 호출하여 전역에서 소켓 상태를 공유한다.
     useSocket();
 
     return (
         <div className="w-full min-h-screen bg-black text-white">
             <BrowserRouter>
                 <Routes>
+                    {/* 홈: 닉네임 입력 후 게임 진입 */}
                     <Route path="/" element={<Home />} />
+
+                    {/* 로비 목록: 세션이 없으면 홈으로 리다이렉트 */}
                     <Route
                         path="/lobbies"
-                        element={<ProtectedRoute><Lobbies /></ProtectedRoute>}
+                        element={
+                            <ProtectedRoute>
+                                <Lobbies />
+                            </ProtectedRoute>
+                        }
                     />
+
+                    {/* 특정 로비 입장: 6자리 초대코드 기반, 세션이 없으면 홈으로 리다이렉트 */}
                     <Route
                         path="/lobby/:inviteCode"
-                        element={<ProtectedRoute><LobbyRoom /></ProtectedRoute>}
+                        element={
+                            <ProtectedRoute>
+                                <LobbyRoom />
+                            </ProtectedRoute>
+                        }
                     />
                 </Routes>
             </BrowserRouter>

--- a/src/components/common/ProtectedRoute.tsx
+++ b/src/components/common/ProtectedRoute.tsx
@@ -1,0 +1,36 @@
+// 인증된 사용자 (게스트 포함)만 특정 라우트에 접근할 수 있도록 제어하는 라우트 가드 컴포넌트
+
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuthStore } from '../../store/useAuthStore';
+
+interface ProtectedRouteProps {
+    children: React.ReactNode;
+}
+
+/**
+ * [라우트 가드 컴포넌트]
+ *
+ * Zustand의 useAuthStore에서 isGuest 상태를 읽어
+ * 세션이 있으면 자식을 렌더링하고, 없으면 홈('/')으로 리다이렉트한다.
+ *
+ * 사용 예시:
+ *   <ProtectedRoute>
+ *     <Lobbies />
+ *   </ProtectedRoute>
+ */
+export function ProtectedRoute({ children }: ProtectedRouteProps) {
+    // Zustand에서 인증 여부를 구독
+    // isGuest가 true = 게스트 또는 정식 회원 세션이 존재하는 상태
+    const isGuest = useAuthStore((state) => state.isGuest);
+
+    // 세션이 없으면 홈으로 강제 이동한다.
+    // replace: true → 브라우저 히스토리에 현재 경로를 남기지 않아
+    // 뒤로가기를 눌렀을 때 보호된 페이지로 돌아오는 것을 방지한다.
+    if (!isGuest) {
+        return <Navigate to="/" replace />;
+    }
+
+    // 인증된 사용자는 자식 컴포넌트를 그대로 렌더링한다.
+    return <>{children}</>;
+}

--- a/src/components/home/NicknameForm.tsx
+++ b/src/components/home/NicknameForm.tsx
@@ -1,0 +1,76 @@
+// 홈 화면의 닉네임 입력 UI를 담당하고, useGuestSession 훅과 연결하여 세션 생성을 트리거하는 컴포넌트
+
+import { useRef } from 'react';
+import { MonomatInput } from '../common/MonomatInput';
+import { useGuestSession } from '../../hooks/useGuestSession';
+
+/**
+ * [닉네임 입력 폼 컴포넌트]
+ *
+ * 이 컴포넌트의 책임 범위:
+ *   - 닉네임 입력창(MonomatInput)과 입장 버튼 렌더링
+ *   - 버튼 클릭 또는 엔터 입력 시 useGuestSession 훅으로 값 전달
+ *
+ * 이 컴포넌트가 하지 않는 것:
+ *   - UUID 생성, localStorage 저장, Zustand 상태 업데이트
+ *     → 모두 useGuestSession 훅 내부에서 처리
+ */
+
+export function NicknameForm() {
+    // 입력 요소에 직접 접근하기 위해 ref를 사용
+    // 버튼 클릭 시 input의 현재 값을 읽어야 하기 때문이다.
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    // 세션 생성 로직은 훅에 캡슐화되어 있으며,
+    // 이 컴포넌트는 createGuestSession 함수만 받아서 호출한다.
+    const { createGuestSession } = useGuestSession();
+
+    // 버튼 클릭 핸들러
+    // ref로 input의 현재 값을 읽어 훅에 전달한다.
+    // (onEnter는 MonomatInput 내부에서 value를 직접 파라미터로 넘겨주므로
+    //  ref가 필요 없지만, 버튼 클릭 경로에서는 ref를 통해 값을 읽는다.)
+    const handleButtonClick = () => {
+        if (inputRef.current) {
+            createGuestSession(inputRef.current.value);
+        }
+    };
+
+    return (
+        <div className="w-full max-w-md flex flex-col gap-3">
+            <div className="relative group">
+                {/*
+                 * MonomatInput: 프로젝트 전용 커스텀 인풋 컴포넌트 (#15에서 생성)
+                 *
+                 * onEnter 콜백을 사용하는 이유:
+                 *   일반 onKeyDown에서 엔터를 감지하면 한글 조합 완료 시점에
+                 *   이벤트가 2번 발생하는 'Double Fire' 문제가 생긴다.
+                 *   MonomatInput은 내부적으로 isComposing 상태를 체크하여
+                 *   한글 조합이 끝난 후 엔터가 눌렸을 때만 onEnter를 호출한다.
+                 */}
+                <MonomatInput
+                    ref={inputRef}
+                    type="text"
+                    placeholder="닉네임을 입력하세요"
+                    maxLength={12}
+                    autoFocus
+                    onEnter={createGuestSession}  // 엔터 입력 시 세션 생성 요청
+                    className="w-full px-5 py-4 text-xl bg-gray-900 border-2 border-gray-800 rounded-2xl outline-none focus:border-blue-500 transition-all text-white placeholder-gray-600"
+                />
+
+                {/* 입장 버튼: 클릭 시 ref로 현재 input 값을 읽어 세션 생성 요청 */}
+                <button
+                    onClick={handleButtonClick}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 px-4 py-2 bg-blue-600 hover:bg-blue-500 active:scale-95 rounded-xl font-bold transition-all"
+                    aria-label="게임 입장"
+                >
+                    입장
+                </button>
+            </div>
+
+            {/* 게스트 진입 안내 문구 */}
+            <p className="text-center text-xs text-gray-500 mt-2">
+                별도의 회원가입 없이 즉시 플레이가 가능합니다.
+            </p>
+        </div>
+    );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,63 +1,40 @@
-// 게임 진입점 페이지
+// 게임 진입점 페이지의 레이아웃과 구조만 담당한다.
 // 닉네임 입력 UI를 렌더링하고, useGuestSession 훅을 통해 세션 생성을 위임한다.
+// 입력 및 세션 로직은 NicknameForm 컴포넌트에 위임한다.
 
-import { useRef } from 'react';
-import { MonomatInput } from '../components/common/MonomatInput';
-import { useGuestSession } from '../hooks/useGuestSession';
+import { NicknameForm } from '../components/home/NicknameForm';
+
+/**
+ * [홈 페이지 컴포넌트]
+ *
+ * 이 컴포넌트의 책임:
+ *   - 서비스 타이틀, 설명 문구, NicknameForm의 레이아웃 구성
+ *
+ * 이 컴포넌트가 하지 않는 것:
+ *   - 닉네임 입력값 처리, 세션 생성, 훅 직접 호출
+ *     → NicknameForm과 useGuestSession 훅이 담당한다.
+ */
 
 export const Home = () => {
-    const inputRef = useRef<HTMLInputElement>(null);
-
-    // 세션 생성과 관련된 모든 비즈니스 로직은 훅 내부에 캡슐화되어 있다.
-    // Home.tsx는 createGuestSession을 호출하는 방법만 알면 된다.
-    const { createGuestSession } = useGuestSession();
-
-    // 버튼 클릭 시 input의 현재 값을 읽어 세션 생성을 요청한다.
-    const handleButtonClick = () => {
-        if (inputRef.current) {
-            createGuestSession(inputRef.current.value);
-        }
-    };
-
     return (
         <div className="flex flex-col items-center justify-center min-h-screen bg-black text-white px-4">
+
+            {/* 서비스 헤더 영역: 타이틀과 설명 문구 */}
             <div className="text-center mb-10">
                 <h1 className="text-6xl font-black mb-4 tracking-tighter text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-purple-500">
                     MONOMAT
                 </h1>
-                <p className="text-gray-400 text-lg">YouTube 음악 퀴즈를 실시간으로 즐기세요.</p>
-            </div>
-
-            <div className="w-full max-w-md flex flex-col gap-3">
-                <div className="relative group">
-                    {/*
-                     * MonomatInput은 onEnter 콜백을 통해
-                     * 한글 조합 중 엔터 2중 제출(Double Fire) 문제를 내부적으로 방지한다.
-                     * (isComposing 처리가 MonomatInput 내부에 캡슐화되어 있다.)
-                     */}
-                    <MonomatInput
-                        ref={inputRef}
-                        type="text"
-                        placeholder="닉네임을 입력하세요"
-                        maxLength={12}
-                        autoFocus
-                        onEnter={createGuestSession}
-                        className="w-full px-5 py-4 text-xl bg-gray-900 border-2 border-gray-800 rounded-2xl outline-none focus:border-blue-500 transition-all text-white placeholder-gray-600"
-                    />
-
-                    <button
-                        onClick={handleButtonClick}
-                        className="absolute right-3 top-1/2 -translate-y-1/2 px-4 py-2 bg-blue-600 hover:bg-blue-500 active:scale-95 rounded-xl font-bold transition-all"
-                        aria-label="게임 입장"
-                    >
-                        입장
-                    </button>
-                </div>
-
-                <p className="text-center text-xs text-gray-500 mt-2">
-                    별도의 회원가입 없이 즉시 플레이가 가능합니다.
+                <p className="text-gray-400 text-lg">
+                    YouTube 음악 퀴즈를 실시간으로 즐기세요.
                 </p>
             </div>
+
+            {/*
+             * 닉네임 입력 폼 영역
+             * 입력 UI, 버튼 핸들러, 세션 생성 로직이 모두 이 컴포넌트 안에 있다.
+             * Home은 이 컴포넌트를 "어디에 배치할지"만 결정한다.
+             */}
+            <NicknameForm />
         </div>
     );
 };


### PR DESCRIPTION
## 📣 Related Issue

- #16

## 📝 Summary

- `ProtectedRoute`를 `App.tsx` 인라인 선언에서 독립 컴포넌트로 분리
- `NicknameForm` 컴포넌트 완성 — 빈 파일에 `UI` 및 `useGuestSession` 훅 연결
- `Home.tsx`에서 `useRef`, `useGuestSession`, 핸들러 제거 — `NicknameForm` 배치만 담당
- `App.tsx`에서 불필요한 `import React` 제거 및 라우팅 역할만 담당하도록 정리

## 🙏 PR point

- 인라인 컴포넌트를 독립 파일로 분리할 경우 `React`가 렌더링 사이클마다 새로운 참조로 인식하는 문제를 방지할 수 있습니다
- 기능 변경 없이 구조만 개선한 순수 리팩토링입니다.

## 📬 Reference
- 선행 이슈: #14, #15