### PR TITLE
[Feat/#30] 초대 코드 기반 로비 입장 모달 구현

### DIFF
--- a/src/api/lobbyApi.ts
+++ b/src/api/lobbyApi.ts
@@ -1,28 +1,57 @@
-import { lobbyListSchema } from '../schemas/lobbySchema';
-import type { Lobby } from '../types/lobby';
+import { API_ENDPOINTS } from '../constants/endpoints';
+import { joinLobbyResponseSchema } from '../schemas/lobbySchema';
 
-const LOBBY_API_ERROR_MESSAGES = {
-    FETCH_FAILED: '로비 목록을 불러오는 데 실패했습니다.',
-    INVALID_RESPONSE: '로비 목록 응답 형식이 올바르지 않습니다.',
-} as const;
+import type {
+    JoinLobbyRequest,
+    JoinLobbyResponse,
+} from '../types/lobby';
 
-export async function fetchLobbyList(): Promise<Lobby[]> {
-    const response = await fetch('/api/lobbies');
+const JSON_CONTENT_TYPE = 'application/json';
+
+const DEFAULT_JOIN_LOBBY_ERROR_MESSAGE = '로비 입장에 실패했습니다.';
+
+async function parseErrorMessage(response: Response): Promise<string> {
+    try {
+        const payload = (await response.json()) as {
+            message?: string;
+            error?: string;
+        };
+
+        return (
+            payload.message ??
+            payload.error ??
+            DEFAULT_JOIN_LOBBY_ERROR_MESSAGE
+        );
+    } catch {
+        return DEFAULT_JOIN_LOBBY_ERROR_MESSAGE;
+    }
+}
+
+export async function joinLobbyByInviteCode(
+    request: JoinLobbyRequest,
+): Promise<JoinLobbyResponse> {
+    const response = await fetch(API_ENDPOINTS.LOBBY.JOIN, {
+        method: 'POST',
+        headers: {
+            'Content-Type': JSON_CONTENT_TYPE,
+        },
+        body: JSON.stringify(request),
+    });
 
     if (!response.ok) {
-        throw new Error(LOBBY_API_ERROR_MESSAGES.FETCH_FAILED);
+        throw new Error(await parseErrorMessage(response));
     }
 
-    const payload = await response.json() as unknown;
-    const parsed = lobbyListSchema.safeParse(payload);
+    const payload = (await response.json()) as unknown;
+    const parsed = joinLobbyResponseSchema.safeParse(payload);
 
     if (!parsed.success) {
-        console.error('[lobbyApi] 로비 목록 응답 검증 실패:', {
-            payload,
-            error: parsed.error,
-        });
+        console.error(
+            '[lobbyApi] 로비 입장 응답 검증 실패:',
+            parsed.error,
+        );
 
-        throw new Error(LOBBY_API_ERROR_MESSAGES.INVALID_RESPONSE);
+        throw new Error('로비 입장 응답 형식이 올바르지 않습니다.');
     }
 
     return parsed.data;

--- a/src/components/common/NavigationBar.tsx
+++ b/src/components/common/NavigationBar.tsx
@@ -1,10 +1,9 @@
-import { type KeyboardEvent, useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { InviteCodeJoinModal } from '../lobby/InviteCodeJoinModal';
 import { useAuthStore } from '../../store/useAuthStore';
 import { AccountModal } from './AccountModal';
-
-const INVITE_CODE_LENGTH = 6;
 
 export function NavigationBar() {
     const navigate = useNavigate();
@@ -12,7 +11,7 @@ export function NavigationBar() {
     const nickname = useAuthStore((state) => state.nickname);
     const isGuest = useAuthStore((state) => state.isGuest);
 
-    const [inviteCode, setInviteCode] = useState('');
+    const [isInviteCodeModalOpen, setIsInviteCodeModalOpen] = useState(false);
     const [isAccountModalOpen, setIsAccountModalOpen] = useState(false);
 
     const displayNickname = nickname ?? 'Guest';
@@ -23,29 +22,6 @@ export function NavigationBar() {
 
     const handleLogoClick = () => {
         navigate('/lobbies');
-    };
-
-    const handleInviteCodeSubmit = () => {
-        const normalizedInviteCode = inviteCode.trim();
-
-        if (normalizedInviteCode.length !== INVITE_CODE_LENGTH) {
-            alert(`${INVITE_CODE_LENGTH}자리 초대 코드를 입력해주세요.`);
-            return;
-        }
-
-        navigate(`/lobby/${normalizedInviteCode}`);
-    };
-
-    const handleInviteCodeKeyDown = (
-        event: KeyboardEvent<HTMLInputElement>,
-    ) => {
-        if (event.nativeEvent.isComposing) {
-            return;
-        }
-
-        if (event.key === 'Enter') {
-            handleInviteCodeSubmit();
-        }
     };
 
     const handleCreateMapClick = () => {
@@ -82,29 +58,13 @@ export function NavigationBar() {
                         </button>
                     )}
 
-                    <div className="flex items-center rounded-lg border border-gray-300 bg-white px-3 py-2">
-                        <span className="mr-2 text-sm text-gray-900">▣</span>
-
-                        <input
-                            type="text"
-                            value={inviteCode}
-                            maxLength={INVITE_CODE_LENGTH}
-                            onChange={(event) =>
-                                setInviteCode(event.target.value)
-                            }
-                            onKeyDown={handleInviteCodeKeyDown}
-                            placeholder="초대 코드"
-                            className="w-28 bg-transparent text-sm text-gray-900 placeholder:text-gray-400 focus:outline-none"
-                        />
-
-                        <button
-                            type="button"
-                            onClick={handleInviteCodeSubmit}
-                            className="rounded-full bg-gray-100 px-3 py-1 text-xs text-gray-500 hover:bg-gray-200"
-                        >
-                            입장
-                        </button>
-                    </div>
+                    <button
+                        type="button"
+                        onClick={() => setIsInviteCodeModalOpen(true)}
+                        className="rounded-lg border border-gray-300 bg-white px-5 py-2.5 text-sm font-semibold text-gray-900 hover:bg-gray-50"
+                    >
+                        ▣ 초대 코드 입장
+                    </button>
 
                     <button
                         type="button"
@@ -124,6 +84,11 @@ export function NavigationBar() {
                     </button>
                 </div>
             </header>
+
+            <InviteCodeJoinModal
+                isOpen={isInviteCodeModalOpen}
+                onClose={() => setIsInviteCodeModalOpen(false)}
+            />
 
             <AccountModal
                 isOpen={isAccountModalOpen}

--- a/src/components/lobby/InviteCodeJoinModal.tsx
+++ b/src/components/lobby/InviteCodeJoinModal.tsx
@@ -1,0 +1,249 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { joinLobbyByInviteCode } from '../../api/lobbyApi';
+import { INVITE_CODE_POLICY } from '../../constants/lobby';
+import type { JoinLobbyResponse } from '../../types/lobby';
+import {
+    normalizeInviteCode,
+    validateInviteCode,
+} from '../../utils/inviteCode';
+import { MonomatInput } from '../common/MonomatInput';
+
+interface InviteCodeJoinModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+function getJoinBlockedMessage(response: JoinLobbyResponse): string | null {
+    if (response.status === 'PLAYING') {
+        return '이미 진행 중인 로비에는 입장할 수 없습니다.';
+    }
+
+    if (response.currentPlayers >= response.maxPlayers) {
+        return '최대 인원을 초과하여 입장할 수 없습니다.';
+    }
+
+    return null;
+}
+
+export function InviteCodeJoinModal({
+                                        isOpen,
+                                        onClose,
+                                    }: InviteCodeJoinModalProps) {
+    const navigate = useNavigate();
+
+    const [inviteCodeInput, setInviteCodeInput] = useState('');
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [joinedLobby, setJoinedLobby] = useState<JoinLobbyResponse | null>(
+        null,
+    );
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        setInviteCodeInput('');
+        setErrorMessage(null);
+        setJoinedLobby(null);
+        setIsSubmitting(false);
+    }, [isOpen]);
+
+    if (!isOpen) {
+        return null;
+    }
+
+    const handleClose = () => {
+        if (isSubmitting) {
+            return;
+        }
+
+        onClose();
+    };
+
+    const handleInputChange = (
+        event: React.ChangeEvent<HTMLInputElement>,
+    ) => {
+        const normalizedValue = normalizeInviteCode(event.target.value);
+
+        setInviteCodeInput(normalizedValue);
+        setErrorMessage(null);
+        setJoinedLobby(null);
+    };
+
+    const handleJoinCheck = async (value: string) => {
+        const normalizedInviteCode = normalizeInviteCode(value);
+        const validationMessage = validateInviteCode(normalizedInviteCode);
+
+        if (validationMessage) {
+            setErrorMessage(validationMessage);
+            setJoinedLobby(null);
+            return;
+        }
+
+        if (isSubmitting) {
+            return;
+        }
+
+        try {
+            setIsSubmitting(true);
+            setErrorMessage(null);
+            setJoinedLobby(null);
+
+            const response = await joinLobbyByInviteCode({
+                inviteCode: normalizedInviteCode,
+            });
+
+            const blockedMessage = getJoinBlockedMessage(response);
+
+            if (blockedMessage) {
+                setErrorMessage(blockedMessage);
+                return;
+            }
+
+            setJoinedLobby(response);
+        } catch (error) {
+            if (error instanceof Error && error.message) {
+                setErrorMessage(error.message);
+                return;
+            }
+
+            setErrorMessage('로비 입장에 실패했습니다.');
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const handleConfirmEnter = () => {
+        if (!joinedLobby) {
+            return;
+        }
+
+        onClose();
+        navigate(`/lobby/${joinedLobby.inviteCode}`);
+    };
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="invite-code-join-modal-title"
+        >
+            <div className="relative w-[460px] rounded-2xl bg-white px-9 py-8 text-[#333338] shadow-xl">
+                <button
+                    type="button"
+                    onClick={handleClose}
+                    disabled={isSubmitting}
+                    className="absolute right-6 top-6 text-3xl leading-none text-[#808085] hover:text-[#333338] disabled:cursor-not-allowed disabled:opacity-40"
+                    aria-label="초대 코드 입장 모달 닫기"
+                >
+                    ×
+                </button>
+
+                <h2
+                    id="invite-code-join-modal-title"
+                    className="mb-3 text-center text-2xl font-bold text-[#333338]"
+                >
+                    초대 코드로 입장
+                </h2>
+
+                <p className="mb-8 text-center text-sm text-[#808085]">
+                    전달받은 6자리 초대 코드를 입력해주세요.
+                </p>
+
+                <section className="mb-5">
+                    <label
+                        htmlFor="invite-code-input"
+                        className="mb-3 block text-sm font-bold text-[#333338]"
+                    >
+                        초대 코드
+                    </label>
+
+                    <MonomatInput
+                        id="invite-code-input"
+                        type="text"
+                        value={inviteCodeInput}
+                        maxLength={INVITE_CODE_POLICY.LENGTH}
+                        autoFocus
+                        disabled={isSubmitting}
+                        onChange={handleInputChange}
+                        onEnter={handleJoinCheck}
+                        placeholder="ABC123"
+                        className="h-13 w-full rounded-lg border border-[#CCCCD1] bg-[#F5F5F7] px-4 text-center font-mono text-2xl font-bold tracking-[0.35em] text-[#333338] outline-none transition placeholder:text-[#B5B5BA] focus:border-[#3873E6] disabled:cursor-not-allowed disabled:opacity-60"
+                    />
+
+                    <p className="mt-2 text-xs text-[#808085]">
+                        영문 대문자와 숫자 조합 6자리만 입력할 수 있습니다.
+                    </p>
+                </section>
+
+                {errorMessage && (
+                    <div
+                        role="alert"
+                        className="mb-5 rounded-lg bg-red-50 px-4 py-3 text-sm font-semibold text-red-500"
+                    >
+                        {errorMessage}
+                    </div>
+                )}
+
+                {joinedLobby && (
+                    <section className="mb-5 rounded-xl bg-[#F5F5F7] px-4 py-4">
+                        <p className="mb-2 text-sm font-bold text-[#333338]">
+                            입장 가능한 로비입니다.
+                        </p>
+
+                        <dl className="space-y-2 text-sm">
+                            <div className="flex justify-between gap-4">
+                                <dt className="text-[#808085]">로비 이름</dt>
+                                <dd className="max-w-[240px] truncate font-semibold text-[#333338]">
+                                    {joinedLobby.title}
+                                </dd>
+                            </div>
+
+                            <div className="flex justify-between gap-4">
+                                <dt className="text-[#808085]">현재 인원</dt>
+                                <dd className="font-semibold text-[#333338]">
+                                    {joinedLobby.currentPlayers}/
+                                    {joinedLobby.maxPlayers}명
+                                </dd>
+                            </div>
+                        </dl>
+                    </section>
+                )}
+
+                <div className="flex gap-3">
+                    <button
+                        type="button"
+                        onClick={handleClose}
+                        disabled={isSubmitting}
+                        className="h-12 flex-1 rounded-lg border border-[#CCCCD1] font-bold text-[#333338] hover:bg-[#F5F5F7] disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        취소
+                    </button>
+
+                    {joinedLobby ? (
+                        <button
+                            type="button"
+                            onClick={handleConfirmEnter}
+                            className="h-12 flex-1 rounded-lg bg-[#3873E6] font-bold text-white hover:bg-blue-600"
+                        >
+                            입장하기
+                        </button>
+                    ) : (
+                        <button
+                            type="button"
+                            onClick={() => handleJoinCheck(inviteCodeInput)}
+                            disabled={isSubmitting}
+                            className="h-12 flex-1 rounded-lg bg-[#3873E6] font-bold text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:bg-blue-300"
+                        >
+                            {isSubmitting ? '확인 중...' : '입장 확인'}
+                        </button>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -21,9 +21,7 @@ const normalizeBaseUrl = (baseUrl?: string) => {
         return '';
     }
 
-    return baseUrl.endsWith('/')
-        ? baseUrl.slice(0, -1)
-        : baseUrl;
+    return baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
 };
 
 const createApiEndpoint = (path: string) => {
@@ -35,5 +33,10 @@ export const WS_ENDPOINT = rawWsUrl;
 export const API_ENDPOINTS = {
     AUTH: {
         GUEST: createApiEndpoint('/api/auth/guest'),
+    },
+
+    LOBBY: {
+        JOIN: createApiEndpoint('/api/lobbies/join'),
+        LIST: createApiEndpoint('/api/lobbies'),
     },
 } as const;

--- a/src/constants/lobby.ts
+++ b/src/constants/lobby.ts
@@ -1,0 +1,11 @@
+export const INVITE_CODE_POLICY = {
+    LENGTH: 6,
+    ALLOWED_PATTERN: /^[A-Z0-9]{6}$/,
+    REMOVE_WHITESPACE_PATTERN: /\s/g,
+} as const;
+
+export const INVITE_CODE_MESSAGES = {
+    EMPTY: '초대 코드를 입력해주세요.',
+    INVALID_LENGTH: '초대 코드는 6자리여야 합니다.',
+    INVALID_FORMAT: '초대 코드는 영문 대문자와 숫자만 입력할 수 있습니다.',
+} as const;

--- a/src/schemas/lobbySchema.ts
+++ b/src/schemas/lobbySchema.ts
@@ -1,27 +1,15 @@
 import { z } from 'zod';
 
-export const lobbyCategorySchema = z
-    .enum(['K-POP', 'J-POP', 'POP', 'OST'])
-    .nullable()
-    .catch(null);
+export const lobbyCategorySchema = z.enum(['K-POP', 'J-POP', 'POP', 'OST']);
 
-export const lobbySchema = z.object({
-    code: z.string().min(1),
+export const joinLobbyResponseSchema = z.object({
+    inviteCode: z.string().regex(/^[A-Z0-9]{6}$/),
+    title: z.string().min(1),
     hostId: z.string().min(1),
-    title: z.string().catch(''),
-    mapId: z.number().nullable().catch(null),
-    mapTitle: z.string().nullable().optional().catch(null),
-
-    /**
-     * BE 응답 기준 로비 카테고리는 로비 자체가 아니라
-     * 로비에 연결된 맵의 카테고리입니다.
-     */
-    mapCategory: lobbyCategorySchema,
-
     maxPlayers: z.number().int().positive(),
-    currentPlayers: z.number().int().min(0).optional().catch(0),
-    isPrivate: z.boolean(),
+    currentPlayers: z.number().int().min(0),
     status: z.enum(['WAITING', 'PLAYING']),
+    mapId: z.number().int().positive().nullable(),
+    mapTitle: z.string().min(1).nullable(),
+    mapCategory: lobbyCategorySchema.nullable(),
 });
-
-export const lobbyListSchema = z.array(lobbySchema);

--- a/src/types/lobby.ts
+++ b/src/types/lobby.ts
@@ -1,10 +1,7 @@
 // 게임 로비 (대기방)와 관련된 타입을 정의한다.
 // DB의 GAME_LOBBY 테이블 구조를 기반으로 한다.
 
-export type LobbyStatus =
-    | 'WAITING'
-    | 'PLAYING'
-    | 'RESULT';
+export type LobbyStatus = 'WAITING' | 'PLAYING' | 'RESULT';
 
 export type LobbyCategory = 'K-POP' | 'J-POP' | 'POP' | 'OST';
 
@@ -18,4 +15,20 @@ export interface Lobby {
     currentPlayers: number;
     isPrivate: boolean;
     status: 'WAITING' | 'PLAYING';
+}
+
+export interface JoinLobbyRequest {
+    inviteCode: string;
+}
+
+export interface JoinLobbyResponse {
+    inviteCode: string;
+    title: string;
+    hostId: string;
+    maxPlayers: number;
+    currentPlayers: number;
+    status: 'WAITING' | 'PLAYING';
+    mapId: number | null;
+    mapTitle: string | null;
+    mapCategory: LobbyCategory | null;
 }

--- a/src/utils/inviteCode.ts
+++ b/src/utils/inviteCode.ts
@@ -1,0 +1,44 @@
+import {
+    INVITE_CODE_MESSAGES,
+    INVITE_CODE_POLICY,
+} from '../constants/lobby';
+
+/**
+ * 사용자가 입력한 초대 코드를 BE 계약에 맞는 형태로 정규화한다.
+ *
+ * 처리 규칙:
+ * - 앞뒤 공백 제거
+ * - 중간 공백 제거
+ * - 영문 소문자를 대문자로 변환
+ */
+export function normalizeInviteCode(value: string): string {
+    return value
+        .trim()
+        .replace(INVITE_CODE_POLICY.REMOVE_WHITESPACE_PATTERN, '')
+        .toUpperCase();
+}
+
+/**
+ * 초대 코드가 BE 요청 DTO의 형식과 일치하는지 검증한다.
+ *
+ * BE 계약:
+ * - 영문 대문자 + 숫자
+ * - 정확히 6자리
+ */
+export function validateInviteCode(value: string): string | null {
+    const normalizedInviteCode = normalizeInviteCode(value);
+
+    if (!normalizedInviteCode) {
+        return INVITE_CODE_MESSAGES.EMPTY;
+    }
+
+    if (normalizedInviteCode.length !== INVITE_CODE_POLICY.LENGTH) {
+        return INVITE_CODE_MESSAGES.INVALID_LENGTH;
+    }
+
+    if (!INVITE_CODE_POLICY.ALLOWED_PATTERN.test(normalizedInviteCode)) {
+        return INVITE_CODE_MESSAGES.INVALID_FORMAT;
+    }
+
+    return null;
+}


### PR DESCRIPTION
## 📣 Related Issue

- #30

## 📝 Summary

- 초대 코드를 입력해 로비 입장 가능 여부를 확인하는 모달을 구현했습니다.
- 초대 코드 입력값을 영문 대문자 + 숫자 6자리 형식으로 정규화하고 검증하도록 처리했습니다.
- `POST /api/lobbies/join` API를 연동하여 존재하지 않는 로비, 진행 중인 로비, 최대 인원 초과 로비에 대한 에러 처리를 추가했습니다.
- 입장 가능 응답을 받은 경우 로비 제목과 현재 인원 정보를 확인한 뒤 `/lobby/{inviteCode}`로 이동하도록 구현했습니다.
- 기존 NavigationBar의 단순 초대 코드 이동 로직을 제거하고, 초대 코드 입장 모달을 여는 방식으로 변경했습니다.

## 🙏PR point

- 이번 PR은 기능 구현 범위에 집중했으며, 모달/버튼/상단바의 세부 디자인 개선은 추후 별도 UI 개선 이슈로 분리하는 것이 좋습니다.
- 실제 로비 참여자 등록은 BE 정책상 `POST /api/lobbies/join` 이후 WebSocket 구독 시점에 처리됩니다. 이번 PR은 입장 가능 여부 사전 검증과 라우팅까지만 담당합니다.
- 로컬에서 `/api/lobbies` 또는 `/api/lobbies/join` 요청 확인 시 BE 서버가 `localhost:8080`에서 실행 중이어야 합니다.

## 📬 Reference

- BE `POST /api/lobbies/join` API 계약
- 기존 `AccountModal` 모달 UI 구조
- 기존 `MonomatInput` 한글 IME 조합 방지 처리