### PR TITLE
[Refactor/#27] 로비 리스트 화면 컴포넌트 세분화

### DIFF
--- a/src/components/lobby/GlobalChat.tsx
+++ b/src/components/lobby/GlobalChat.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
-import { useGlobalChat } from '../../hooks/useGlobalChat';
+
 import { useChatCooldown } from '../../hooks/useChatCooldown';
-import { MonomatInput } from '../common/MonomatInput';
+import { useGlobalChat } from '../../hooks/useGlobalChat';
 import { useSocketStore } from '../../store/useSocketStore';
 import type { ChatMessage } from '../../types/chat';
+import { MonomatInput } from '../common/MonomatInput';
 
 const CHAT_COOLDOWN_MS = 3000;
 const MAX_CHAT_LENGTH = 200;
@@ -20,7 +21,10 @@ function formatTime(timestamp: string): string {
     }
 }
 
-function getConnectionLabel(isConnected: boolean, isReconnecting: boolean): string {
+function getConnectionLabel(
+    isConnected: boolean,
+    isReconnecting: boolean,
+): string {
     if (isConnected) {
         return '연결됨';
     }
@@ -166,7 +170,7 @@ export function GlobalChat() {
                         maxLength={MAX_CHAT_LENGTH}
                         className="
                             flex-1 rounded-lg border border-gray-300 bg-gray-50 px-3 py-2 text-sm
-                          text-gray-900 placeholder:text-gray-400
+                            text-gray-900 placeholder:text-gray-400
                             outline-none transition-colors
                             focus:border-blue-500
                             disabled:cursor-not-allowed disabled:opacity-50

--- a/src/components/lobby/LobbyCard.tsx
+++ b/src/components/lobby/LobbyCard.tsx
@@ -1,4 +1,5 @@
 import type { Lobby, LobbyCategory } from '../../types/lobby';
+import { getCurrentPlayers } from '../../utils/lobbySort';
 
 interface LobbyCardProps {
     lobby: Lobby;
@@ -21,7 +22,11 @@ function StatusBadge({ status }: { status: Lobby['status'] }) {
     );
 }
 
-function CategoryBadge({ category }: { category: LobbyCategory | null | undefined }) {
+function CategoryBadge({
+                           category,
+                       }: {
+    category: LobbyCategory | null | undefined;
+}) {
     if (!category) {
         return null;
     }
@@ -42,8 +47,10 @@ function ProgressBar({
     max: number;
     status: Lobby['status'];
 }) {
-    const percent = Math.round((current / max) * 100);
+    const safeMax = Math.max(max, 1);
+    const percent = Math.min(Math.round((current / safeMax) * 100), 100);
     const isFull = current >= max;
+
     const color =
         status === 'PLAYING'
             ? 'bg-yellow-400'
@@ -62,15 +69,9 @@ function ProgressBar({
 }
 
 export function LobbyCard({ lobby, onEnter }: LobbyCardProps) {
-    const {
-        code,
-        title,
-        status,
-        maxPlayers,
-        category,
-    } = lobby;
+    const { code, title, status, maxPlayers, category } = lobby;
 
-    const currentPlayers = 1;
+    const currentPlayers = getCurrentPlayers(lobby);
     const isFull = currentPlayers >= maxPlayers;
     const isEnterDisabled = isFull || status === 'PLAYING';
 
@@ -87,7 +88,9 @@ export function LobbyCard({ lobby, onEnter }: LobbyCardProps) {
 
             <div className="mb-2 flex items-center justify-between text-sm text-gray-500">
                 <span>👤 host</span>
-                <span>{currentPlayers}/{maxPlayers}명</span>
+                <span>
+                    {currentPlayers}/{maxPlayers}명
+                </span>
             </div>
 
             <ProgressBar

--- a/src/components/lobby/LobbyCategoryFilter.tsx
+++ b/src/components/lobby/LobbyCategoryFilter.tsx
@@ -1,0 +1,30 @@
+interface LobbyCategoryFilterProps<TCategory extends string> {
+    categories: readonly TCategory[];
+    selectedCategory: TCategory;
+    onChange: (value: TCategory) => void;
+}
+
+export function LobbyCategoryFilter<TCategory extends string>({
+                                                                  categories,
+                                                                  selectedCategory,
+                                                                  onChange,
+                                                              }: LobbyCategoryFilterProps<TCategory>) {
+    return (
+        <div className="mb-5 flex gap-2">
+            {categories.map((category) => (
+                <button
+                    key={category}
+                    type="button"
+                    onClick={() => onChange(category)}
+                    className={`rounded-full px-4 py-1.5 text-sm font-medium ${
+                        selectedCategory === category
+                            ? 'bg-blue-500 text-white'
+                            : 'border border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
+                    }`}
+                >
+                    {category}
+                </button>
+            ))}
+        </div>
+    );
+}

--- a/src/components/lobby/LobbyEmptyState.tsx
+++ b/src/components/lobby/LobbyEmptyState.tsx
@@ -1,0 +1,9 @@
+export function LobbyEmptyState() {
+    return (
+        <div className="grid grid-cols-2 gap-4">
+            <div className="col-span-2 flex h-40 items-center justify-center text-gray-400">
+                현재 조건에 맞는 로비가 없습니다.
+            </div>
+        </div>
+    );
+}

--- a/src/components/lobby/LobbyFooter.tsx
+++ b/src/components/lobby/LobbyFooter.tsx
@@ -1,0 +1,19 @@
+export function LobbyFooter() {
+    return (
+        <footer className="flex h-10 shrink-0 items-center justify-between border-t border-gray-200 bg-white px-10 text-sm text-gray-500">
+            <span>© 2026 Monomat. 실시간 멀티플레이 퀴즈.</span>
+
+            <div className="flex items-center gap-6">
+                <button type="button" className="hover:text-gray-700">
+                    문제 신고
+                </button>
+                <button type="button" className="hover:text-gray-700">
+                    이용약관
+                </button>
+                <button type="button" className="hover:text-gray-700">
+                    개인정보처리방침
+                </button>
+            </div>
+        </footer>
+    );
+}

--- a/src/components/lobby/LobbyHeader.tsx
+++ b/src/components/lobby/LobbyHeader.tsx
@@ -1,0 +1,48 @@
+import { LobbyCategoryFilter } from './LobbyCategoryFilter';
+import { LobbySearchInput } from './LobbySearchInput';
+import {
+    LobbySortDropdown,
+    type LobbySortOption,
+} from './LobbySortDropdown';
+
+interface LobbyHeaderProps<TCategory extends string> {
+    searchKeyword: string;
+    onSearchKeywordChange: (value: string) => void;
+    categories: readonly TCategory[];
+    selectedCategory: TCategory;
+    onSelectedCategoryChange: (value: TCategory) => void;
+    sortOption: LobbySortOption;
+    onSortOptionChange: (value: LobbySortOption) => void;
+}
+
+export function LobbyHeader<TCategory extends string>({
+                                                          searchKeyword,
+                                                          onSearchKeywordChange,
+                                                          categories,
+                                                          selectedCategory,
+                                                          onSelectedCategoryChange,
+                                                          sortOption,
+                                                          onSortOptionChange,
+                                                      }: LobbyHeaderProps<TCategory>) {
+    return (
+        <>
+            <div className="mb-4 flex items-center gap-3">
+                <LobbySearchInput
+                    value={searchKeyword}
+                    onChange={onSearchKeywordChange}
+                />
+
+                <LobbySortDropdown
+                    value={sortOption}
+                    onChange={onSortOptionChange}
+                />
+            </div>
+
+            <LobbyCategoryFilter
+                categories={categories}
+                selectedCategory={selectedCategory}
+                onChange={onSelectedCategoryChange}
+            />
+        </>
+    );
+}

--- a/src/components/lobby/LobbyList.tsx
+++ b/src/components/lobby/LobbyList.tsx
@@ -1,0 +1,26 @@
+import type { Lobby } from '../../types/lobby';
+import { LobbyCard } from './LobbyCard';
+import { LobbyEmptyState } from './LobbyEmptyState';
+
+interface LobbyListProps {
+    lobbies: Lobby[];
+    onEnter: (code: string) => void;
+}
+
+export function LobbyList({ lobbies, onEnter }: LobbyListProps) {
+    if (lobbies.length === 0) {
+        return <LobbyEmptyState />;
+    }
+
+    return (
+        <div className="grid grid-cols-2 gap-4">
+            {lobbies.map((lobby) => (
+                <LobbyCard
+                    key={lobby.code}
+                    lobby={lobby}
+                    onEnter={onEnter}
+                />
+            ))}
+        </div>
+    );
+}

--- a/src/components/lobby/LobbySearchInput.tsx
+++ b/src/components/lobby/LobbySearchInput.tsx
@@ -1,0 +1,19 @@
+interface LobbySearchInputProps {
+    value: string;
+    onChange: (value: string) => void;
+}
+
+export function LobbySearchInput({
+                                     value,
+                                     onChange,
+                                 }: LobbySearchInputProps) {
+    return (
+        <input
+            type="text"
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            placeholder="로비 제목 검색"
+            className="flex-1 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm text-gray-700 placeholder:text-gray-400 shadow-sm focus:border-blue-400 focus:outline-none"
+        />
+    );
+}

--- a/src/components/lobby/LobbySortDropdown.tsx
+++ b/src/components/lobby/LobbySortDropdown.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import type { LobbySortOption } from '../../utils/lobbySort';
+
+export type { LobbySortOption } from '../../utils/lobbySort';
+
+const SORT_LABELS: Record<LobbySortOption, string> = {
+    LATEST: '최신순',
+    MOST_PLAYERS: '인원 많은 순',
+    MOST_EMPTY_SLOTS: '빈 자리 많은 순',
+};
+
+interface LobbySortDropdownProps {
+    value: LobbySortOption;
+    onChange: (value: LobbySortOption) => void;
+}
+
+export function LobbySortDropdown({
+                                      value,
+                                      onChange,
+                                  }: LobbySortDropdownProps) {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const handleSelect = (nextValue: LobbySortOption) => {
+        onChange(nextValue);
+        setIsOpen(false);
+    };
+
+    return (
+        <div className="relative">
+            <button
+                type="button"
+                onClick={() => setIsOpen((prev) => !prev)}
+                className="min-w-36 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm text-gray-600 shadow-sm hover:bg-gray-50"
+            >
+                {SORT_LABELS[value]} ▼
+            </button>
+
+            {isOpen && (
+                <div className="absolute right-0 z-20 mt-2 w-44 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg">
+                    {(Object.keys(SORT_LABELS) as LobbySortOption[]).map(
+                        (option) => (
+                            <button
+                                key={option}
+                                type="button"
+                                onClick={() => handleSelect(option)}
+                                className={`block w-full px-4 py-2.5 text-left text-sm hover:bg-gray-50 ${
+                                    value === option
+                                        ? 'font-semibold text-blue-500'
+                                        : 'text-gray-600'
+                                }`}
+                            >
+                                {SORT_LABELS[option]}
+                            </button>
+                        ),
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/pages/Lobbies.tsx
+++ b/src/pages/Lobbies.tsx
@@ -3,115 +3,17 @@ import { useNavigate } from 'react-router-dom';
 
 import { NavigationBar } from '../components/common/NavigationBar';
 import { GlobalChat } from '../components/lobby/GlobalChat';
-import { LobbyCard } from '../components/lobby/LobbyCard';
+import { LobbyFooter } from '../components/lobby/LobbyFooter';
+import { LobbyHeader } from '../components/lobby/LobbyHeader';
+import { LobbyList } from '../components/lobby/LobbyList';
 import { useLobbyList } from '../hooks/useLobbyList';
 import { useSocketStore } from '../store/useSocketStore';
-import type { Lobby } from '../types/lobby';
 import { getOrCreateBrowserUserId } from '../utils/browserUserId';
-
-type SortOption = 'LATEST' | 'MOST_PLAYERS' | 'MOST_EMPTY_SLOTS';
-
-const SORT_LABELS: Record<SortOption, string> = {
-    LATEST: '최신순',
-    MOST_PLAYERS: '인원 많은 순',
-    MOST_EMPTY_SLOTS: '빈 자리 많은 순',
-};
+import { sortLobbies, type LobbySortOption } from '../utils/lobbySort';
 
 const CATEGORY_FILTERS = ['전체', 'K-POP', 'J-POP', 'POP', 'OST'] as const;
 
-function getCurrentPlayers(lobby: Lobby): number {
-    return 'currentPlayers' in lobby && typeof lobby.currentPlayers === 'number'
-        ? lobby.currentPlayers
-        : 1;
-}
-
-function sortLobbies(lobbies: Lobby[], sortOption: SortOption): Lobby[] {
-    const copiedLobbies = [...lobbies];
-
-    switch (sortOption) {
-        case 'MOST_PLAYERS':
-            return copiedLobbies.sort(
-                (left, right) => getCurrentPlayers(right) - getCurrentPlayers(left),
-            );
-
-        case 'MOST_EMPTY_SLOTS':
-            return copiedLobbies.sort(
-                (left, right) =>
-                    right.maxPlayers -
-                    getCurrentPlayers(right) -
-                    (left.maxPlayers - getCurrentPlayers(left)),
-            );
-
-        case 'LATEST':
-        default:
-            return copiedLobbies;
-    }
-}
-
-function LobbyFooter() {
-    return (
-        <footer className="flex h-10 shrink-0 items-center justify-between border-t border-gray-200 bg-white px-10 text-sm text-gray-500">
-            <span>© 2026 Monomat. 실시간 멀티플레이 퀴즈.</span>
-
-            <div className="flex items-center gap-6">
-                <button type="button" className="hover:text-gray-700">
-                    문제 신고
-                </button>
-                <button type="button" className="hover:text-gray-700">
-                    이용약관
-                </button>
-                <button type="button" className="hover:text-gray-700">
-                    개인정보처리방침
-                </button>
-            </div>
-        </footer>
-    );
-}
-
-interface SortDropdownProps {
-    value: SortOption;
-    onChange: (value: SortOption) => void;
-}
-
-function SortDropdown({ value, onChange }: SortDropdownProps) {
-    const [isOpen, setIsOpen] = useState(false);
-
-    const handleSelect = (nextValue: SortOption) => {
-        onChange(nextValue);
-        setIsOpen(false);
-    };
-
-    return (
-        <div className="relative">
-            <button
-                type="button"
-                onClick={() => setIsOpen((prev) => !prev)}
-                className="min-w-36 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm text-gray-600 shadow-sm hover:bg-gray-50"
-            >
-                {SORT_LABELS[value]} ▼
-            </button>
-
-            {isOpen && (
-                <div className="absolute right-0 z-20 mt-2 w-44 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg">
-                    {(Object.keys(SORT_LABELS) as SortOption[]).map((option) => (
-                        <button
-                            key={option}
-                            type="button"
-                            onClick={() => handleSelect(option)}
-                            className={`block w-full px-4 py-2.5 text-left text-sm hover:bg-gray-50 ${
-                                value === option
-                                    ? 'font-semibold text-blue-500'
-                                    : 'text-gray-600'
-                            }`}
-                        >
-                            {SORT_LABELS[option]}
-                        </button>
-                    ))}
-                </div>
-            )}
-        </div>
-    );
-}
+type LobbyCategoryFilter = (typeof CATEGORY_FILTERS)[number];
 
 export function Lobbies() {
     const navigate = useNavigate();
@@ -121,8 +23,9 @@ export function Lobbies() {
 
     const [searchKeyword, setSearchKeyword] = useState('');
     const [selectedCategory, setSelectedCategory] =
-        useState<(typeof CATEGORY_FILTERS)[number]>('전체');
-    const [sortOption, setSortOption] = useState<SortOption>('LATEST');
+        useState<LobbyCategoryFilter>('전체');
+    const [sortOption, setSortOption] =
+        useState<LobbySortOption>('LATEST');
 
     useEffect(() => {
         const browserUserId = getOrCreateBrowserUserId();
@@ -132,11 +35,12 @@ export function Lobbies() {
 
     const filteredAndSortedLobbies = useMemo(() => {
         const safeLobbies = lobbies ?? [];
+        const normalizedKeyword = searchKeyword.trim().toLowerCase();
 
         const filteredLobbies = safeLobbies.filter((lobby) => {
             const matchesKeyword = lobby.title
                 .toLowerCase()
-                .includes(searchKeyword.trim().toLowerCase());
+                .includes(normalizedKeyword);
 
             const matchesCategory =
                 selectedCategory === '전체' ||
@@ -174,55 +78,20 @@ export function Lobbies() {
 
             <main className="flex flex-1 gap-5 px-9 py-6">
                 <section className="min-w-0 flex-1">
-                    <div className="mb-4 flex items-center gap-3">
-                        <input
-                            type="text"
-                            value={searchKeyword}
-                            onChange={(event) =>
-                                setSearchKeyword(event.target.value)
-                            }
-                            placeholder="로비 제목 검색"
-                            className="flex-1 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm text-gray-700 placeholder:text-gray-400 shadow-sm focus:border-blue-400 focus:outline-none"
-                        />
+                    <LobbyHeader
+                        searchKeyword={searchKeyword}
+                        onSearchKeywordChange={setSearchKeyword}
+                        categories={CATEGORY_FILTERS}
+                        selectedCategory={selectedCategory}
+                        onSelectedCategoryChange={setSelectedCategory}
+                        sortOption={sortOption}
+                        onSortOptionChange={setSortOption}
+                    />
 
-                        <SortDropdown
-                            value={sortOption}
-                            onChange={setSortOption}
-                        />
-                    </div>
-
-                    <div className="mb-5 flex gap-2">
-                        {CATEGORY_FILTERS.map((category) => (
-                            <button
-                                key={category}
-                                type="button"
-                                onClick={() => setSelectedCategory(category)}
-                                className={`rounded-full px-4 py-1.5 text-sm font-medium ${
-                                    selectedCategory === category
-                                        ? 'bg-blue-500 text-white'
-                                        : 'border border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
-                                }`}
-                            >
-                                {category}
-                            </button>
-                        ))}
-                    </div>
-
-                    <div className="grid grid-cols-2 gap-4">
-                        {filteredAndSortedLobbies.length > 0 ? (
-                            filteredAndSortedLobbies.map((lobby) => (
-                                <LobbyCard
-                                    key={lobby.code}
-                                    lobby={lobby}
-                                    onEnter={handleEnter}
-                                />
-                            ))
-                        ) : (
-                            <div className="col-span-2 flex h-40 items-center justify-center text-gray-400">
-                                현재 조건에 맞는 로비가 없습니다.
-                            </div>
-                        )}
-                    </div>
+                    <LobbyList
+                        lobbies={filteredAndSortedLobbies}
+                        onEnter={handleEnter}
+                    />
                 </section>
 
                 <aside className="sticky top-6 h-[calc(100vh-8.5rem)] w-96 shrink-0 self-start">

--- a/src/utils/lobbySort.ts
+++ b/src/utils/lobbySort.ts
@@ -1,0 +1,41 @@
+import type { Lobby } from '../types/lobby';
+
+export type LobbySortOption =
+    | 'LATEST'
+    | 'MOST_PLAYERS'
+    | 'MOST_EMPTY_SLOTS';
+
+export function getCurrentPlayers(lobby: Lobby): number {
+    return 'currentPlayers' in lobby && typeof lobby.currentPlayers === 'number'
+        ? lobby.currentPlayers
+        : 1;
+}
+
+export function sortLobbies(
+    lobbies: Lobby[],
+    sortOption: LobbySortOption,
+): Lobby[] {
+    const copiedLobbies = [...lobbies];
+
+    switch (sortOption) {
+        case 'MOST_PLAYERS':
+            return copiedLobbies.sort(
+                (left, right) =>
+                    getCurrentPlayers(right) - getCurrentPlayers(left),
+            );
+
+        case 'MOST_EMPTY_SLOTS':
+            return copiedLobbies.sort((left, right) => {
+                const rightEmptySlots =
+                    right.maxPlayers - getCurrentPlayers(right);
+                const leftEmptySlots =
+                    left.maxPlayers - getCurrentPlayers(left);
+
+                return rightEmptySlots - leftEmptySlots;
+            });
+
+        case 'LATEST':
+        default:
+            return copiedLobbies;
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- #27

## 📝 Summary

- 로비 리스트 화면의 책임을 역할별 컴포넌트로 분리했습니다.
- 기존 `Lobbies.tsx`에 포함되어 있던 검색, 카테고리 필터, 정렬 드롭다운, 로비 목록, 빈 상태, 푸터 UI를 개별 컴포넌트로 분리했습니다.
- 로비 정렬 로직을 `src/utils/lobbySort.ts`로 이동하여 UI 컴포넌트와 비즈니스 로직을 분리했습니다.
- 기존 `LobbyCard`, `GlobalChat` 컴포넌트 구조는 유지하되, `LobbyCard`에서 현재 인원 계산 로직을 공통 유틸 함수로 사용하도록 정리했습니다.

## 🙏PR point

- 이번 PR은 UI 동작 변경이 아니라 구조 개선 목적의 리팩터링입니다.
- 로비 목록 검색, 카테고리 필터, 정렬, 입장 버튼 동작이 기존과 동일하게 유지되는지 확인 부탁드립니다.
- 현재 FE 카테고리 필터는 임시로 프론트 상수 기준으로 관리하고 있습니다.
- BE `MapCategory`는 현재 `kpop`, `jpop`, `pop` 응답 구조이므로, 추후 로비 리스트 API에서 맵 카테고리를 내려줄 때 FE 필터 값도 BE 응답 기준으로 맞출 예정입니다.
- `OST` 카테고리는 현재 BE enum에 없기 때문에, 지원 여부 확정 후 FE 필터에 반영할 예정입니다.

## 📬 Reference
