### PR TITLE
[Feat/#37] 게스트 회원 공통 로비 생성 구현

### DIFF
--- a/src/api/lobbyApi.ts
+++ b/src/api/lobbyApi.ts
@@ -2,11 +2,14 @@ import { API_ENDPOINTS } from '../constants/endpoints';
 import { fetchWithAuth } from './apiClient';
 import { createApiError } from './apiError';
 import {
+    createLobbyResponseSchema,
     joinLobbyResponseSchema,
     lobbyListResponseSchema,
 } from '../schemas/lobbySchema';
 
 import type {
+    CreateLobbyRequest,
+    CreateLobbyResponse,
     JoinLobbyRequest,
     JoinLobbyResponse,
     LobbyListItem,
@@ -16,6 +19,7 @@ import type {
 
 const JSON_CONTENT_TYPE = 'application/json';
 
+const DEFAULT_CREATE_LOBBY_ERROR_MESSAGE = '로비 생성에 실패했습니다.';
 const DEFAULT_JOIN_LOBBY_ERROR_MESSAGE = '로비 입장에 실패했습니다.';
 const DEFAULT_FETCH_LOBBY_LIST_ERROR_MESSAGE = '로비 목록을 불러오는 데 실패했습니다.';
 
@@ -79,6 +83,39 @@ export async function fetchLobbyList(
         );
 
         throw new Error('로비 목록 응답 형식이 올바르지 않습니다.');
+    }
+
+    return parsed.data;
+}
+
+export async function createLobby(
+    request: CreateLobbyRequest,
+): Promise<CreateLobbyResponse> {
+    const response = await fetchWithAuth(API_ENDPOINTS.LOBBY.CREATE, {
+        method: 'POST',
+        headers: {
+            'Content-Type': JSON_CONTENT_TYPE,
+        },
+        body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            DEFAULT_CREATE_LOBBY_ERROR_MESSAGE,
+        );
+    }
+
+    const payload = (await response.json()) as unknown;
+    const parsed = createLobbyResponseSchema.safeParse(payload);
+
+    if (!parsed.success) {
+        console.error(
+            '[lobbyApi] 로비 생성 응답 검증 실패:',
+            parsed.error,
+        );
+
+        throw new Error('로비 생성 응답 형식이 올바르지 않습니다.');
     }
 
     return parsed.data;

--- a/src/components/common/NavigationBar.tsx
+++ b/src/components/common/NavigationBar.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { CreateLobbyModal } from '../lobby/CreateLobbyModal';
 import { InviteCodeJoinModal } from '../lobby/InviteCodeJoinModal';
 import { useAuthStore } from '../../store/useAuthStore';
 import { AccountModal } from './AccountModal';
+import type { CreateLobbyResponse } from '../../types/lobby';
 
 export function NavigationBar() {
     const navigate = useNavigate();
@@ -12,6 +14,7 @@ export function NavigationBar() {
     const isGuest = useAuthStore((state) => state.isGuest);
 
     const [isInviteCodeModalOpen, setIsInviteCodeModalOpen] = useState(false);
+    const [isCreateLobbyModalOpen, setIsCreateLobbyModalOpen] = useState(false);
     const [isAccountModalOpen, setIsAccountModalOpen] = useState(false);
 
     const displayNickname = nickname ?? 'Guest';
@@ -29,7 +32,11 @@ export function NavigationBar() {
     };
 
     const handleCreateLobbyClick = () => {
-        alert('로비 만들기 기능은 추후 로비 생성 기능과 연결합니다.');
+        setIsCreateLobbyModalOpen(true);
+    };
+
+    const handleLobbyCreated = (response: CreateLobbyResponse) => {
+        navigate(`/lobby/${response.inviteCode}`);
     };
 
     return (
@@ -88,6 +95,12 @@ export function NavigationBar() {
             <InviteCodeJoinModal
                 isOpen={isInviteCodeModalOpen}
                 onClose={() => setIsInviteCodeModalOpen(false)}
+            />
+
+            <CreateLobbyModal
+                isOpen={isCreateLobbyModalOpen}
+                onClose={() => setIsCreateLobbyModalOpen(false)}
+                onCreated={handleLobbyCreated}
             />
 
             <AccountModal

--- a/src/components/lobby/CreateLobbyModal.tsx
+++ b/src/components/lobby/CreateLobbyModal.tsx
@@ -1,0 +1,475 @@
+import {
+    useCallback,
+    useEffect,
+    useState,
+    type ChangeEvent,
+    type FormEvent,
+} from 'react';
+
+import { createLobby } from '../../api/lobbyApi';
+import { CREATE_LOBBY_POLICY } from '../../constants/lobby';
+import type {
+    CreateLobbyRequest,
+    CreateLobbyResponse,
+} from '../../types/lobby';
+import { MonomatInput } from '../common/MonomatInput';
+
+interface CreateLobbyModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onCreated: (response: CreateLobbyResponse) => void;
+}
+
+const MAX_PLAYER_OPTIONS = Array.from(
+    {
+        length:
+            CREATE_LOBBY_POLICY.MAX_PLAYERS -
+            CREATE_LOBBY_POLICY.MIN_PLAYERS +
+            1,
+    },
+    (_, index) => CREATE_LOBBY_POLICY.MIN_PLAYERS + index,
+);
+
+interface CreateLobbyFormState {
+    title: string;
+    maxPlayers: number;
+    isPrivate: boolean;
+    roundCount: string;
+    timeLimitSeconds: string;
+}
+
+const DEFAULT_FORM_STATE: CreateLobbyFormState = {
+    title: '',
+    maxPlayers: CREATE_LOBBY_POLICY.DEFAULT_MAX_PLAYERS,
+    isPrivate: false,
+    roundCount: '',
+    timeLimitSeconds: '',
+};
+
+function parseOptionalInteger(value: string) {
+    const trimmedValue = value.trim();
+
+    if (!trimmedValue) {
+        return undefined;
+    }
+
+    const parsedValue = Number(trimmedValue);
+
+    return Number.isInteger(parsedValue) ? parsedValue : null;
+}
+
+function validateOptionalIntegerRange(
+    value: string,
+    min: number,
+    max: number,
+    label: string,
+) {
+    const parsedValue = parseOptionalInteger(value);
+
+    if (parsedValue === undefined) {
+        return {
+            value: undefined,
+            message: null,
+        };
+    }
+
+    if (parsedValue === null || parsedValue < min || parsedValue > max) {
+        return {
+            value: null,
+            message: `${label}은 ${min}~${max} 범위로 입력해주세요.`,
+        };
+    }
+
+    return {
+        value: parsedValue,
+        message: null,
+    };
+}
+
+function createRequestFromFormState(
+    formState: CreateLobbyFormState,
+): CreateLobbyRequest | string {
+    const title = formState.title.trim();
+
+    if (!title) {
+        return '로비 제목을 입력해주세요.';
+    }
+
+    if (title.length > CREATE_LOBBY_POLICY.TITLE_MAX_LENGTH) {
+        return `로비 제목은 최대 ${CREATE_LOBBY_POLICY.TITLE_MAX_LENGTH}자까지 입력할 수 있습니다.`;
+    }
+
+    if (
+        formState.maxPlayers < CREATE_LOBBY_POLICY.MIN_PLAYERS ||
+        formState.maxPlayers > CREATE_LOBBY_POLICY.MAX_PLAYERS
+    ) {
+        return `최대 인원은 ${CREATE_LOBBY_POLICY.MIN_PLAYERS}~${CREATE_LOBBY_POLICY.MAX_PLAYERS}명 중에서 선택해주세요.`;
+    }
+
+    const roundCountResult = validateOptionalIntegerRange(
+        formState.roundCount,
+        CREATE_LOBBY_POLICY.MIN_ROUND_COUNT,
+        CREATE_LOBBY_POLICY.MAX_ROUND_COUNT,
+        '라운드 수',
+    );
+
+    if (roundCountResult.message) {
+        return roundCountResult.message;
+    }
+
+    const timeLimitResult = validateOptionalIntegerRange(
+        formState.timeLimitSeconds,
+        CREATE_LOBBY_POLICY.MIN_TIME_LIMIT_SECONDS,
+        CREATE_LOBBY_POLICY.MAX_TIME_LIMIT_SECONDS,
+        '제한 시간',
+    );
+
+    if (timeLimitResult.message) {
+        return timeLimitResult.message;
+    }
+
+    return {
+        title,
+        maxPlayers: formState.maxPlayers,
+        isPrivate: formState.isPrivate,
+        mapId: null,
+        roundCount: roundCountResult.value,
+        timeLimitSeconds: timeLimitResult.value,
+    };
+}
+
+export function CreateLobbyModal({
+                                     isOpen,
+                                     onClose,
+                                     onCreated,
+                                 }: CreateLobbyModalProps) {
+    const [formState, setFormState] =
+        useState<CreateLobbyFormState>(DEFAULT_FORM_STATE);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+
+    const resetState = useCallback(() => {
+        setFormState(DEFAULT_FORM_STATE);
+        setErrorMessage(null);
+        setIsSubmitting(false);
+    }, []);
+
+    useEffect(() => {
+        if (!isOpen) {
+            resetState();
+        }
+    }, [isOpen, resetState]);
+
+    useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        const handleEscapeKey = (event: KeyboardEvent) => {
+            if (event.key !== 'Escape' || isSubmitting) {
+                return;
+            }
+
+            resetState();
+            onClose();
+        };
+
+        window.addEventListener('keydown', handleEscapeKey);
+
+        return () => {
+            window.removeEventListener('keydown', handleEscapeKey);
+        };
+    }, [isOpen, isSubmitting, onClose, resetState]);
+
+    if (!isOpen) {
+        return null;
+    }
+
+    const updateFormState = <TKey extends keyof CreateLobbyFormState>(
+        key: TKey,
+        value: CreateLobbyFormState[TKey],
+    ) => {
+        setFormState((currentFormState) => ({
+            ...currentFormState,
+            [key]: value,
+        }));
+        setErrorMessage(null);
+    };
+
+    const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
+        updateFormState('title', event.target.value);
+    };
+
+    const handleMaxPlayersChange = (event: ChangeEvent<HTMLSelectElement>) => {
+        updateFormState('maxPlayers', Number(event.target.value));
+    };
+
+    const handleRoundCountChange = (event: ChangeEvent<HTMLInputElement>) => {
+        updateFormState('roundCount', event.target.value);
+    };
+
+    const handleTimeLimitChange = (event: ChangeEvent<HTMLInputElement>) => {
+        updateFormState('timeLimitSeconds', event.target.value);
+    };
+
+    const handleClose = () => {
+        if (isSubmitting) {
+            return;
+        }
+
+        resetState();
+        onClose();
+    };
+
+    const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        if (isSubmitting) {
+            return;
+        }
+
+        const request = createRequestFromFormState(formState);
+
+        if (typeof request === 'string') {
+            setErrorMessage(request);
+            return;
+        }
+
+        try {
+            setIsSubmitting(true);
+            setErrorMessage(null);
+
+            const response = await createLobby(request);
+
+            resetState();
+            onClose();
+            onCreated(response);
+        } catch (error) {
+            if (error instanceof Error && error.message) {
+                setErrorMessage(error.message);
+                return;
+            }
+
+            setErrorMessage('로비 생성에 실패했습니다.');
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="create-lobby-modal-title"
+        >
+            <div className="relative w-[520px] rounded-2xl bg-white px-9 py-8 text-[#333338] shadow-xl">
+                <button
+                    type="button"
+                    onClick={handleClose}
+                    disabled={isSubmitting}
+                    className="absolute right-6 top-6 text-3xl leading-none text-[#808085] hover:text-[#333338] disabled:cursor-not-allowed disabled:opacity-40"
+                    aria-label="로비 만들기 모달 닫기"
+                >
+                    ×
+                </button>
+
+                <h2
+                    id="create-lobby-modal-title"
+                    className="mb-3 text-center text-2xl font-bold text-[#333338]"
+                >
+                    로비 만들기
+                </h2>
+
+                <p className="mb-8 text-center text-sm text-[#808085]">
+                    기본 설정만 입력하면 바로 대기실로 이동합니다.
+                </p>
+
+                <form onSubmit={handleSubmit}>
+                    <section className="mb-5">
+                        <label
+                            htmlFor="create-lobby-title"
+                            className="mb-3 block text-sm font-bold text-[#333338]"
+                        >
+                            로비 제목
+                        </label>
+
+                        <MonomatInput
+                            id="create-lobby-title"
+                            type="text"
+                            value={formState.title}
+                            maxLength={CREATE_LOBBY_POLICY.TITLE_MAX_LENGTH}
+                            autoFocus
+                            disabled={isSubmitting}
+                            preventEnterSubmit={false}
+                            onChange={handleTitleChange}
+                            placeholder="로비 제목을 입력해주세요"
+                            className="h-12 w-full rounded-lg border border-[#CCCCD1] bg-[#F5F5F7] px-4 text-sm font-semibold text-[#333338] outline-none transition placeholder:text-[#B5B5BA] focus:border-[#3873E6] disabled:cursor-not-allowed disabled:opacity-60"
+                        />
+
+                        <p className="mt-2 text-right text-xs text-[#808085]">
+                            {formState.title.length}/
+                            {CREATE_LOBBY_POLICY.TITLE_MAX_LENGTH}
+                        </p>
+                    </section>
+
+                    <section className="mb-5 grid grid-cols-2 gap-4">
+                        <div>
+                            <label
+                                htmlFor="create-lobby-max-players"
+                                className="mb-3 block text-sm font-bold text-[#333338]"
+                            >
+                                최대 인원
+                            </label>
+
+                            <select
+                                id="create-lobby-max-players"
+                                value={formState.maxPlayers}
+                                disabled={isSubmitting}
+                                onChange={handleMaxPlayersChange}
+                                className="h-12 w-full rounded-lg border border-[#CCCCD1] bg-[#F5F5F7] px-4 text-sm font-semibold text-[#333338] outline-none transition focus:border-[#3873E6] disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                                {MAX_PLAYER_OPTIONS.map((maxPlayers) => (
+                                    <option
+                                        key={maxPlayers}
+                                        value={maxPlayers}
+                                    >
+                                        {maxPlayers}명
+                                    </option>
+                                ))}
+                            </select>
+                        </div>
+
+                        <div>
+                            <span className="mb-3 block text-sm font-bold text-[#333338]">
+                                공개 설정
+                            </span>
+
+                            <div className="grid h-12 grid-cols-2 rounded-lg border border-[#CCCCD1] bg-[#F5F5F7] p-1">
+                                <button
+                                    type="button"
+                                    disabled={isSubmitting}
+                                    onClick={() => updateFormState(
+                                        'isPrivate',
+                                        false,
+                                    )}
+                                    className={`rounded-md text-sm font-bold transition disabled:cursor-not-allowed ${
+                                        !formState.isPrivate
+                                            ? 'bg-[#3873E6] text-white shadow-sm'
+                                            : 'text-[#808085] hover:text-[#333338]'
+                                    }`}
+                                >
+                                    공개
+                                </button>
+
+                                <button
+                                    type="button"
+                                    disabled={isSubmitting}
+                                    onClick={() => updateFormState(
+                                        'isPrivate',
+                                        true,
+                                    )}
+                                    className={`rounded-md text-sm font-bold transition disabled:cursor-not-allowed ${
+                                        formState.isPrivate
+                                            ? 'bg-[#3873E6] text-white shadow-sm'
+                                            : 'text-[#808085] hover:text-[#333338]'
+                                    }`}
+                                >
+                                    비공개
+                                </button>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section className="mb-5 grid grid-cols-2 gap-4">
+                        <div>
+                            <label
+                                htmlFor="create-lobby-round-count"
+                                className="mb-3 block text-sm font-bold text-[#333338]"
+                            >
+                                라운드 수
+                            </label>
+
+                            <input
+                                id="create-lobby-round-count"
+                                type="number"
+                                min={CREATE_LOBBY_POLICY.MIN_ROUND_COUNT}
+                                max={CREATE_LOBBY_POLICY.MAX_ROUND_COUNT}
+                                value={formState.roundCount}
+                                disabled={isSubmitting}
+                                onChange={handleRoundCountChange}
+                                placeholder="기본값"
+                                className="h-12 w-full rounded-lg border border-[#CCCCD1] bg-[#F5F5F7] px-4 text-sm font-semibold text-[#333338] outline-none transition placeholder:text-[#B5B5BA] focus:border-[#3873E6] disabled:cursor-not-allowed disabled:opacity-60"
+                            />
+
+                            <p className="mt-2 text-xs text-[#808085]">
+                                {CREATE_LOBBY_POLICY.MIN_ROUND_COUNT}~
+                                {CREATE_LOBBY_POLICY.MAX_ROUND_COUNT}, 비우면
+                                서버 기본값
+                            </p>
+                        </div>
+
+                        <div>
+                            <label
+                                htmlFor="create-lobby-time-limit"
+                                className="mb-3 block text-sm font-bold text-[#333338]"
+                            >
+                                제한 시간(초)
+                            </label>
+
+                            <input
+                                id="create-lobby-time-limit"
+                                type="number"
+                                min={
+                                    CREATE_LOBBY_POLICY.MIN_TIME_LIMIT_SECONDS
+                                }
+                                max={
+                                    CREATE_LOBBY_POLICY.MAX_TIME_LIMIT_SECONDS
+                                }
+                                value={formState.timeLimitSeconds}
+                                disabled={isSubmitting}
+                                onChange={handleTimeLimitChange}
+                                placeholder="기본값"
+                                className="h-12 w-full rounded-lg border border-[#CCCCD1] bg-[#F5F5F7] px-4 text-sm font-semibold text-[#333338] outline-none transition placeholder:text-[#B5B5BA] focus:border-[#3873E6] disabled:cursor-not-allowed disabled:opacity-60"
+                            />
+
+                            <p className="mt-2 text-xs text-[#808085]">
+                                {CREATE_LOBBY_POLICY.MIN_TIME_LIMIT_SECONDS}~
+                                {CREATE_LOBBY_POLICY.MAX_TIME_LIMIT_SECONDS}초,
+                                비우면 서버 기본값
+                            </p>
+                        </div>
+                    </section>
+
+                    {errorMessage && (
+                        <div
+                            role="alert"
+                            className="mb-5 rounded-lg bg-red-50 px-4 py-3 text-sm font-semibold text-red-500"
+                        >
+                            {errorMessage}
+                        </div>
+                    )}
+
+                    <div className="flex gap-3">
+                        <button
+                            type="button"
+                            onClick={handleClose}
+                            disabled={isSubmitting}
+                            className="h-12 flex-1 rounded-lg border border-[#CCCCD1] font-bold text-[#333338] hover:bg-[#F5F5F7] disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                            취소
+                        </button>
+
+                        <button
+                            type="submit"
+                            disabled={isSubmitting}
+                            className="h-12 flex-1 rounded-lg bg-[#3873E6] font-bold text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:bg-blue-300"
+                        >
+                            {isSubmitting ? '생성 중...' : '생성하기'}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+}

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -40,6 +40,7 @@ export const API_ENDPOINTS = {
     },
 
     LOBBY: {
+        CREATE: createApiEndpoint('/api/lobbies'),
         JOIN: createApiEndpoint('/api/lobbies/join'),
         LIST: createApiEndpoint('/api/lobbies'),
     },

