### PR TITLE
[Feat/#22] 네비게이션 바 게스트/회원 분기 및 계정 모달 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,15 +55,11 @@ function App() {
     }
 
     return (
-        // AppLayout: 전역 레이아웃 너비 기준(min/max)을 담당
-        // App.tsx는 "AppLayout 안에 라우터를 넣는다"는 것만 알면 된다.
-        <AppLayout>
-            <BrowserRouter>
+        <BrowserRouter>
+            <AppLayout>
                 <Routes>
-                    {/* 홈: 닉네임 입력 후 게임 진입 */}
                     <Route path="/" element={<Home />} />
 
-                    {/* 로비 목록: 세션이 없으면 홈으로 리다이렉트 */}
                     <Route
                         path="/lobbies"
                         element={
@@ -73,7 +69,6 @@ function App() {
                         }
                     />
 
-                    {/* 특정 로비 입장: 6자리 초대코드 기반, 세션이 없으면 홈으로 리다이렉트 */}
                     <Route
                         path="/lobby/:inviteCode"
                         element={
@@ -83,8 +78,8 @@ function App() {
                         }
                     />
                 </Routes>
-            </BrowserRouter>
-        </AppLayout>
+            </AppLayout>
+        </BrowserRouter>
     );
 }
 

--- a/src/components/common/AccountModal.tsx
+++ b/src/components/common/AccountModal.tsx
@@ -1,0 +1,249 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { useAuthStore } from '../../store/useAuthStore';
+
+type AccountType = 'guest' | 'member';
+
+interface AccountModalProps {
+    isOpen: boolean;
+    accountType: AccountType;
+    onClose: () => void;
+}
+
+interface AccountModalContentProps {
+    accountType: AccountType;
+    onClose: () => void;
+}
+
+const ACCOUNT_TYPE_LABEL: Record<AccountType, string> = {
+    guest: '게스트',
+    member: '정식 회원',
+};
+
+const NICKNAME_MAX_LENGTH = 12;
+const PASSWORD_MIN_LENGTH = 6;
+
+function AccountModalContent({
+                                 accountType,
+                                 onClose,
+                             }: AccountModalContentProps) {
+    const navigate = useNavigate();
+
+    const nickname = useAuthStore((state) => state.nickname);
+    const updateNickname = useAuthStore((state) => state.updateNickname);
+    const clearSession = useAuthStore((state) => state.clearSession);
+
+    const [nicknameInput, setNicknameInput] = useState(nickname ?? '');
+    const [currentPassword, setCurrentPassword] = useState('');
+    const [newPassword, setNewPassword] = useState('');
+    const [newPasswordConfirm, setNewPasswordConfirm] = useState('');
+
+    const displayNickname = nickname ?? 'Guest';
+    const avatarText = displayNickname.charAt(0).toUpperCase();
+
+    const handleNicknameSave = () => {
+        const trimmedNickname = nicknameInput.trim();
+
+        if (!trimmedNickname) {
+            alert('닉네임을 입력해주세요.');
+            return;
+        }
+
+        if (trimmedNickname.length > NICKNAME_MAX_LENGTH) {
+            alert(`닉네임은 ${NICKNAME_MAX_LENGTH}자 이내로 입력해주세요.`);
+            return;
+        }
+
+        updateNickname(trimmedNickname);
+    };
+
+    const handleRegisterClick = () => {
+        onClose();
+        navigate('/register');
+    };
+
+    const handleLogout = () => {
+        clearSession();
+        onClose();
+        navigate('/');
+    };
+
+    const handlePasswordChange = () => {
+        if (!currentPassword || !newPassword || !newPasswordConfirm) {
+            alert('비밀번호 정보를 모두 입력해주세요.');
+            return;
+        }
+
+        if (newPassword.length < PASSWORD_MIN_LENGTH) {
+            alert(`새 비밀번호는 ${PASSWORD_MIN_LENGTH}자 이상이어야 합니다.`);
+            return;
+        }
+
+        if (newPassword !== newPasswordConfirm) {
+            alert('새 비밀번호와 새 비밀번호 확인이 일치하지 않습니다.');
+            return;
+        }
+
+        alert('비밀번호 변경 API 연동 후 처리할 기능입니다.');
+    };
+
+    return (
+        <div
+            className={`relative w-[480px] rounded-2xl bg-white px-10 py-8 text-[#333338] shadow-xl ${
+                accountType === 'member' ? 'min-h-[690px]' : 'min-h-[375px]'
+            }`}
+        >
+            <button
+                type="button"
+                onClick={onClose}
+                className="absolute right-6 top-6 text-3xl leading-none text-[#808085] hover:text-[#333338]"
+                aria-label="계정 모달 닫기"
+            >
+                ×
+            </button>
+
+            <h2
+                id="account-modal-title"
+                className="mb-10 text-center text-2xl font-bold text-[#333338]"
+            >
+                내 계정
+            </h2>
+
+            <section className="mb-8 flex items-center gap-5 rounded-lg bg-[#F5F5F7] px-4 py-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#3873E6] text-xl font-bold text-white">
+                    {avatarText}
+                </div>
+
+                <div>
+                    <p className="text-lg font-bold text-[#333338]">
+                        {displayNickname}
+                    </p>
+                    <p className="text-sm text-[#B9B9B9]">
+                        {ACCOUNT_TYPE_LABEL[accountType]}
+                    </p>
+                </div>
+            </section>
+
+            <section className="mb-8">
+                <label
+                    htmlFor="account-nickname"
+                    className="mb-3 block text-base font-bold text-[#333338]"
+                >
+                    📝 닉네임 변경
+                </label>
+
+                <div className="flex gap-2">
+                    <input
+                        id="account-nickname"
+                        type="text"
+                        value={nicknameInput}
+                        maxLength={NICKNAME_MAX_LENGTH}
+                        onChange={(event) =>
+                            setNicknameInput(event.target.value)
+                        }
+                        className="h-12 flex-1 rounded-lg border border-[#CCCCD1] px-4 text-base font-semibold text-[#333338] outline-none focus:border-[#3873E6]"
+                    />
+
+                    <button
+                        type="button"
+                        onClick={handleNicknameSave}
+                        className="h-12 rounded-lg bg-[#3873E6] px-6 font-bold text-white hover:bg-blue-600"
+                    >
+                        저장
+                    </button>
+                </div>
+            </section>
+
+            {accountType === 'member' ? (
+                <>
+                    <section className="mb-8 border-t border-[#E0E0E6] pt-6">
+                        <p className="mb-5 text-base font-bold text-[#333338]">
+                            🔑 비밀번호 변경
+                        </p>
+
+                        <div className="flex flex-col gap-4">
+                            <input
+                                type="password"
+                                value={currentPassword}
+                                onChange={(event) =>
+                                    setCurrentPassword(event.target.value)
+                                }
+                                placeholder="현재 비밀번호"
+                                className="h-12 rounded-lg border border-[#CCCCD1] px-4 text-[#333338] outline-none placeholder:text-[#CCCCD1] focus:border-[#3873E6]"
+                            />
+
+                            <input
+                                type="password"
+                                value={newPassword}
+                                onChange={(event) =>
+                                    setNewPassword(event.target.value)
+                                }
+                                placeholder="새 비밀번호 (6자 이상)"
+                                className="h-12 rounded-lg border border-[#CCCCD1] px-4 text-[#333338] outline-none placeholder:text-[#CCCCD1] focus:border-[#3873E6]"
+                            />
+
+                            <input
+                                type="password"
+                                value={newPasswordConfirm}
+                                onChange={(event) =>
+                                    setNewPasswordConfirm(event.target.value)
+                                }
+                                placeholder="새 비밀번호 확인"
+                                className="h-12 rounded-lg border border-[#CCCCD1] px-4 text-[#333338] outline-none placeholder:text-[#CCCCD1] focus:border-[#3873E6]"
+                            />
+
+                            <button
+                                type="button"
+                                onClick={handlePasswordChange}
+                                className="h-12 rounded-lg border border-[#CCCCD1] font-bold text-[#333338] hover:bg-[#F5F5F7]"
+                            >
+                                🔑 비밀번호 변경
+                            </button>
+                        </div>
+                    </section>
+
+                    <button
+                        type="button"
+                        onClick={handleLogout}
+                        className="h-12 w-full rounded-lg bg-red-50 font-bold text-red-600 hover:bg-red-100"
+                    >
+                        로그아웃
+                    </button>
+                </>
+            ) : (
+                <button
+                    type="button"
+                    onClick={handleRegisterClick}
+                    className="mx-auto block font-bold text-[#3873E6] underline underline-offset-2"
+                >
+                    회원가입
+                </button>
+            )}
+        </div>
+    );
+}
+
+export function AccountModal({
+                                 isOpen,
+                                 accountType,
+                                 onClose,
+                             }: AccountModalProps) {
+    if (!isOpen) {
+        return null;
+    }
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="account-modal-title"
+        >
+            <AccountModalContent
+                accountType={accountType}
+                onClose={onClose}
+            />
+        </div>
+    );
+}

