### PR TITLE
[Feat/#31] 게스트 로그인 API 연동

### DIFF
--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -1,0 +1,55 @@
+// API 호출은 Hook에서 직접 fetch() 하지 않고 별도 모듈로 분리한다.
+
+import { API_ENDPOINTS } from '../constants/endpoints';
+import { AUTH_MESSAGES } from '../constants/auth';
+import { guestSessionSchema } from '../schemas/authSchema';
+
+import type {
+    GuestLoginRequest,
+    GuestLoginResponse,
+} from '../types/auth';
+
+const JSON_CONTENT_TYPE = 'application/json';
+
+async function parseErrorMessage(response: Response): Promise<string> {
+    try {
+        const payload = await response.json() as {
+            message?: string;
+            error?: string;
+        };
+
+        return payload.message ?? payload.error ?? AUTH_MESSAGES.GUEST_LOGIN_FAILED;
+    } catch {
+        return AUTH_MESSAGES.GUEST_LOGIN_FAILED;
+    }
+}
+
+export async function loginAsGuest(
+    request: GuestLoginRequest,
+): Promise<GuestLoginResponse> {
+    const response = await fetch(API_ENDPOINTS.AUTH.GUEST, {
+        method: 'POST',
+        headers: {
+            'Content-Type': JSON_CONTENT_TYPE,
+        },
+        body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+        throw new Error(await parseErrorMessage(response));
+    }
+
+    const payload = await response.json() as unknown;
+    const parsed = guestSessionSchema.safeParse(payload);
+
+    if (!parsed.success) {
+        console.error(
+            '[authApi] 게스트 로그인 응답 검증 실패:',
+            parsed.error,
+        );
+
+        throw new Error(AUTH_MESSAGES.INVALID_GUEST_LOGIN_RESPONSE);
+    }
+
+    return parsed.data;
+}

--- a/src/api/lobbyApi.ts
+++ b/src/api/lobbyApi.ts
@@ -1,0 +1,29 @@
+import { lobbyListSchema } from '../schemas/lobbySchema';
+import type { Lobby } from '../types/lobby';
+
+const LOBBY_API_ERROR_MESSAGES = {
+    FETCH_FAILED: '로비 목록을 불러오는 데 실패했습니다.',
+    INVALID_RESPONSE: '로비 목록 응답 형식이 올바르지 않습니다.',
+} as const;
+
+export async function fetchLobbyList(): Promise<Lobby[]> {
+    const response = await fetch('/api/lobbies');
+
+    if (!response.ok) {
+        throw new Error(LOBBY_API_ERROR_MESSAGES.FETCH_FAILED);
+    }
+
+    const payload = await response.json() as unknown;
+    const parsed = lobbyListSchema.safeParse(payload);
+
+    if (!parsed.success) {
+        console.error('[lobbyApi] 로비 목록 응답 검증 실패:', {
+            payload,
+            error: parsed.error,
+        });
+
+        throw new Error(LOBBY_API_ERROR_MESSAGES.INVALID_RESPONSE);
+    }
+
+    return parsed.data;
+}

--- a/src/components/home/NicknameForm.tsx
+++ b/src/components/home/NicknameForm.tsx
@@ -1,76 +1,119 @@
-// 홈 화면의 닉네임 입력 UI를 담당하고, useGuestSession 훅과 연결하여 세션 생성을 트리거하는 컴포넌트
-
 import { useRef } from 'react';
+
 import { MonomatInput } from '../common/MonomatInput';
 import { useGuestSession } from '../../hooks/useGuestSession';
-
-/**
- * [닉네임 입력 폼 컴포넌트]
- *
- * 이 컴포넌트의 책임 범위:
- *   - 닉네임 입력창(MonomatInput)과 입장 버튼 렌더링
- *   - 버튼 클릭 또는 엔터 입력 시 useGuestSession 훅으로 값 전달
- *
- * 이 컴포넌트가 하지 않는 것:
- *   - UUID 생성, localStorage 저장, Zustand 상태 업데이트
- *     → 모두 useGuestSession 훅 내부에서 처리
- */
+import {
+    AUTH_LABELS,
+    GUEST_NICKNAME_GUIDE,
+} from '../../constants/auth';
 
 export function NicknameForm() {
-    // 입력 요소에 직접 접근하기 위해 ref를 사용
-    // 버튼 클릭 시 input의 현재 값을 읽어야 하기 때문이다.
     const inputRef = useRef<HTMLInputElement>(null);
 
-    // 세션 생성 로직은 훅에 캡슐화되어 있으며,
-    // 이 컴포넌트는 createGuestSession 함수만 받아서 호출한다.
-    const { createGuestSession } = useGuestSession();
+    const {
+        createGuestSession,
+        isSubmitting,
+        errorMessage,
+        clearErrorMessage,
+    } = useGuestSession();
 
-    // 버튼 클릭 핸들러
-    // ref로 input의 현재 값을 읽어 훅에 전달한다.
-    // (onEnter는 MonomatInput 내부에서 value를 직접 파라미터로 넘겨주므로
-    //  ref가 필요 없지만, 버튼 클릭 경로에서는 ref를 통해 값을 읽는다.)
-    const handleButtonClick = () => {
-        if (inputRef.current) {
-            createGuestSession(inputRef.current.value);
-        }
+    const handleSubmit = () => {
+        const nickname = inputRef.current?.value ?? '';
+        void createGuestSession(nickname);
     };
 
     return (
-        <div className="w-full max-w-md flex flex-col gap-3">
-            <div className="relative group">
-                {/*
-                 * MonomatInput: 프로젝트 전용 커스텀 인풋 컴포넌트 (#15에서 생성)
-                 *
-                 * onEnter 콜백을 사용하는 이유:
-                 *   일반 onKeyDown에서 엔터를 감지하면 한글 조합 완료 시점에
-                 *   이벤트가 2번 발생하는 'Double Fire' 문제가 생긴다.
-                 *   MonomatInput은 내부적으로 isComposing 상태를 체크하여
-                 *   한글 조합이 끝난 후 엔터가 눌렸을 때만 onEnter를 호출한다.
-                 */}
-                <MonomatInput
-                    ref={inputRef}
-                    type="text"
-                    placeholder="닉네임을 입력하세요"
-                    maxLength={12}
-                    autoFocus
-                    onEnter={createGuestSession}  // 엔터 입력 시 세션 생성 요청
-                    className="w-full px-5 py-4 text-xl bg-gray-900 border-2 border-gray-800 rounded-2xl outline-none focus:border-blue-500 transition-all text-white placeholder-gray-600"
-                />
+        <div className="w-full max-w-[480px] rounded-2xl bg-white px-10 py-16 shadow-2xl">
+            <header className="mb-7 text-center">
+                <h2 className="mb-4 text-3xl font-extrabold !text-[#333338]">
+                    {AUTH_LABELS.GUEST_LOGIN}
+                </h2>
 
-                {/* 입장 버튼: 클릭 시 ref로 현재 input 값을 읽어 세션 생성 요청 */}
+                <p className="text-sm text-[#808085]">
+                    닉네임만 입력하면 바로 게임에 참가할 수 있습니다
+                </p>
+            </header>
+
+            <div className="mb-7 flex rounded-xl bg-[#F5F5F7] p-1">
                 <button
-                    onClick={handleButtonClick}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 px-4 py-2 bg-blue-600 hover:bg-blue-500 active:scale-95 rounded-xl font-bold transition-all"
-                    aria-label="게임 입장"
+                    type="button"
+                    disabled
+                    className="h-10 flex-1 rounded-lg text-sm font-medium text-[#808085] disabled:cursor-not-allowed"
                 >
-                    입장
+                    {AUTH_LABELS.MEMBER_LOGIN}
+                </button>
+
+                <button
+                    type="button"
+                    className="h-10 flex-1 rounded-lg bg-white text-sm font-semibold text-[#333338] shadow"
+                >
+                    {AUTH_LABELS.GUEST_LOGIN}
                 </button>
             </div>
 
-            {/* 게스트 진입 안내 문구 */}
-            <p className="text-center text-xs text-gray-500 mt-2">
-                별도의 회원가입 없이 즉시 플레이가 가능합니다.
-            </p>
+            {errorMessage && (
+                <div
+                    role="alert"
+                    className="mb-4 rounded-lg bg-red-50 px-4 py-3 text-sm font-medium text-red-500"
+                >
+                    {errorMessage}
+                </div>
+            )}
+
+            <div className="mb-5 text-left">
+                <label
+                    htmlFor="guest-nickname"
+                    className="mb-2 block text-sm font-medium text-[#808085]"
+                >
+                    {AUTH_LABELS.NICKNAME}
+                </label>
+
+                <MonomatInput
+                    id="guest-nickname"
+                    ref={inputRef}
+                    type="text"
+                    placeholder={AUTH_LABELS.NICKNAME_PLACEHOLDER}
+                    maxLength={12}
+                    autoFocus
+                    disabled={isSubmitting}
+                    onChange={clearErrorMessage}
+                    onEnter={(value) => {
+                        void createGuestSession(value);
+                    }}
+                    className="h-12 w-full rounded-lg border border-[#CCCCD1] bg-[#F5F5F7] px-4 text-left text-sm text-[#333338] outline-none transition placeholder:text-[#B5B5BA] focus:border-blue-500 disabled:cursor-not-allowed disabled:opacity-60"
+                />
+            </div>
+
+            <ul className="mb-12 list-disc space-y-2 pl-5 text-left text-sm text-[#808085]">
+                {GUEST_NICKNAME_GUIDE.map((guide) => (
+                    <li key={guide}>{guide}</li>
+                ))}
+            </ul>
+
+            <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={isSubmitting}
+                className="h-14 w-full rounded-lg bg-blue-500 text-base font-bold text-white transition hover:bg-blue-600 disabled:cursor-not-allowed disabled:bg-blue-300"
+            >
+                {isSubmitting
+                    ? AUTH_LABELS.SUBMITTING
+                    : AUTH_LABELS.SUBMIT}
+            </button>
+
+            <footer className="mt-10 flex items-center justify-between text-sm">
+                <span className="text-[#808085]">
+                    {AUTH_LABELS.CREATE_MAP_HINT}
+                </span>
+
+                <button
+                    type="button"
+                    disabled
+                    className="font-semibold text-blue-500 underline disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                    {AUTH_LABELS.MEMBER_LOGIN}
+                </button>
+            </footer>
         </div>
     );
 }

--- a/src/components/lobby/LobbyCard.tsx
+++ b/src/components/lobby/LobbyCard.tsx
@@ -69,7 +69,7 @@ function ProgressBar({
 }
 
 export function LobbyCard({ lobby, onEnter }: LobbyCardProps) {
-    const { code, title, status, maxPlayers, category } = lobby;
+    const { code, title, status, maxPlayers, mapCategory } = lobby;
 
     const currentPlayers = getCurrentPlayers(lobby);
     const isFull = currentPlayers >= maxPlayers;
@@ -79,7 +79,7 @@ export function LobbyCard({ lobby, onEnter }: LobbyCardProps) {
         <div className="flex flex-col justify-between rounded-xl bg-white p-5 text-left shadow-sm">
             <div className="mb-3 flex items-center gap-2">
                 <StatusBadge status={status} />
-                <CategoryBadge category={category} />
+                <CategoryBadge category={mapCategory} />
             </div>
 
             <p className="mb-4 text-left text-base font-semibold text-gray-900">

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,0 +1,36 @@
+// 닉네임 정책, 에러 메시지, 버튼 문구를 한 곳에서 관리한다.
+
+export const GUEST_NICKNAME_POLICY = {
+    MIN_LENGTH: 2,
+    MAX_LENGTH: 12,
+    /**
+     * 공백 문자가 포함된 닉네임은 허용하지 않는다.
+     * 예: "홍 길동", "guest user"
+     */
+    WHITESPACE_PATTERN: /\s/,
+} as const;
+
+export const AUTH_MESSAGES = {
+    EMPTY_NICKNAME: '닉네임을 입력해주세요.',
+    INVALID_NICKNAME_LENGTH: `닉네임은 ${GUEST_NICKNAME_POLICY.MIN_LENGTH}~${GUEST_NICKNAME_POLICY.MAX_LENGTH}자 이내로 입력해주세요.`,
+    INVALID_NICKNAME_WHITESPACE: '공백이 포함된 닉네임은 사용할 수 없습니다.',
+    GUEST_LOGIN_FAILED: '게스트 입장에 실패했습니다. 잠시 후 다시 시도해주세요.',
+    INVALID_GUEST_LOGIN_RESPONSE: '서버 응답 형식이 올바르지 않습니다.',
+    SESSION_RESTORE_FAILED: '저장된 게스트 세션을 복구하지 못했습니다.',
+} as const;
+
+export const AUTH_LABELS = {
+    MEMBER_LOGIN: '회원 로그인',
+    GUEST_LOGIN: '게스트 입장',
+    NICKNAME: '닉네임',
+    NICKNAME_PLACEHOLDER: '게임에서 사용할 닉네임을 입력하세요',
+    SUBMIT: '게임 참가하기',
+    SUBMITTING: '입장 중...',
+    CREATE_MAP_HINT: '맵을 만들려면?',
+} as const;
+
+export const GUEST_NICKNAME_GUIDE = [
+    `${GUEST_NICKNAME_POLICY.MIN_LENGTH}~${GUEST_NICKNAME_POLICY.MAX_LENGTH}자 이내로 입력해주세요`,
+    '정식 회원의 닉네임은 사용할 수 없습니다',
+    '공백이 포함된 닉네임은 사용 불가합니다',
+] as const;

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -1,14 +1,9 @@
-// 서버와 통신할 때 사용하는 주소 (URL)를 관리한다.
-// 개발 환경과 실제 배포 환경의 주소가 다르기 때문에
-// .env.development / .env.production 파일에 주소를 따로 저장해두고 여기서 불러온다.
+// 서버와 통신할 때 사용하는 주소(URL)를 관리한다.
+// WebSocket 주소는 환경변수로 강제하고, REST API는 기본적으로 상대 경로를 사용한다.
 
-// import.meta.env는 Vite가 제공하는 환경변수 접근 방법이다.
-// VITE_WS_URL은 .env 파일에 정의된 WebSocket 서버 주소이다.
 const rawWsUrl = import.meta.env.VITE_WS_URL as string | undefined;
+const rawApiBaseUrl = import.meta.env.VITE_API_BASE_URL as string | undefined;
 
-// 환경변수가 설정되지 않은 채로 앱이 실행되면 즉시 에러를 발생시킨다.
-// 소켓 연결을 시도한 후 실패하는 것보다, 앱 시작 시점에 바로 발견하는 것이 훨씬 좋다.
-// 이를 Fail-Fast (빠른 실패) 원칙이라고 한다.
 if (!rawWsUrl) {
     throw new Error(
         '[Endpoints] VITE_WS_URL 환경변수가 설정되지 않았습니다.\n' +
@@ -16,5 +11,29 @@ if (!rawWsUrl) {
     );
 }
 
-// 검증을 통과한 안전한 값만 외부로 내보낸다.
+/**
+ * API base URL은 선택값이다.
+ * - 값이 없으면 같은 origin의 /api 경로를 사용한다.
+ * - 값이 있으면 마지막 slash를 제거하여 경로 조합 오류를 방지한다.
+ */
+const normalizeBaseUrl = (baseUrl?: string) => {
+    if (!baseUrl) {
+        return '';
+    }
+
+    return baseUrl.endsWith('/')
+        ? baseUrl.slice(0, -1)
+        : baseUrl;
+};
+
+const createApiEndpoint = (path: string) => {
+    return `${normalizeBaseUrl(rawApiBaseUrl)}${path}`;
+};
+
 export const WS_ENDPOINT = rawWsUrl;
+
+export const API_ENDPOINTS = {
+    AUTH: {
+        GUEST: createApiEndpoint('/api/auth/guest'),
+    },
+} as const;

--- a/src/constants/home.ts
+++ b/src/constants/home.ts
@@ -1,0 +1,22 @@
+// 화면 문구와 기능 리스트를 컴포넌트에서 분리한다.
+
+export const HOME_COPY = {
+    SERVICE_NAME: 'Monomat',
+    TITLE: '실시간 YouTube\n음악 퀴즈 게임',
+    DESCRIPTION: '닉네임만 입력하면 바로 시작!\n회원가입 없이 게스트로 즉시 참가합니다.',
+} as const;
+
+export const HOME_FEATURES = [
+    {
+        icon: '🎵',
+        label: 'YouTube 영상 재생 제어',
+    },
+    {
+        icon: '⚡',
+        label: '실시간 점수 동기화',
+    },
+    {
+        icon: '👥',
+        label: '최대 N인 동시 플레이',
+    },
+] as const;

--- a/src/hooks/useGuestSession.ts
+++ b/src/hooks/useGuestSession.ts
@@ -1,48 +1,71 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+
+import { loginAsGuest } from '../api/authApi';
+import { AUTH_MESSAGES } from '../constants/auth';
 import { useAuthStore } from '../store/useAuthStore';
-import { generateUUID } from '../utils/uuid';
-import { STORAGE_KEYS } from '../constants/storage';
+import { validateGuestNickname } from '../utils/validateNickname';
 
 interface UseGuestSessionReturn {
-    createGuestSession: (nickname: string) => void;
+    createGuestSession: (nickname: string) => Promise<void>;
+    isSubmitting: boolean;
+    errorMessage: string | null;
+    clearErrorMessage: () => void;
+}
+
+function getErrorMessage(error: unknown): string {
+    if (error instanceof Error && error.message) {
+        return error.message;
+    }
+
+    return AUTH_MESSAGES.GUEST_LOGIN_FAILED;
 }
 
 export function useGuestSession(): UseGuestSessionReturn {
     const setSession = useAuthStore((state) => state.setSession);
     const navigate = useNavigate();
 
-    const createGuestSession = (nickname: string) => {
-        const trimmedNickname = nickname.trim();
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-        if (!trimmedNickname) {
-            alert('닉네임을 입력해주세요.');
+    const clearErrorMessage = () => {
+        setErrorMessage(null);
+    };
+
+    const createGuestSession = async (nickname: string) => {
+        const trimmedNickname = nickname.trim();
+        const validationMessage = validateGuestNickname(trimmedNickname);
+
+        if (validationMessage) {
+            setErrorMessage(validationMessage);
             return;
         }
 
-        const guestUuid = generateUUID();
-        const sessionData = {
-            uuid: guestUuid,
-            nickname: trimmedNickname,
-            createdAt: Date.now(),
-        };
-
-        try {
-            localStorage.setItem(
-                STORAGE_KEYS.GUEST_SESSION,
-                JSON.stringify(sessionData),
-            );
-            console.log('[useGuestSession] 게스트 세션 생성 완료:', trimmedNickname);
-        } catch (error) {
-            console.error('[useGuestSession] localStorage 저장 실패:', error);
-            alert(
-                '브라우저의 시크릿 모드이거나 저장 공간이 부족합니다.\n' +
-                '게임은 진행할 수 있으나 새로고침 시 접속이 끊어질 수 있습니다.',
-            );
+        if (isSubmitting) {
+            return;
         }
 
-        setSession(guestUuid, trimmedNickname);
-        navigate('/lobbies');
+        try {
+            setIsSubmitting(true);
+            setErrorMessage(null);
+
+            const session = await loginAsGuest({
+                nickname: trimmedNickname,
+            });
+
+            setSession(session);
+            navigate('/lobbies');
+        } catch (error) {
+            setErrorMessage(getErrorMessage(error));
+        } finally {
+            setIsSubmitting(false);
+        }
     };
 
-    return { createGuestSession };
+    return {
+        createGuestSession,
+        isSubmitting,
+        errorMessage,
+        clearErrorMessage,
+    };
 }

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -3,29 +3,20 @@ import { useAuthStore } from '../store/useAuthStore';
 import { useSocketStore } from '../store/useSocketStore';
 
 // 소켓의 생명주기(연결/해제)를 관리하는 커스텀 훅입니다.
-// App.tsx처럼 인증된 사용자가 접근하는 최상위 컴포넌트에서 딱 한 번만 호출합니다.
-// 하위 컴포넌트들은 이 훅을 직접 쓰지 않고,
-// useSocketStore()로 필요한 상태나 액션만 가져다 씁니다.
+// App.tsx처럼 인증된 사용자가 접근하는 최상위 컴포넌트에서 한 번만 호출합니다.
+// WebSocket 식별자는 FE가 직접 만든 UUID가 아니라 BE가 발급한 userIdentifier를 사용합니다.
 export function useSocket() {
-    const uuid = useAuthStore((state) => state.uuid);
+    const userIdentifier = useAuthStore((state) => state.userIdentifier);
     const connect = useSocketStore((state) => state.connect);
     const disconnect = useSocketStore((state) => state.disconnect);
 
     useEffect(() => {
-        // uuid가 없으면(비인증 상태) 소켓 연결을 시도하지 않습니다.
-        if (!uuid) return;
+        if (!userIdentifier) return;
 
-        connect(uuid);
+        connect(userIdentifier);
 
-        // [cleanup 함수]
-        // 아래 두 가지 시점에 자동으로 실행됩니다.
-        // 1. 컴포넌트가 화면에서 사라질 때 (로그아웃, 페이지 이탈)
-        // 2. uuid가 바뀔 때 (기존 소켓 끊고 새 uuid로 재연결)
         return () => {
-            // disconnect()는 async 함수라 Promise를 반환합니다.
-            // useEffect cleanup은 void만 반환할 수 있으므로
-            // 화살표 함수로 감싸서 Promise가 외부로 노출되지 않게 합니다.
             void disconnect();
         };
-    }, [uuid, connect, disconnect]);
+    }, [userIdentifier, connect, disconnect]);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,18 +1,29 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'; // 추가
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools'; // 선택 사항 (개발용)
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
 import './index.css';
 import App from './App.tsx';
 
-// MSW 개발 환경에서만 활성화
+const ENABLE_MSW = import.meta.env.VITE_ENABLE_MSW === 'true';
+
+/**
+ * MSW는 개발 환경에서 명시적으로 활성화한 경우에만 실행한다.
+ *
+ * 실제 BE API 연동 중에는 Service Worker가 요청을 가로채면
+ * CORS, passthrough 실패, stale mock 문제를 만들 수 있으므로 기본값은 비활성화한다.
+ */
 async function enableMocking() {
-    if (import.meta.env.DEV) {
-        const { worker } = await import('./mocks/browser');
-        return worker.start({
-            onUnhandledRequest: 'bypass',
-        });
+    if (!import.meta.env.DEV || !ENABLE_MSW) {
+        return;
     }
+
+    const { worker } = await import('./mocks/browser');
+
+    return worker.start({
+        onUnhandledRequest: 'bypass',
+    });
 }
 
 // QueryClient 인스턴스 생성
@@ -20,9 +31,9 @@ async function enableMocking() {
 const queryClient = new QueryClient({
     defaultOptions: {
         queries: {
-            staleTime: 1000 * 60 * 5, // oEmbed 캐싱 등을 위해 5분간 유지
-            refetchOnWindowFocus: false, // 윈도우 포커스 시 자동 새로고침 방지
-            retry: 1, // 에러 발생 시 재시도 횟수
+            staleTime: 1000 * 60 * 5,
+            refetchOnWindowFocus: false,
+            retry: 1,
         },
     },
 });

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,40 +1,49 @@
-// 게임 진입점 페이지의 레이아웃과 구조만 담당한다.
-// 닉네임 입력 UI를 렌더링하고, useGuestSession 훅을 통해 세션 생성을 위임한다.
-// 입력 및 세션 로직은 NicknameForm 컴포넌트에 위임한다.
-
 import { NicknameForm } from '../components/home/NicknameForm';
-
-/**
- * [홈 페이지 컴포넌트]
- *
- * 이 컴포넌트의 책임:
- *   - 서비스 타이틀, 설명 문구, NicknameForm의 레이아웃 구성
- *
- * 이 컴포넌트가 하지 않는 것:
- *   - 닉네임 입력값 처리, 세션 생성, 훅 직접 호출
- *     → NicknameForm과 useGuestSession 훅이 담당한다.
- */
+import {
+    HOME_COPY,
+    HOME_FEATURES,
+} from '../constants/home';
 
 export const Home = () => {
     return (
-        <div className="flex flex-col items-center justify-center min-h-screen bg-black text-white px-4">
+        <main className="grid min-h-screen grid-cols-[minmax(0,0.72fr)_minmax(0,1fr)] bg-[#F5F5F7]">
+            <section className="flex flex-col bg-[#202433] px-16 py-16 text-white">
+                <div className="flex items-center gap-4">
+                    <div
+                        aria-hidden
+                        className="h-12 w-12 rounded-xl bg-blue-500"
+                    />
+                    <span className="text-3xl font-bold">
+                        {HOME_COPY.SERVICE_NAME}
+                    </span>
+                </div>
 
-            {/* 서비스 헤더 영역: 타이틀과 설명 문구 */}
-            <div className="text-center mb-10">
-                <h1 className="text-6xl font-black mb-4 tracking-tighter text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-purple-500">
-                    MONOMAT
-                </h1>
-                <p className="text-gray-400 text-lg">
-                    YouTube 음악 퀴즈를 실시간으로 즐기세요.
-                </p>
-            </div>
+                <div className="mt-14 max-w-[520px] text-left">
+                    <h1 className="whitespace-pre-line text-[44px] font-extrabold leading-[1.25] tracking-tight text-white">
+                        {HOME_COPY.TITLE}
+                    </h1>
 
-            {/*
-             * 닉네임 입력 폼 영역
-             * 입력 UI, 버튼 핸들러, 세션 생성 로직이 모두 이 컴포넌트 안에 있다.
-             * Home은 이 컴포넌트를 "어디에 배치할지"만 결정한다.
-             */}
-            <NicknameForm />
-        </div>
+                    <p className="mt-9 whitespace-pre-line text-base leading-relaxed text-gray-300">
+                        {HOME_COPY.DESCRIPTION}
+                    </p>
+
+                    <ul className="mt-11 space-y-4">
+                        {HOME_FEATURES.map((feature) => (
+                            <li
+                                key={feature.label}
+                                className="flex h-12 items-center gap-3 rounded-lg bg-white/10 px-5 text-base text-gray-200"
+                            >
+                                <span aria-hidden>{feature.icon}</span>
+                                <span>{feature.label}</span>
+                            </li>
+                        ))}
+                    </ul>
+                </div>
+            </section>
+
+            <section className="flex items-center justify-center bg-[#F5F5F7] px-10">
+                <NicknameForm />
+            </section>
+        </main>
     );
 };

--- a/src/pages/Lobbies.tsx
+++ b/src/pages/Lobbies.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { NavigationBar } from '../components/common/NavigationBar';
@@ -7,8 +7,6 @@ import { LobbyFooter } from '../components/lobby/LobbyFooter';
 import { LobbyHeader } from '../components/lobby/LobbyHeader';
 import { LobbyList } from '../components/lobby/LobbyList';
 import { useLobbyList } from '../hooks/useLobbyList';
-import { useSocketStore } from '../store/useSocketStore';
-import { getOrCreateBrowserUserId } from '../utils/browserUserId';
 import { sortLobbies, type LobbySortOption } from '../utils/lobbySort';
 
 const CATEGORY_FILTERS = ['전체', 'K-POP', 'J-POP', 'POP', 'OST'] as const;
@@ -19,32 +17,34 @@ export function Lobbies() {
     const navigate = useNavigate();
     const { data: lobbies, isLoading, isError } = useLobbyList();
 
-    const connectSocket = useSocketStore((state) => state.connect);
-
     const [searchKeyword, setSearchKeyword] = useState('');
     const [selectedCategory, setSelectedCategory] =
         useState<LobbyCategoryFilter>('전체');
     const [sortOption, setSortOption] =
         useState<LobbySortOption>('LATEST');
 
-    useEffect(() => {
-        const browserUserId = getOrCreateBrowserUserId();
-
-        connectSocket(browserUserId);
-    }, [connectSocket]);
-
     const filteredAndSortedLobbies = useMemo(() => {
         const safeLobbies = lobbies ?? [];
         const normalizedKeyword = searchKeyword.trim().toLowerCase();
 
         const filteredLobbies = safeLobbies.filter((lobby) => {
-            const matchesKeyword = lobby.title
+            /*
+             * BE 응답이 일시적으로 비어 있거나, 기존 mock 데이터가 남아 있는 경우에도
+             * 로비 목록 화면 전체가 죽지 않도록 title을 안전하게 정규화한다.
+             */
+            const lobbyTitle = lobby.title ?? '';
+
+            const matchesKeyword = lobbyTitle
                 .toLowerCase()
                 .includes(normalizedKeyword);
 
+            /*
+             * 로비 카테고리는 로비 자체의 속성이 아니라 선택된 맵의 카테고리이므로
+             * BE 응답 필드명인 mapCategory를 기준으로 필터링한다.
+             */
             const matchesCategory =
                 selectedCategory === '전체' ||
-                lobby.category === selectedCategory;
+                lobby.mapCategory === selectedCategory;
 
             return matchesKeyword && matchesCategory;
         });

--- a/src/schemas/authSchema.ts
+++ b/src/schemas/authSchema.ts
@@ -1,0 +1,14 @@
+// 서버 응답을 그대로 믿지 않고 런타임 검증한다.
+
+import { z } from 'zod';
+
+export const guestSessionSchema = z.object({
+    userId: z.number().int().positive(),
+    nickname: z.string().min(1),
+    userType: z.enum(['REGISTERED', 'GUEST']),
+    userIdentifier: z.uuid(),
+    accessToken: z.string().min(1),
+    accessTokenExpiresAt: z.string().min(1),
+    refreshToken: z.string().min(1),
+    refreshTokenExpiresAt: z.string().min(1),
+});

--- a/src/schemas/lobbySchema.ts
+++ b/src/schemas/lobbySchema.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+export const lobbyCategorySchema = z
+    .enum(['K-POP', 'J-POP', 'POP', 'OST'])
+    .nullable()
+    .catch(null);
+
+export const lobbySchema = z.object({
+    code: z.string().min(1),
+    hostId: z.string().min(1),
+    title: z.string().catch(''),
+    mapId: z.number().nullable().catch(null),
+    mapTitle: z.string().nullable().optional().catch(null),
+
+    /**
+     * BE 응답 기준 로비 카테고리는 로비 자체가 아니라
+     * 로비에 연결된 맵의 카테고리입니다.
+     */
+    mapCategory: lobbyCategorySchema,
+
+    maxPlayers: z.number().int().positive(),
+    currentPlayers: z.number().int().min(0).optional().catch(0),
+    isPrivate: z.boolean(),
+    status: z.enum(['WAITING', 'PLAYING']),
+});
+
+export const lobbyListSchema = z.array(lobbySchema);

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -1,101 +1,91 @@
 import { create } from 'zustand';
-import { z } from 'zod';
 
-import { STORAGE_KEYS, SESSION_EXPIRY_MS } from '../constants/storage';
+import { STORAGE_KEYS } from '../constants/storage';
+import { AUTH_MESSAGES } from '../constants/auth';
+import { guestSessionSchema } from '../schemas/authSchema';
 
-import type { GuestSession } from '../types/auth';
-
-const guestSessionSchema = z.object({
-    uuid: z.uuid({ error: '유효하지 않은 UUID 형식입니다.' }),
-    nickname: z
-        .string()
-        .min(1, { error: '닉네임은 최소 1자 이상이어야 합니다.' })
-        .max(12, { error: '닉네임은 12자 이내여야 합니다.' }),
-    createdAt: z.number().refine(
-        (time) => Date.now() - time <= SESSION_EXPIRY_MS,
-        {
-            error: `세션이 만료되었습니다. (기준: ${
-                SESSION_EXPIRY_MS / (1000 * 60 * 60 * 24)
-            }일)`,
-        },
-    ),
-}) satisfies z.ZodType<GuestSession>;
+import type {
+    GuestSession,
+    UserType,
+} from '../types/auth';
 
 interface AuthState {
-    uuid: string | null;
+    userId: number | null;
+    userIdentifier: string | null;
     nickname: string | null;
+    userType: UserType | null;
+    accessToken: string | null;
+    accessTokenExpiresAt: string | null;
+    refreshToken: string | null;
+    refreshTokenExpiresAt: string | null;
     isGuest: boolean;
     isHydrated: boolean;
-    setSession: (uuid: string, nickname: string) => void;
+    setSession: (session: GuestSession) => void;
     clearSession: () => void;
     initializeSession: () => void;
     updateNickname: (nickname: string) => void;
 }
 
+function createSessionState(session: GuestSession) {
+    return {
+        userId: session.userId,
+        userIdentifier: session.userIdentifier,
+        nickname: session.nickname,
+        userType: session.userType,
+        accessToken: session.accessToken,
+        accessTokenExpiresAt: session.accessTokenExpiresAt,
+        refreshToken: session.refreshToken,
+        refreshTokenExpiresAt: session.refreshTokenExpiresAt,
+        isGuest: session.userType === 'GUEST',
+        isHydrated: true,
+    };
+}
+
+function createEmptyAuthState() {
+    return {
+        userId: null,
+        userIdentifier: null,
+        nickname: null,
+        userType: null,
+        accessToken: null,
+        accessTokenExpiresAt: null,
+        refreshToken: null,
+        refreshTokenExpiresAt: null,
+        isGuest: false,
+        isHydrated: true,
+    };
+}
+
 export const useAuthStore = create<AuthState>((set, get) => ({
-    uuid: null,
+    userId: null,
+    userIdentifier: null,
     nickname: null,
+    userType: null,
+    accessToken: null,
+    accessTokenExpiresAt: null,
+    refreshToken: null,
+    refreshTokenExpiresAt: null,
     isGuest: false,
     isHydrated: false,
 
-    setSession: (uuid, nickname) => {
-        set({
-            uuid,
-            nickname,
-            isGuest: true,
-            isHydrated: true,
-        });
+    setSession: (session) => {
+        try {
+            localStorage.setItem(
+                STORAGE_KEYS.GUEST_SESSION,
+                JSON.stringify(session),
+            );
+        } catch (error) {
+            // localStorage 저장 실패가 즉시 플레이를 막지는 않도록 메모리 상태는 유지한다.
+            // 단, 새로고침 시 세션 복구는 실패할 수 있으므로 로그를 남긴다.
+            console.error('[useAuthStore] 게스트 세션 저장 실패:', error);
+        }
+
+        set(createSessionState(session));
     },
 
     clearSession: () => {
         localStorage.removeItem(STORAGE_KEYS.GUEST_SESSION);
-
-        set({
-            uuid: null,
-            nickname: null,
-            isGuest: false,
-            isHydrated: true,
-        });
-    },
-
-    updateNickname: (nickname) => {
-        const trimmedNickname = nickname.trim();
-        const { uuid } = get();
-
-        if (!uuid || !trimmedNickname) {
-            return;
-        }
-
-        try {
-            const storedData = localStorage.getItem(STORAGE_KEYS.GUEST_SESSION);
-            const parsedData = storedData
-                ? (JSON.parse(storedData) as Partial<GuestSession>)
-                : null;
-
-            const nextSession: GuestSession = {
-                uuid,
-                nickname: trimmedNickname,
-                createdAt:
-                    typeof parsedData?.createdAt === 'number'
-                        ? parsedData.createdAt
-                        : Date.now(),
-            };
-
-            localStorage.setItem(
-                STORAGE_KEYS.GUEST_SESSION,
-                JSON.stringify(nextSession),
-            );
-
-            set({
-                nickname: trimmedNickname,
-            });
-        } catch (error) {
-            console.error('[useAuthStore] 닉네임 변경 저장 실패:', error);
-
-            set({
-                nickname: trimmedNickname,
-            });
-        }
+        set(createEmptyAuthState());
     },
 
     initializeSession: () => {
@@ -107,32 +97,76 @@ export const useAuthStore = create<AuthState>((set, get) => ({
                 return;
             }
 
-            const parsed = JSON.parse(storedData) as unknown;
-            const result = guestSessionSchema.safeParse(parsed);
+            const parsedData = JSON.parse(storedData) as unknown;
+            const result = guestSessionSchema.safeParse(parsedData);
 
-            if (result.success) {
-                set({
-                    uuid: result.data.uuid,
-                    nickname: result.data.nickname,
-                    isGuest: true,
-                    isHydrated: true,
-                });
-
-                console.log('세션 복구 완료:', result.data.nickname);
-            } else {
+            if (!result.success) {
                 console.warn(
-                    '세션 무효화 (오염 또는 만료):',
-                    z.treeifyError(result.error),
+                    `[useAuthStore] ${AUTH_MESSAGES.SESSION_RESTORE_FAILED}`,
+                    result.error,
                 );
 
                 localStorage.removeItem(STORAGE_KEYS.GUEST_SESSION);
-                set({ isHydrated: true });
+                set(createEmptyAuthState());
+                return;
             }
+
+            set(createSessionState(result.data));
         } catch (error) {
-            console.error('세션 파싱 중 오류 발생:', error);
+            console.error('[useAuthStore] 세션 복구 중 오류 발생:', error);
 
             localStorage.removeItem(STORAGE_KEYS.GUEST_SESSION);
-            set({ isHydrated: true });
+            set(createEmptyAuthState());
         }
+    },
+
+    updateNickname: (nickname) => {
+        const trimmedNickname = nickname.trim();
+        const {
+            userId,
+            userIdentifier,
+            userType,
+            accessToken,
+            accessTokenExpiresAt,
+            refreshToken,
+            refreshTokenExpiresAt,
+        } = get();
+
+        if (
+            !trimmedNickname ||
+            userId == null ||
+            !userIdentifier ||
+            !userType ||
+            !accessToken ||
+            !accessTokenExpiresAt ||
+            !refreshToken ||
+            !refreshTokenExpiresAt
+        ) {
+            return;
+        }
+
+        const nextSession: GuestSession = {
+            userId,
+            userIdentifier,
+            nickname: trimmedNickname,
+            userType,
+            accessToken,
+            accessTokenExpiresAt,
+            refreshToken,
+            refreshTokenExpiresAt,
+        };
+
+        try {
+            localStorage.setItem(
+                STORAGE_KEYS.GUEST_SESSION,
+                JSON.stringify(nextSession),
+            );
+        } catch (error) {
+            console.error('[useAuthStore] 닉네임 변경 저장 실패:', error);
+        }
+
+        set({
+            nickname: trimmedNickname,
+        });
     },
 }));

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,24 +1,20 @@
-// 인증 (로그인)과 관련된 타입 (데이터 구조)을 정의한다.
-// TypeScript의 타입은 "이 데이터는 어떤 모양이어야 한다"는 약속이다.
-// 타입을 미리 정의해두면 잘못된 구조의 데이터를 사용할 때 코드 작성 시점에 바로 에러가 난다.
+// BE가 내려주는 userIdentifier, accessToken, refreshToken이 기준
 
-// 사용자 종류를 정의한다.
-// DB의 user 테이블 user_type 컬럼과 동일한 값을 사용한다.
-// REGISTERED : 아이디/비밀번호로 가입한 정식 회원
-// GUEST : 닉네임만 입력하고 바로 참여한 게스트
 export type UserType = 'REGISTERED' | 'GUEST';
 
-// 게스트 세션 데이터의 구조를 정의한다.
-// 게스트가 브라우저를 닫았다가 다시 열어도 닉네임이 유지되도록 localStorge에 이 구조로 저장한다.
-export interface GuestSession {
-    // 게스트를 식별하는 고유 ID이다. (예: '550e8400-e29b-41d4-a716-446655440000')
-    // UUID (Universally Unique Identifier) 형식으로, 전 세계에서 중복될 확률이 거의 없다.
-    uuid: string;
-
-    // 게임에서 표시되는 닉네임이다. (1~12자)
+export interface GuestLoginRequest {
     nickname: string;
-
-    // 세션이 처음 만들어진 시각이다. (밀리초 단위 Unix 타임스탬프)
-    // 현재 시각과 비교해서 30일이 지나면 세션을 만료시키는 데 사용한다.
-    createdAt: number;
 }
+
+export interface GuestSession {
+    userId: number;
+    nickname: string;
+    userType: UserType;
+    userIdentifier: string;
+    accessToken: string;
+    accessTokenExpiresAt: string;
+    refreshToken: string;
+    refreshTokenExpiresAt: string;
+}
+
+export type GuestLoginResponse = GuestSession;

--- a/src/types/lobby.ts
+++ b/src/types/lobby.ts
@@ -13,7 +13,7 @@ export interface Lobby {
     hostId: string;
     title: string;
     mapId: number | null;
-    category: LobbyCategory | null;
+    mapCategory: LobbyCategory | null;
     maxPlayers: number;
     isPrivate: boolean;
     status: 'WAITING' | 'PLAYING';

--- a/src/utils/validateNickname.ts
+++ b/src/utils/validateNickname.ts
@@ -1,0 +1,27 @@
+// 닉네임 검증을 컴포넌트나 Hook에 직접 넣지 않는다.
+
+import {
+    AUTH_MESSAGES,
+    GUEST_NICKNAME_POLICY,
+} from '../constants/auth';
+
+export function validateGuestNickname(nickname: string): string | null {
+    const trimmedNickname = nickname.trim();
+
+    if (!trimmedNickname) {
+        return AUTH_MESSAGES.EMPTY_NICKNAME;
+    }
+
+    if (
+        trimmedNickname.length < GUEST_NICKNAME_POLICY.MIN_LENGTH ||
+        trimmedNickname.length > GUEST_NICKNAME_POLICY.MAX_LENGTH
+    ) {
+        return AUTH_MESSAGES.INVALID_NICKNAME_LENGTH;
+    }
+
+    if (GUEST_NICKNAME_POLICY.WHITESPACE_PATTERN.test(trimmedNickname)) {
+        return AUTH_MESSAGES.INVALID_NICKNAME_WHITESPACE;
+    }
+
+    return null;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,8 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
-import tailwindcss from '@tailwindcss/vite'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+
+const DEV_SERVER_TARGET = 'http://localhost:8080';
 
 export default defineConfig({
   plugins: [
@@ -8,6 +10,19 @@ export default defineConfig({
     tailwindcss(),
   ],
   define: {
-    global: 'globalThis',  // 이 줄 추가
+    global: 'globalThis',
   },
-})
+  server: {
+    proxy: {
+      '/api': {
+        target: DEV_SERVER_TARGET,
+        changeOrigin: true,
+      },
+      '/ws': {
+        target: DEV_SERVER_TARGET,
+        ws: true,
+        changeOrigin: true,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## 📣 Related Issue

- #31

## 📝 Summary

- `POST /api/auth/guest` API를 연동하여 게스트 로그인 흐름을 BE 기준으로 변경했습니다.
- 기존 브라우저 UUID 직접 생성 방식을 제거하고, BE가 발급한 `userIdentifier`, `accessToken`, `refreshToken`을 저장하도록 수정했습니다.
- WebSocket 연결 식별자를 클라이언트 생성 UUID가 아닌 `userIdentifier` 기준으로 변경했습니다.
- 게스트 입장 화면에 로딩 상태와 카드 내부 에러 메시지 표시를 추가했습니다.
- MSW가 실제 BE API 연동을 방해하지 않도록 `VITE_ENABLE_MSW=true`일 때만 활성화되도록 수정했습니다.
- 개발 환경에서 `/api`, `/ws` 요청이 BE로 프록시되도록 Vite proxy 설정을 추가했습니다.
- 로비 목록 응답 검증 로직을 추가하여 잘못된 응답 형식으로 인해 화면이 런타임 에러로 중단되지 않도록 방어했습니다.

## 🙏PR point

- 현재 BE의 `GET /api/lobbies` 응답이 순수 `Lobby[]`가 아니라 Jackson 타입 정보가 포함된 형태로 내려오는 문제가 확인되었습니다.
  - 예: `["java.util.ArrayList", [...]]`
  - FE에서는 응답 검증을 통해 화면이 죽지 않도록 방어 처리했습니다.
  - BE 응답 포맷 수정은 별도 BE 이슈 또는 PR에서 처리하는 것이 적절해 보입니다.
- `mapCategory` 값도 일부 응답에서 `jpop`처럼 소문자로 내려오는 케이스가 확인되었습니다.
  - FE 필터 값은 `J-POP` 기준이므로 추후 BE-FE enum 포맷 통일이 필요합니다.
- 회원 로그인 탭은 이번 이슈 범위가 아니므로 UI만 유지하고 실제 동작은 구현하지 않았습니다.
- 확인 완료:
  - `npm run lint`
  - `npm run build`
  - 게스트 로그인 성공 후 `/lobbies` 이동
  - localStorage 세션 저장
  - WebSocket 연결 성공

## 📬 Reference

- BE 게스트 로그인 API: `POST /api/auth/guest`