### PR TITLE
[Feat/#29] 로비 생성 페이지 및 생성 API 연동

### DIFF
--- a/src/components/lobby/LobbyCard.tsx
+++ b/src/components/lobby/LobbyCard.tsx
@@ -69,7 +69,7 @@ function ProgressBar({
 }
 
 export function LobbyCard({ lobby, onEnter }: LobbyCardProps) {
-    const { code, title, status, maxPlayers, category } = lobby;
+    const { code, title, status, maxPlayers, mapCategory } = lobby;
 
     const currentPlayers = getCurrentPlayers(lobby);
     const isFull = currentPlayers >= maxPlayers;
@@ -79,7 +79,7 @@ export function LobbyCard({ lobby, onEnter }: LobbyCardProps) {
         <div className="flex flex-col justify-between rounded-xl bg-white p-5 text-left shadow-sm">
             <div className="mb-3 flex items-center gap-2">
                 <StatusBadge status={status} />
-                <CategoryBadge category={category} />
+                <CategoryBadge category={mapCategory} />
             </div>
 
             <p className="mb-4 text-left text-base font-semibold text-gray-900">

--- a/src/pages/Lobbies.tsx
+++ b/src/pages/Lobbies.tsx
@@ -44,8 +44,8 @@ export function Lobbies() {
 
             const matchesCategory =
                 selectedCategory === '전체' ||
-                lobby.category === selectedCategory;
-
+                lobby.mapCategory === selectedCategory;
+            
             return matchesKeyword && matchesCategory;
         });
 

--- a/src/pages/Lobbies.tsx
+++ b/src/pages/Lobbies.tsx
@@ -45,7 +45,7 @@ export function Lobbies() {
             const matchesCategory =
                 selectedCategory === '전체' ||
                 lobby.mapCategory === selectedCategory;
-            
+
             return matchesKeyword && matchesCategory;
         });
 

--- a/src/types/lobby.ts
+++ b/src/types/lobby.ts
@@ -15,6 +15,7 @@ export interface Lobby {
     mapId: number | null;
     mapCategory: LobbyCategory | null;
     maxPlayers: number;
+    currentPlayers: number;
     isPrivate: boolean;
     status: 'WAITING' | 'PLAYING';
 }

--- a/src/types/lobby.ts
+++ b/src/types/lobby.ts
@@ -13,7 +13,7 @@ export interface Lobby {
     hostId: string;
     title: string;
     mapId: number | null;
-    category: LobbyCategory | null;
+    mapCategory: LobbyCategory | null;
     maxPlayers: number;
     isPrivate: boolean;
     status: 'WAITING' | 'PLAYING';

--- a/src/utils/lobbySort.ts
+++ b/src/utils/lobbySort.ts
@@ -6,9 +6,7 @@ export type LobbySortOption =
     | 'MOST_EMPTY_SLOTS';
 
 export function getCurrentPlayers(lobby: Lobby): number {
-    return 'currentPlayers' in lobby && typeof lobby.currentPlayers === 'number'
-        ? lobby.currentPlayers
-        : 1;
+    return lobby.currentPlayers;
 }
 
 export function sortLobbies(


### PR DESCRIPTION
## 📣 Related Issue

- #29

## 📝 Summary

- `/lobbies/create` 로비 생성 페이지 라우트를 추가했습니다.
- 로비 생성 페이지 UI를 구현했습니다.
  - 맵 선택 영역
  - 방 제목 입력
  - 최대 인원 슬라이더
  - 라운드 수 슬라이더
  - 라운드 당 제한 시간 슬라이더
  - 공개 / 비공개 선택 UI
- `POST /api/lobbies` 로비 생성 API를 연동했습니다.
- 로비 생성 성공 시 응답으로 받은 `inviteCode`를 기준으로 `/lobby/{inviteCode}` 페이지로 이동하도록 처리했습니다.
- 로비 생성 실패 시 에러 메시지를 화면에 표시하도록 처리했습니다.
- 상단 NavigationBar의 `+ 로비 만들기` 버튼을 `/lobbies/create` 이동과 연결했습니다.
- 로비 목록 검색/정렬 영역에 중복으로 있던 로비 만들기 버튼을 제거했습니다.
- 로비 생성 페이지 상단바를 sticky 처리하고, 우측 프로필 표시는 사용자 닉네임 첫 글자를 사용하도록 수정했습니다.
- 맵 선택은 현재 UI만 배치하고 비활성화 상태로 처리했습니다.

## 🙏 PR point

- BE develop 기준 `POST /api/lobbies`는 `mapId`를 지원하지만, 이번 이슈에서는 맵 선택 모달까지 구현하지 않고 `mapId: null`로 생성 요청을 보냅니다.
- 실제 맵 선택 기능은 별도 이슈에서 `GET /api/maps` 기반으로 확장하는 것이 적절합니다.
- 로비 생성 API는 인증이 필요하므로 `Authorization: Bearer {accessToken}` 헤더를 포함했습니다.
- 생성 페이지의 UI는 제공된 디자인 시안을 기준으로 맞췄으며, 전역 `h1`, `h2`, `#root` 스타일 영향이 있어 일부 스타일은 명시적으로 오버라이드했습니다.

## ✅ Test
- [ ] `npm run lint`
- [ ] `npm run build`
- [ ] 게스트 로그인 후 `/lobbies` 진입
- [ ] 상단 `+ 로비 만들기` 클릭 시 `/lobbies/create` 이동 확인
- [ ] 로비 생성 폼 입력 후 생성 성공 시 `/lobby/{inviteCode}` 이동 확인
- [ ] 제목 미입력 또는 생성 실패 시 에러 메시지 표시 확인

## 📬 Reference

- BE `POST /api/lobbies`
- BE `CreateLobbyRequest`
- BE `CreateLobbyResponse`