--- a/src/components/common/AppLayout.tsx
+++ b/src/components/common/AppLayout.tsx
@@ -1,27 +1,16 @@
 import { type ReactNode } from 'react';
+
 import { BREAKPOINTS } from '../../constants/layout';
 
 interface AppLayoutProps {
-    /** 레이아웃 내부에 렌더링될 하위 페이지 컴포넌트 또는 요소 */
     children: ReactNode;
 }
 
-/**
- * 앱 전체 페이지에 공통으로 적용되는 레이아웃 래퍼 컴포넌트.
- *
- * [레이아웃 기준]
- * - 최소 너비: BREAKPOINTS.MIN_PC (소형 노트북)
- * - 최대 너비: BREAKPOINTS.MAX_CONTENT — 초과 시 중앙 정렬로 공백 처리
- * - 그 사이 구간: w-full로 꽉 채워서 자연스럽게 늘어났다 줄어듦
- * - 기준값 변경 시 layout.ts의 BREAKPOINTS 상수만 수정하면 된다.
- */
 export function AppLayout({ children }: AppLayoutProps) {
     return (
         <div
-            className="min-h-screen w-full mx-auto px-6 bg-black text-white"
+            className="min-h-screen w-full mx-auto bg-[#F5F5F7] text-[#333338]"
             style={{
-                // Tailwind는 동적 값을 클래스로 쓸 수 없으므로
-                // 상수 기반의 maxWidth는 인라인 style로 적용한다.
                 maxWidth: `${BREAKPOINTS.MAX_CONTENT}px`,
                 minWidth: `${BREAKPOINTS.MIN_PC}px`,
             }}

--- a/src/components/common/NavigationBar.tsx
+++ b/src/components/common/NavigationBar.tsx
@@ -1,0 +1,135 @@
+import { type KeyboardEvent, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { useAuthStore } from '../../store/useAuthStore';
+import { AccountModal } from './AccountModal';
+
+const INVITE_CODE_LENGTH = 6;
+
+export function NavigationBar() {
+    const navigate = useNavigate();
+
+    const nickname = useAuthStore((state) => state.nickname);
+    const isGuest = useAuthStore((state) => state.isGuest);
+
+    const [inviteCode, setInviteCode] = useState('');
+    const [isAccountModalOpen, setIsAccountModalOpen] = useState(false);
+
+    const displayNickname = nickname ?? 'Guest';
+    const avatarText = displayNickname.charAt(0).toUpperCase();
+
+    const accountType = isGuest ? 'guest' : 'member';
+    const canCreateMap = accountType === 'member';
+
+    const handleLogoClick = () => {
+        navigate('/lobbies');
+    };
+
+    const handleInviteCodeSubmit = () => {
+        const normalizedInviteCode = inviteCode.trim();
+
+        if (normalizedInviteCode.length !== INVITE_CODE_LENGTH) {
+            alert(`${INVITE_CODE_LENGTH}자리 초대 코드를 입력해주세요.`);
+            return;
+        }
+
+        navigate(`/lobby/${normalizedInviteCode}`);
+    };
+
+    const handleInviteCodeKeyDown = (
+        event: KeyboardEvent<HTMLInputElement>,
+    ) => {
+        if (event.nativeEvent.isComposing) {
+            return;
+        }
+
+        if (event.key === 'Enter') {
+            handleInviteCodeSubmit();
+        }
+    };
+
+    const handleCreateMapClick = () => {
+        alert('맵 만들기 기능은 정식 회원 전용 기능입니다.');
+    };
+
+    const handleCreateLobbyClick = () => {
+        alert('로비 만들기 기능은 추후 로비 생성 기능과 연결합니다.');
+    };
+
+    return (
+        <>
+            <header className="flex h-20 shrink-0 items-center justify-between border-b border-gray-200 bg-white px-9">
+                <button
+                    type="button"
+                    onClick={handleLogoClick}
+                    className="flex items-center gap-3"
+                    aria-label="로비 목록으로 이동"
+                >
+                    <div className="h-10 w-10 rounded-lg bg-[#0B1E46]" />
+                    <span className="text-2xl font-bold text-gray-800">
+                        Monomat
+                    </span>
+                </button>
+
+                <div className="flex items-center gap-4">
+                    {canCreateMap && (
+                        <button
+                            type="button"
+                            onClick={handleCreateMapClick}
+                            className="rounded-lg border border-gray-300 bg-white px-5 py-2.5 text-sm font-semibold text-gray-900 hover:bg-gray-50"
+                        >
+                            🗺️ 맵 만들기
+                        </button>
+                    )}
+
+                    <div className="flex items-center rounded-lg border border-gray-300 bg-white px-3 py-2">
+                        <span className="mr-2 text-sm text-gray-900">▣</span>
+
+                        <input
+                            type="text"
+                            value={inviteCode}
+                            maxLength={INVITE_CODE_LENGTH}
+                            onChange={(event) =>
+                                setInviteCode(event.target.value)
+                            }
+                            onKeyDown={handleInviteCodeKeyDown}
+                            placeholder="초대 코드"
+                            className="w-28 bg-transparent text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none"
+                        />
+
+                        <button
+                            type="button"
+                            onClick={handleInviteCodeSubmit}
+                            className="rounded-full bg-gray-100 px-3 py-1 text-xs text-gray-500 hover:bg-gray-200"
+                        >
+                            입장
+                        </button>
+                    </div>
+
+                    <button
+                        type="button"
+                        onClick={handleCreateLobbyClick}
+                        className="rounded-lg bg-[#0B1E46] px-5 py-2.5 text-sm font-semibold text-white hover:bg-[#12306B]"
+                    >
+                        + 로비 만들기
+                    </button>
+
+                    <button
+                        type="button"
+                        onClick={() => setIsAccountModalOpen(true)}
+                        className="flex h-10 w-10 items-center justify-center rounded-full bg-[#0B1E46] text-sm font-bold text-white"
+                        aria-label="내 계정 열기"
+                    >
+                        {avatarText}
+                    </button>
+                </div>
+            </header>
+
+            <AccountModal
+                isOpen={isAccountModalOpen}
+                accountType={accountType}
+                onClose={() => setIsAccountModalOpen(false)}
+            />
+        </>
+    );
+}

--- a/src/pages/Lobbies.tsx
+++ b/src/pages/Lobbies.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { LobbyCard } from '../components/lobby/LobbyCard';
+
+import { NavigationBar } from '../components/common/NavigationBar';
 import { GlobalChat } from '../components/lobby/GlobalChat';
+import { LobbyCard } from '../components/lobby/LobbyCard';
 import { useLobbyList } from '../hooks/useLobbyList';
 import { useSocketStore } from '../store/useSocketStore';
-import { getOrCreateBrowserUserId } from '../utils/browserUserId';
 import type { Lobby } from '../types/lobby';
+import { getOrCreateBrowserUserId } from '../utils/browserUserId';
 
 type SortOption = 'LATEST' | 'MOST_PLAYERS' | 'MOST_EMPTY_SLOTS';
 
@@ -18,8 +20,6 @@ const SORT_LABELS: Record<SortOption, string> = {
 const CATEGORY_FILTERS = ['전체', 'K-POP', 'J-POP', 'POP', 'OST'] as const;
 
 function getCurrentPlayers(lobby: Lobby): number {
-    // 현재 Lobby 타입에 currentPlayers가 없다면 임시값을 사용합니다.
-    // BE 응답에 currentPlayers가 추가되면 아래 로직을 해당 필드 기준으로 교체하면 됩니다.
     return 'currentPlayers' in lobby && typeof lobby.currentPlayers === 'number'
         ? lobby.currentPlayers
         : 1;
@@ -44,60 +44,8 @@ function sortLobbies(lobbies: Lobby[], sortOption: SortOption): Lobby[] {
 
         case 'LATEST':
         default:
-            // 현재 Lobby 타입에 createdAt이 없으므로 서버 응답 순서를 최신순으로 간주합니다.
             return copiedLobbies;
     }
-}
-
-function LobbyHeader() {
-    return (
-        <header className="flex h-20 shrink-0 items-center justify-between border-b border-gray-200 bg-white px-9">
-            <div className="flex items-center gap-3">
-                <div className="h-10 w-10 rounded-lg bg-blue-500" />
-                <span className="text-2xl font-bold text-gray-800">
-                    Monomat
-                </span>
-            </div>
-
-            <div className="flex items-center gap-4">
-                <button
-                    type="button"
-                    className="rounded-lg border border-gray-300 bg-white px-5 py-2.5 text-sm font-semibold text-gray-900 hover:bg-gray-50"
-                >
-                    맵 만들기
-                </button>
-
-                <div className="flex items-center rounded-lg border border-gray-300 bg-white px-3 py-2">
-                    <input
-                        type="text"
-                        placeholder="초대 코드"
-                        className="w-28 bg-transparent text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none"
-                    />
-                    <button
-                        type="button"
-                        className="rounded-full bg-gray-100 px-3 py-1 text-xs text-gray-500"
-                    >
-                        입장
-                    </button>
-                </div>
-
-                <button
-                    type="button"
-                    className="rounded-lg bg-blue-500 px-5 py-2.5 text-sm font-semibold text-white hover:bg-blue-600"
-                >
-                    + 로비 만들기
-                </button>
-
-                <button
-                    type="button"
-                    className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-500 text-sm font-bold text-white"
-                    aria-label="프로필"
-                >
-                    H
-                </button>
-            </div>
-        </header>
-    );
 }
 
 function LobbyFooter() {
@@ -172,7 +120,8 @@ export function Lobbies() {
     const connectSocket = useSocketStore((state) => state.connect);
 
     const [searchKeyword, setSearchKeyword] = useState('');
-    const [selectedCategory, setSelectedCategory] = useState<(typeof CATEGORY_FILTERS)[number]>('전체');
+    const [selectedCategory, setSelectedCategory] =
+        useState<(typeof CATEGORY_FILTERS)[number]>('전체');
     const [sortOption, setSortOption] = useState<SortOption>('LATEST');
 
     useEffect(() => {
@@ -221,7 +170,7 @@ export function Lobbies() {
 
     return (
         <div className="flex min-h-screen flex-col bg-[#F5F5F7]">
-            <LobbyHeader />
+            <NavigationBar />
 
             <main className="flex flex-1 gap-5 px-9 py-6">
                 <section className="min-w-0 flex-1">
@@ -229,7 +178,9 @@ export function Lobbies() {
                         <input
                             type="text"
                             value={searchKeyword}
-                            onChange={(event) => setSearchKeyword(event.target.value)}
+                            onChange={(event) =>
+                                setSearchKeyword(event.target.value)
+                            }
                             placeholder="로비 제목 검색"
                             className="flex-1 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm text-gray-700 placeholder:text-gray-400 shadow-sm focus:border-blue-400 focus:outline-none"
                         />

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -5,10 +5,6 @@ import { STORAGE_KEYS, SESSION_EXPIRY_MS } from '../constants/storage';
 
 import type { GuestSession } from '../types/auth';
 
-// localStorage에서 읽어온 데이터가 올바른 구조인지 검증하는 스키마
-// 사용자가 localStorage 값을 임의로 수정했거나, 형식이 맞지 않을 때를 대비한다.
-// satisfies는 이 스키마가 GuestSession 타입과 일치하는지 TypeScript가 확인하도록 한다.
-// 스키마 구조와 타입 정의가 서로 어긋나면 이 줄에서 바로 에러가 발생한다.
 const guestSessionSchema = z.object({
     uuid: z.uuid({ error: '유효하지 않은 UUID 형식입니다.' }),
     nickname: z
@@ -17,7 +13,11 @@ const guestSessionSchema = z.object({
         .max(12, { error: '닉네임은 12자 이내여야 합니다.' }),
     createdAt: z.number().refine(
         (time) => Date.now() - time <= SESSION_EXPIRY_MS,
-        { error: `세션이 만료되었습니다. (기준: ${SESSION_EXPIRY_MS / (1000 * 60 * 60 * 24)}일)` },
+        {
+            error: `세션이 만료되었습니다. (기준: ${
+                SESSION_EXPIRY_MS / (1000 * 60 * 60 * 24)
+            }일)`,
+        },
     ),
 }) satisfies z.ZodType<GuestSession>;
 
@@ -25,42 +25,89 @@ interface AuthState {
     uuid: string | null;
     nickname: string | null;
     isGuest: boolean;
-    // localStorage 데이터를 읽어오기 전과 후를 구분하는 플래그
-    // 이 값이 true가 되기 전에 화면을 렌더링하면 로그인 상태가 깜빡이는 현상이 발생한다.
     isHydrated: boolean;
     setSession: (uuid: string, nickname: string) => void;
     clearSession: () => void;
     initializeSession: () => void;
+    updateNickname: (nickname: string) => void;
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
+export const useAuthStore = create<AuthState>((set, get) => ({
     uuid: null,
     nickname: null,
     isGuest: false,
     isHydrated: false,
 
     setSession: (uuid, nickname) => {
-        set({ uuid, nickname, isGuest: true, isHydrated: true });
+        set({
+            uuid,
+            nickname,
+            isGuest: true,
+            isHydrated: true,
+        });
     },
 
     clearSession: () => {
-        // STORAGE_KEYS.GUEST_SESSION을 사용하므로 문자열 오타 위험이 없다.
         localStorage.removeItem(STORAGE_KEYS.GUEST_SESSION);
-        set({ uuid: null, nickname: null, isGuest: false, isHydrated: true });
+
+        set({
+            uuid: null,
+            nickname: null,
+            isGuest: false,
+            isHydrated: true,
+        });
+    },
+
+    updateNickname: (nickname) => {
+        const trimmedNickname = nickname.trim();
+        const { uuid } = get();
+
+        if (!uuid || !trimmedNickname) {
+            return;
+        }
+
+        try {
+            const storedData = localStorage.getItem(STORAGE_KEYS.GUEST_SESSION);
+            const parsedData = storedData
+                ? (JSON.parse(storedData) as Partial<GuestSession>)
+                : null;
+
+            const nextSession: GuestSession = {
+                uuid,
+                nickname: trimmedNickname,
+                createdAt:
+                    typeof parsedData?.createdAt === 'number'
+                        ? parsedData.createdAt
+                        : Date.now(),
+            };
+
+            localStorage.setItem(
+                STORAGE_KEYS.GUEST_SESSION,
+                JSON.stringify(nextSession),
+            );
+
+            set({
+                nickname: trimmedNickname,
+            });
+        } catch (error) {
+            console.error('[useAuthStore] 닉네임 변경 저장 실패:', error);
+
+            set({
+                nickname: trimmedNickname,
+            });
+        }
     },
 
     initializeSession: () => {
         try {
             const storedData = localStorage.getItem(STORAGE_KEYS.GUEST_SESSION);
 
-            // 저장된 데이터가 없으면 신규 방문자이다.
             if (!storedData) {
                 set({ isHydrated: true });
                 return;
             }
 
             const parsed = JSON.parse(storedData) as unknown;
-            // safeParse는 검증 실패 시 예외를 던지지 않고 성공/실패 결과를 반환한다.
             const result = guestSessionSchema.safeParse(parsed);
 
             if (result.success) {
@@ -70,17 +117,20 @@ export const useAuthStore = create<AuthState>((set) => ({
                     isGuest: true,
                     isHydrated: true,
                 });
+
                 console.log('세션 복구 완료:', result.data.nickname);
             } else {
-                // 데이터가 오염되었거나 만료된 경우 즉시 삭제한다.
-                // z.treeifyError는 Zod v4의 기능으로, 에러를 보기 좋은 트리 형태로 출력한다.
-                console.warn('세션 무효화 (오염 또는 만료):', z.treeifyError(result.error));
+                console.warn(
+                    '세션 무효화 (오염 또는 만료):',
+                    z.treeifyError(result.error),
+                );
+
                 localStorage.removeItem(STORAGE_KEYS.GUEST_SESSION);
                 set({ isHydrated: true });
             }
         } catch (error) {
-            // JSON.parse 실패 등 예기치 못한 에러를 대비한 최후의 처리이다.
             console.error('세션 파싱 중 오류 발생:', error);
+
             localStorage.removeItem(STORAGE_KEYS.GUEST_SESSION);
             set({ isHydrated: true });
         }


### PR DESCRIPTION
## 📣 Related Issue

- #22

## 📝 Summary

- 로비 화면 상단 네비게이션 바를 공통 컴포넌트로 분리했습니다.
- `useAuthStore`의 `isGuest`, `nickname` 상태를 기준으로 네비게이션 바 UI를 분기했습니다.
- 게스트 사용자의 경우 `맵 만들기` 버튼이 노출되지 않도록 처리했습니다.
- 아바타 버튼 클릭 시 `내 계정` 모달이 열리도록 구현했습니다.
- 계정 모달에서 사용자 닉네임과 사용자 유형(게스트 / 정식 회원)을 표시하도록 구현했습니다.
- 게스트 계정 모달에서는 닉네임 변경과 회원가입 이동 링크만 노출되도록 구성했습니다.
- 정식 회원 계정 모달 구조도 함께 추가하여 닉네임 변경, 비밀번호 변경, 로그아웃 UI를 분기 처리할 수 있도록 했습니다.
- 게스트 닉네임 변경 시 Zustand 상태와 `localStorage`의 게스트 세션 정보가 함께 갱신되도록 `updateNickname` 액션을 추가했습니다.
- 기존 `Lobbies.tsx` 내부에 있던 `LobbyHeader`를 제거하고 새 `NavigationBar` 컴포넌트를 사용하도록 변경했습니다.

## 🙏PR point

- 현재 정식 회원 로그인 기능이 아직 연결되어 있지 않아 실제 런타임에서는 대부분 게스트 분기만 동작합니다.
- 정식 회원용 계정 모달 UI는 이후 로그인/회원 API 연동을 고려해 미리 분기 구조만 잡아두었습니다.
- `맵 만들기`, `로비 만들기`, `비밀번호 변경`은 아직 실제 API 또는 페이지가 없어서 임시 알림 처리 상태입니다.
- `/register` 라우트가 아직 없다면 회원가입 클릭 시 라우팅만 먼저 연결된 상태이므로, 추후 회원가입 페이지 작업과 함께 보완이 필요합니다.
- React 19 ESLint 규칙에 맞추기 위해 계정 모달 내부 상태 초기화는 `useEffect` 대신 모달 콘텐츠 컴포넌트 mount 시 초기값을 주입하는 방식으로 처리했습니다.
- `public/mockServiceWorker.js`의 unused eslint-disable warning은 이번 작업과 무관한 기존 경고입니다.

## 📬 Reference

- Figma 네비게이션 바 및 계정 모달 시안
- 기존 `Lobbies.tsx`의 `LobbyHeader` UI 구조
- 기존 `useAuthStore` 게스트 세션 관리 로직