### PR TITLE
[Feat/#9] 전체 채팅 Pub/Sub 연동 및 GlobalChat UI 컴포넌트 구현

### DIFF
--- a/src/components/lobby/GlobalChat.tsx
+++ b/src/components/lobby/GlobalChat.tsx
@@ -1,0 +1,170 @@
+// 로비 리스트 화면 우측에 고정되는 전체 채팅 UI 컴포넌트.
+//
+// [책임]
+// - 메시지 목록 렌더링
+// - 입력창 및 전송 버튼 렌더링
+// - 새 메시지 수신 시 자동 스크롤 (Auto-scroll)
+//
+// [이 컴포넌트가 하지 않는 것]
+// - 소켓 구독/발행 로직 → useGlobalChat 훅이 담당
+// - 소켓 연결 관리 → useSocket, useSocketStore가 담당
+
+import { useEffect, useRef, useState } from 'react';
+import { useGlobalChat } from '../../hooks/useGlobalChat';
+import { MonomatInput } from '../common/MonomatInput';
+import { useSocketStore } from '../../store/useSocketStore';
+import type { ChatMessage } from '../../types/chat';
+
+// 타임스탬프 포맷 유틸 (ISO 8601 → "HH:MM")
+// 컴포넌트 외부에 선언하여 렌더링마다 재생성되지 않도록 한다.
+function formatTime(timestamp: string): string {
+    try {
+        return new Date(timestamp).toLocaleTimeString('ko-KR', {
+            hour: '2-digit',
+            minute: '2-digit',
+            hour12: false,
+        });
+    } catch {
+        return '';
+    }
+}
+
+// 메시지 타입별 스타일 분기
+// SYSTEM 메시지(ENTER/LEAVE)는 회색 이탤릭으로 표시한다.
+function MessageItem({ message }: { message: ChatMessage }) {
+    const isSystem = message.type === 'ENTER' || message.type === 'LEAVE';
+
+    if (isSystem) {
+        return (
+            <div className="py-0.5 text-center text-xs text-gray-400 italic">
+                {message.content}
+            </div>
+        );
+    }
+
+    return (
+        <div className="py-1">
+            {/* 닉네임 + 타임스탬프 */}
+            <div className="flex items-baseline gap-1.5">
+                <span className="text-sm font-semibold text-green-600 truncate max-w-[120px]">
+                    {message.sender}
+                </span>
+                <span className="text-xs text-gray-400 shrink-0">
+                    {formatTime(message.timestamp)}
+                </span>
+            </div>
+            {/* 메시지 본문 */}
+            <p className="text-sm text-gray-800 break-words leading-snug">
+                {message.content}
+            </p>
+        </div>
+    );
+}
+
+export function GlobalChat() {
+    const { messages, sendMessage } = useGlobalChat();
+    const connectionStatus = useSocketStore((state) => state.connectionStatus);
+    const [inputValue, setInputValue] = useState('');
+
+    // 메시지 목록 컨테이너 ref — 자동 스크롤에 사용
+    const messagesEndRef = useRef<HTMLDivElement>(null);
+
+    // 새 메시지가 추가될 때마다 최신 메시지로 자동 스크롤
+    useEffect(() => {
+        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }, [messages]);
+
+    const handleSend = (value: string) => {
+        sendMessage(value);
+        setInputValue('');
+    };
+
+    const isConnected = connectionStatus === 'connected';
+
+    return (
+        <div className="flex flex-col h-full bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+
+            {/* 헤더: 제목 + 접속자 수 표시 영역 */}
+            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 shrink-0">
+                <span className="text-sm font-bold text-gray-800">전체 채팅</span>
+                <div className="flex items-center gap-1.5">
+                    {/* 연결 상태 표시 인디케이터 */}
+                    <span
+                        className={`w-2 h-2 rounded-full ${
+                            isConnected ? 'bg-green-400' : 'bg-gray-300'
+                        }`}
+                    />
+                    <span className="text-xs text-gray-400">
+                        {isConnected ? '연결됨' : '연결 중...'}
+                    </span>
+                </div>
+            </div>
+
+            {/* 메시지 목록 영역 — flex-1로 남은 공간을 채우고 스크롤 가능하게 */}
+            <div className="flex-1 overflow-y-auto px-4 py-2 space-y-0.5 min-h-0">
+                {messages.length === 0 ? (
+                    <p className="text-center text-xs text-gray-400 mt-8">
+                        아직 채팅이 없습니다.
+                    </p>
+                ) : (
+                    messages.map((msg, index) => (
+                        // index를 key로 쓰는 이유:
+                        // ChatMessage에 고유 id가 없고, 동일 sender+content+timestamp가
+                        // 중복될 수 있어 복합 키도 안전하지 않다.
+                        // 메시지는 append-only라 index 불안정 문제가 발생하지 않는다.
+                        <MessageItem key={index} message={msg} />
+                    ))
+                )}
+                {/* 자동 스크롤 앵커 */}
+                <div ref={messagesEndRef} />
+            </div>
+
+            {/* 입력창 영역 */}
+            <div className="px-3 py-3 border-t border-gray-100 shrink-0">
+                <div className="flex items-center gap-2">
+                    <MonomatInput
+                        type="text"
+                        value={inputValue}
+                        onChange={(e) => setInputValue(e.target.value)}
+                        onEnter={handleSend}
+                        placeholder={isConnected ? '메시지를 입력하세요' : '연결 중...'}
+                        disabled={!isConnected}
+                        maxLength={200}
+                        className="flex-1 px-3 py-2 text-sm bg-gray-50 border border-gray-200 rounded-lg outline-none focus:border-blue-400 focus:bg-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    />
+                    {/* 전송 버튼 */}
+                    <button
+                        onClick={() => handleSend(inputValue)}
+                        disabled={!isConnected || !inputValue.trim()}
+                        className="shrink-0 w-9 h-9 flex items-center justify-center bg-blue-500 hover:bg-blue-600 active:scale-95 disabled:bg-gray-200 disabled:cursor-not-allowed rounded-lg transition-all"
+                        aria-label="메시지 전송"
+                    >
+                        {/* 전송 아이콘 (SVG) */}
+                        <svg
+                            width="16"
+                            height="16"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            className="text-white"
+                        >
+                            <path
+                                d="M22 2L11 13"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            />
+                            <path
+                                d="M22 2L15 22L11 13L2 9L22 2Z"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            />
+                        </svg>
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/hooks/useGlobalChat.ts
+++ b/src/hooks/useGlobalChat.ts
@@ -1,0 +1,82 @@
+// 전체 채팅 Pub/Sub 연동 커스텀 훅.
+//
+// [책임]
+// - 컴포넌트 마운트 시 /topic/chat/global 구독
+// - 수신 메시지를 로컬 상태에 누적 (최대 MAX_MESSAGES개 유지)
+// - 메시지 발행 (/app/chat/global)
+// - 컴포넌트 언마운트 시 구독 해제
+
+import { useState, useEffect, useCallback } from 'react';
+import { useSocketStore } from '../store/useSocketStore';
+import { SOCKET_PUBLISH, SOCKET_SUBSCRIBE } from '../constants/socketEvents';
+import type { ChatMessage } from '../types/chat';
+
+// 기능명세서: Redis List 최근 50개 유지 정책과 동일하게 맞춤
+const MAX_MESSAGES = 50;
+
+interface UseGlobalChatReturn {
+    messages: ChatMessage[];
+    sendMessage: (content: string) => void;
+}
+
+export function useGlobalChat(): UseGlobalChatReturn {
+    const stompClient = useSocketStore((state) => state.stompClient);
+    const connectionStatus = useSocketStore((state) => state.connectionStatus);
+    const [messages, setMessages] = useState<ChatMessage[]>([]);
+
+    useEffect(() => {
+        // 연결이 완료된 상태에서만 구독을 시도한다.
+        // stompClient가 있어도 'connecting' 상태면 subscribe 호출이 실패한다.
+        if (!stompClient || connectionStatus !== 'connected') return;
+
+        const subscription = stompClient.subscribe(
+            SOCKET_SUBSCRIBE.CHAT_GLOBAL,
+            (frame) => {
+                try {
+                    const received = JSON.parse(frame.body) as ChatMessage;
+
+                    setMessages((prev) => {
+                        const next = [...prev, received];
+                        // 50개 초과 시 가장 오래된 메시지부터 제거 (FIFO)
+                        return next.length > MAX_MESSAGES
+                            ? next.slice(next.length - MAX_MESSAGES)
+                            : next;
+                    });
+                } catch (error) {
+                    console.error('[useGlobalChat] 메시지 파싱 실패:', error);
+                }
+            },
+        );
+
+        // cleanup: 컴포넌트 언마운트 또는 연결 상태 변경 시 구독 해제
+        return () => {
+            subscription.unsubscribe();
+        };
+    }, [stompClient, connectionStatus]);
+
+    const sendMessage = useCallback(
+        (content: string) => {
+            // 연결이 안 된 상태에서 발행 시도 방어
+            if (!stompClient || connectionStatus !== 'connected') {
+                console.warn('[useGlobalChat] 소켓 미연결 상태에서 메시지 발행 시도');
+                return;
+            }
+
+            const trimmed = content.trim();
+            if (!trimmed) return;
+
+            // BE ChatController가 기대하는 형식
+            // sender는 서버가 세션에서 덮어쓰므로 빈 문자열로 전송
+            stompClient.publish({
+                destination: SOCKET_PUBLISH.CHAT_GLOBAL,
+                body: JSON.stringify({
+                    type: 'CHAT',
+                    content: trimmed,
+                }),
+            });
+        },
+        [stompClient, connectionStatus],
+    );
+
+    return { messages, sendMessage };
+}

--- a/src/pages/Lobbies.tsx
+++ b/src/pages/Lobbies.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { LobbyCard } from '../components/lobby/LobbyCard';
+import { GlobalChat } from '../components/lobby/GlobalChat';
 import { useLobbyList } from '../hooks/useLobbyList';
 
 export function Lobbies() {
@@ -27,50 +28,62 @@ export function Lobbies() {
     }
 
     return (
-        <div className="min-h-screen bg-[#F5F5F7] px-6 py-6">
-            {/* 상단 컨트롤 영역 */}
-            <div className="mb-4 flex items-center gap-3">
-                <input
-                    type="text"
-                    placeholder="로비 제목 검색"
-                    className="flex-1 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm text-gray-700 placeholder-gray-400 shadow-sm focus:border-blue-400 focus:outline-none"
-                />
-                <button className="rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm text-gray-600 shadow-sm hover:bg-gray-50">
-                    정렬: 최신순 ▼
-                </button>
-            </div>
+        // 전체 페이지: 로비 리스트(좌) + 전체 채팅(우) 2단 레이아웃
+        // 높이를 min-h-screen으로 잡고, GlobalChat이 전체 높이를 채우도록 한다.
+        <div className="flex gap-5 min-h-screen bg-[#F5F5F7] px-6 py-6">
 
-            {/* 카테고리 필터 */}
-            <div className="mb-5 flex gap-2">
-                {['전체', 'K-POP', 'J-POP', 'POP', 'OST'].map((cat, i) => (
-                    <button
-                        key={cat}
-                        className={`rounded-full px-4 py-1.5 text-sm font-medium ${
-                            i === 0
-                                ? 'bg-blue-500 text-white'
-                                : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'
-                        }`}
-                    >
-                        {cat}
+            {/* 좌측: 로비 리스트 영역 */}
+            <div className="flex-1 min-w-0">
+                {/* 상단 컨트롤 영역 */}
+                <div className="mb-4 flex items-center gap-3">
+                    <input
+                        type="text"
+                        placeholder="로비 제목 검색"
+                        className="flex-1 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm text-gray-700 placeholder-gray-400 shadow-sm focus:border-blue-400 focus:outline-none"
+                    />
+                    <button className="rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm text-gray-600 shadow-sm hover:bg-gray-50">
+                        정렬: 최신순 ▼
                     </button>
-                ))}
+                </div>
+
+                {/* 카테고리 필터 */}
+                <div className="mb-5 flex gap-2">
+                    {['전체', 'K-POP', 'J-POP', 'POP', 'OST'].map((cat, i) => (
+                        <button
+                            key={cat}
+                            className={`rounded-full px-4 py-1.5 text-sm font-medium ${
+                                i === 0
+                                    ? 'bg-blue-500 text-white'
+                                    : 'bg-white text-gray-600 border border-gray-200 hover:bg-gray-50'
+                            }`}
+                        >
+                            {cat}
+                        </button>
+                    ))}
+                </div>
+
+                {/* 로비 카드 그리드 */}
+                <div className="grid grid-cols-2 gap-4">
+                    {lobbies && lobbies.length > 0 ? (
+                        lobbies.map((lobby) => (
+                            <LobbyCard
+                                key={lobby.code}
+                                lobby={lobby}
+                                onEnter={handleEnter}
+                            />
+                        ))
+                    ) : (
+                        <div className="col-span-2 flex h-40 items-center justify-center text-gray-400">
+                            현재 열린 로비가 없습니다.
+                        </div>
+                    )}
+                </div>
             </div>
 
-            {/* 로비 리스트 그리드 */}
-            <div className="grid grid-cols-2 gap-4">
-                {lobbies && lobbies.length > 0 ? (
-                    lobbies.map((lobby) => (
-                        <LobbyCard
-                            key={lobby.code}
-                            lobby={lobby}
-                            onEnter={handleEnter}
-                        />
-                    ))
-                ) : (
-                    <div className="col-span-2 flex h-40 items-center justify-center text-gray-400">
-                        현재 열린 로비가 없습니다.
-                    </div>
-                )}
+            {/* 우측: 전체 채팅 영역 — 고정 너비, 페이지 높이 전체를 채움 */}
+            {/* sticky top-6으로 스크롤 시에도 채팅창이 뷰포트에 고정되도록 한다 */}
+            <div className="w-80 shrink-0 sticky top-6 self-start h-[calc(100vh-3rem)]">
+                <GlobalChat />
             </div>
         </div>
     );

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -3,23 +3,14 @@
 
 // 채팅 메시지의 종류를 정의한다.
 // 서버에서 오는 메시지가 어떤 종류인지에 따라 UI 표시 방식이 달라진다.
-export type ChatMessageType =
-    | 'CHAT'     // 일반 채팅 메시지 — 흰색 말풍선으로 표시
-    | 'SYSTEM'   // 시스템 알림 — 예: "홍길동님이 입장했습니다" (회색으로 표시)
-    | 'CORRECT'; // 정답 알림 — 예: "홍길동님이 정답을 맞혔습니다!" (강조 표시)
+export type ChatMessageType = 'CHAT' | 'ANSWER' | 'ENTER' | 'LEAVE';
 
-// 채팅 메시지 하나의 구조를 정의한다.
-// 서버에서 WebSocket으로 이 구조의 JSON 데이터가 전달된다.
+// BE ChatMessageDto와 동일한 구조
+// sender: 서버가 세션에서 추출한 UUID (위변조 방지)
 export interface ChatMessage {
-    // 메시지 종류 : 이 값에 따라 UI 렌더링 방식이 달라진다.
     type: ChatMessageType;
-
-    // 메시지를 보낸 사람의 닉네임이다.
-    nickname: string;
-
-    // 메시지 내용이다.
+    roomId: string;    // 전체 채팅은 "global"
+    sender: string;    // UUID 그대로 표시 (닉네임 조회 API 미구현 상태)
     content: string;
-
-    // 서버 기준 메시지 발신 시각이다. (ISO 8601 형식, 예: '2026-04-25T12:00:00Z')
-    timestamp: string;
+    timestamp: string; // ISO 8601 형식
 }


### PR DESCRIPTION
## 📣 Related Issue

- #9

## 📝 Summary

- `src/types/chat.ts` — BE `ChatMessageDto`와 필드명 일치하도록 타입 수정 (`roomId` 추가)
- `src/hooks/useGlobalChat.ts` — `/topic/chat/global` 구독, 메시지 누적(최대 50개 `FIFO`), `/app/chat/global` 발행 로직 구현
- `src/components/lobby/GlobalChat.tsx` — 메시지 목록 렌더링, 입력창, 자동 스크롤 UI 컴포넌트 구현
- `src/pages/Lobbies.tsx` — 로비 리스트(좌) + `GlobalChat`(우) 2단 레이아웃으로 변경

## 🙏PR point

- `GlobalChat`의 채팅 메시지 상태는 `Zustand` 대신 로컬 `useState`로 관리했습니다. 기능명세서의 "Redis List 최근 50개 유지 휘발성 채팅" 정책에 맞게 페이지 이탈 시 초기화되는 것이 자연스럽다고 판단했습니다.
- BE가 아직 미연동 상태라 소켓 연결이 없을 때는 입력창이 `disabled` 처리됩니다.

## 📬 Reference

- 기능명세서: 전체 채팅 데이터 관리 정책 (FIFO 기반)
- BE `ChatMessageDto` 구조 (`global/websocket/dto/ChatMessageDto.java`)