--- a/src/constants/lobby.ts
+++ b/src/constants/lobby.ts
@@ -9,3 +9,14 @@ export const INVITE_CODE_MESSAGES = {
     INVALID_LENGTH: '초대 코드는 6자리여야 합니다.',
     INVALID_FORMAT: '초대 코드는 영문 대문자와 숫자만 입력할 수 있습니다.',
 } as const;
+
+export const CREATE_LOBBY_POLICY = {
+    TITLE_MAX_LENGTH: 255,
+    MIN_PLAYERS: 2,
+    MAX_PLAYERS: 8,
+    DEFAULT_MAX_PLAYERS: 4,
+    MIN_ROUND_COUNT: 1,
+    MAX_ROUND_COUNT: 20,
+    MIN_TIME_LIMIT_SECONDS: 10,
+    MAX_TIME_LIMIT_SECONDS: 120,
+} as const;

--- a/src/schemas/lobbySchema.ts
+++ b/src/schemas/lobbySchema.ts
@@ -16,6 +16,18 @@ export const joinLobbyResponseSchema = z.object({
     mapCategory: lobbyCategorySchema.nullable(),
 });
 
+export const createLobbyResponseSchema = z.object({
+    lobbyId: z.number().int().positive(),
+    inviteCode: z.string().regex(/^[A-Z0-9]{6}$/),
+    title: z.string().min(1),
+    maxPlayers: z.number().int().min(2).max(8),
+    isPrivate: z.boolean(),
+    status: lobbyStatusSchema,
+    mapId: z.number().int().positive().nullable(),
+    mapTitle: z.string().min(1).nullable(),
+    mapCategory: lobbyCategorySchema.nullable(),
+});
+
 export const lobbyListItemSchema = z.object({
     code: z.string().min(1),
     hostId: z.string().min(1),

--- a/src/types/lobby.ts
+++ b/src/types/lobby.ts
@@ -63,3 +63,24 @@ export interface JoinLobbyResponse {
     mapTitle: string | null;
     mapCategory: LobbyCategory | null;
 }
+
+export interface CreateLobbyRequest {
+    title: string;
+    maxPlayers: number;
+    isPrivate: boolean;
+    mapId: number | null;
+    roundCount?: number | null;
+    timeLimitSeconds?: number | null;
+}
+
+export interface CreateLobbyResponse {
+    lobbyId: number;
+    inviteCode: string;
+    title: string;
+    maxPlayers: number;
+    isPrivate: boolean;
+    status: LobbyStatus;
+    mapId: number | null;
+    mapTitle: string | null;
+    mapCategory: LobbyCategory | null;
+}


### PR DESCRIPTION
## 📣 Related Issue

- #37

## 📝 Summary

- 게스트와 정식 회원 모두 사용할 수 있는 로비 생성 모달을 추가했습니다.
- 기존 `+ 로비 만들기` 버튼의 alert 동작을 제거하고, `CreateLobbyModal` 오픈으로 연결했습니다.
- 로비 제목, 최대 인원, 공개/비공개, 라운드 수, 제한 시간 입력 UI와 검증을 추가했습니다.
- BE `POST /api/lobbies` 계약에 맞춰 `createLobby` API 함수를 추가했습니다.
- 로비 생성 요청은 `fetchWithAuth`를 통해 인증 헤더를 포함하도록 구현했습니다.
- 이번 이슈 범위에 맞춰 `mapId`는 항상 `null`로 처리했습니다.
- `roundCount`, `timeLimitSeconds`는 빈 값이면 요청에서 생략하여 BE 기본값을 사용할 수 있도록 처리했습니다.
- 생성 성공 시 응답의 `inviteCode`를 사용해 `/lobby/{inviteCode}`로 이동하도록 구현했습니다.
- 생성 중 중복 제출 방지, 로딩 상태, 에러 메시지 표시, 모달 닫기 시 상태 초기화를 추가했습니다.

## 🙏PR point

- 로비 생성은 게스트와 정식 회원 모두 가능하므로 `isGuest` 여부로 생성 버튼을 숨기지 않았습니다.
- 맵 선택 UI는 이번 PR 범위에서 제외했고, `mapId: null` 로비 생성만 처리했습니다.
- 로비 상세 화면, WebSocket 입장 처리, ready/start 기능은 이번 PR 범위에 포함하지 않았습니다.
- 실제 생성 성공 플로우는 BE `develop`의 `POST /api/lobbies` 응답과 연결해 한 번 더 확인이 필요합니다.
- `npm run lint`, `npm run build`, `git diff --check` 모두 통과했습니다.
- 기존 `public/mockServiceWorker.js` unused eslint-disable warning 1건은 남아 있습니다.

## 📬 Reference

- BE 로비 생성 API 계약
  ```ts
  type CreateLobbyRequest = {
    title: string;
    maxPlayers: number;
    isPrivate: boolean;
    mapId: number | null;
    roundCount?: number | null;
    timeLimitSeconds?: number | null;
  };

  type CreateLobbyResponse = {
    lobbyId: number;
    inviteCode: string;
    title: string;
    maxPlayers: number;
    isPrivate: boolean;
    status: string;
    mapId: number | null;
    mapTitle: string | null;
    mapCategory: string | null;
  };
  ```