### PR TITLE
[Feat/#38] 로비 상세 조회와 입장 동기화 구현

### DIFF
--- a/src/api/lobbyApi.ts
+++ b/src/api/lobbyApi.ts
@@ -4,6 +4,7 @@ import { createApiError } from './apiError';
 import {
     createLobbyResponseSchema,
     joinLobbyResponseSchema,
+    lobbyDetailResponseSchema,
     lobbyListResponseSchema,
 } from '../schemas/lobbySchema';
 
@@ -12,9 +13,11 @@ import type {
     CreateLobbyResponse,
     JoinLobbyRequest,
     JoinLobbyResponse,
+    LobbyDetailResponse,
     LobbyListItem,
     LobbyListQueryParams,
     LobbyPageResponse,
+    UpdateLobbyReadyRequest,
 } from '../types/lobby';
 
 const JSON_CONTENT_TYPE = 'application/json';
@@ -22,6 +25,9 @@ const JSON_CONTENT_TYPE = 'application/json';
 const DEFAULT_CREATE_LOBBY_ERROR_MESSAGE = '로비 생성에 실패했습니다.';
 const DEFAULT_JOIN_LOBBY_ERROR_MESSAGE = '로비 입장에 실패했습니다.';
 const DEFAULT_FETCH_LOBBY_LIST_ERROR_MESSAGE = '로비 목록을 불러오는 데 실패했습니다.';
+const DEFAULT_FETCH_LOBBY_DETAIL_ERROR_MESSAGE = '로비 정보를 불러오는 데 실패했습니다.';
+const DEFAULT_UPDATE_LOBBY_READY_ERROR_MESSAGE = '준비 상태 변경에 실패했습니다.';
+const DEFAULT_START_LOBBY_GAME_ERROR_MESSAGE = '게임 시작에 실패했습니다.';
 
 function appendNonEmptyParam(
     searchParams: URLSearchParams,
@@ -152,4 +158,64 @@ export async function joinLobbyByInviteCode(
     }
 
     return parsed.data;
+}
+
+export async function getLobbyDetail(
+    code: string,
+): Promise<LobbyDetailResponse> {
+    const response = await fetchWithAuth(API_ENDPOINTS.LOBBY.DETAIL(code));
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            DEFAULT_FETCH_LOBBY_DETAIL_ERROR_MESSAGE,
+        );
+    }
+
+    const payload = (await response.json()) as unknown;
+    const parsed = lobbyDetailResponseSchema.safeParse(payload);
+
+    if (!parsed.success) {
+        console.error(
+            '[lobbyApi] 로비 상세 응답 검증 실패:',
+            parsed.error,
+        );
+
+        throw new Error('로비 상세 응답 형식이 올바르지 않습니다.');
+    }
+
+    return parsed.data;
+}
+
+export async function updateLobbyReady(
+    code: string,
+    request: UpdateLobbyReadyRequest,
+): Promise<void> {
+    const response = await fetchWithAuth(API_ENDPOINTS.LOBBY.READY(code), {
+        method: 'PATCH',
+        headers: {
+            'Content-Type': JSON_CONTENT_TYPE,
+        },
+        body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            DEFAULT_UPDATE_LOBBY_READY_ERROR_MESSAGE,
+        );
+    }
+}
+
+export async function startLobbyGame(code: string): Promise<void> {
+    const response = await fetchWithAuth(API_ENDPOINTS.LOBBY.START(code), {
+        method: 'POST',
+    });
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            DEFAULT_START_LOBBY_GAME_ERROR_MESSAGE,
+        );
+    }
 }

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -43,5 +43,8 @@ export const API_ENDPOINTS = {
         CREATE: createApiEndpoint('/api/lobbies'),
         JOIN: createApiEndpoint('/api/lobbies/join'),
         LIST: createApiEndpoint('/api/lobbies'),
+        DETAIL: (code: string) => createApiEndpoint(`/api/lobbies/${code}`),
+        READY: (code: string) => createApiEndpoint(`/api/lobbies/${code}/ready`),
+        START: (code: string) => createApiEndpoint(`/api/lobbies/${code}/start`),
     },
 } as const;

--- a/src/constants/socketEvents.ts
+++ b/src/constants/socketEvents.ts
@@ -30,4 +30,15 @@ export const SOCKET_SUBSCRIBE = {
     // 채팅 메시지뿐 아니라 게임 이벤트 (라운드 시작/종료, 정답 알림 등)도
     // 이 채널로 수신하며, 메시지 안에 type 필드로 어떤 종류인지 구분한다.
     LOBBY: (code: string) => `/topic/lobby/${code}`,
+
+    // 특정 로비의 참여자/ready 등 상태 변경 알림을 수신한다.
+    LOBBY_REFRESH: (code: string) => `/topic/lobby/${code}/refresh`,
+
+    // 특정 로비의 게임 시작 이벤트를 수신한다.
+    LOBBY_GAME: (code: string) => `/topic/lobby/${code}/game`,
+} as const;
+
+export const SOCKET_MESSAGES = {
+    REFRESH_LOBBY_INFO: 'REFRESH_LOBBY_INFO',
+    GAME_STARTED: 'GAME_STARTED',
 } as const;

--- a/src/hooks/useLobbyDetail.ts
+++ b/src/hooks/useLobbyDetail.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getLobbyDetail } from '../api/lobbyApi';
+
+import type { LobbyDetailResponse } from '../types/lobby';
+
+export const lobbyDetailQueryKey = (inviteCode: string) => [
+    'lobbyDetail',
+    inviteCode,
+] as const;
+
+export function useLobbyDetail(inviteCode: string | undefined) {
+    const normalizedInviteCode = inviteCode?.trim() ?? '';
+
+    return useQuery<LobbyDetailResponse>({
+        queryKey: lobbyDetailQueryKey(normalizedInviteCode),
+        queryFn: () => getLobbyDetail(normalizedInviteCode),
+        enabled: normalizedInviteCode.length > 0,
+    });
+}
+

--- a/src/hooks/useLobbySocket.ts
+++ b/src/hooks/useLobbySocket.ts
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { SOCKET_MESSAGES, SOCKET_SUBSCRIBE } from '../constants/socketEvents';
+import { useSocketStore } from '../store/useSocketStore';
+import { lobbyDetailQueryKey } from './useLobbyDetail';
+
+type LobbyGameStatus = 'idle' | 'started';
+
+function parseSocketMessageType(body: string): string {
+    try {
+        const parsed = JSON.parse(body) as unknown;
+
+        if (typeof parsed === 'string') {
+            return parsed;
+        }
+
+        if (
+            parsed &&
+            typeof parsed === 'object' &&
+            'type' in parsed &&
+            typeof parsed.type === 'string'
+        ) {
+            return parsed.type;
+        }
+    } catch {
+        return body;
+    }
+
+    return body;
+}
+
+export function useLobbySocket(inviteCode: string | undefined) {
+    const normalizedInviteCode = inviteCode?.trim() ?? '';
+    const queryClient = useQueryClient();
+    const stompClient = useSocketStore((state) => state.stompClient);
+    const connectionStatus = useSocketStore((state) => state.connectionStatus);
+    const [gameStartedInviteCode, setGameStartedInviteCode] =
+        useState<string | null>(null);
+
+    useEffect(() => {
+        if (
+            !normalizedInviteCode ||
+            !stompClient ||
+            connectionStatus !== 'connected'
+        ) {
+            return;
+        }
+
+        const lobbySubscription = stompClient.subscribe(
+            SOCKET_SUBSCRIBE.LOBBY(normalizedInviteCode),
+            () => {
+                // 이 구독 자체가 BE의 로비 참여자 등록 트리거다.
+            },
+        );
+
+        const refreshSubscription = stompClient.subscribe(
+            SOCKET_SUBSCRIBE.LOBBY_REFRESH(normalizedInviteCode),
+            (frame) => {
+                const messageType = parseSocketMessageType(frame.body);
+
+                if (messageType !== SOCKET_MESSAGES.REFRESH_LOBBY_INFO) {
+                    return;
+                }
+
+                void queryClient.invalidateQueries({
+                    queryKey: lobbyDetailQueryKey(normalizedInviteCode),
+                });
+            },
+        );
+
+        const gameSubscription = stompClient.subscribe(
+            SOCKET_SUBSCRIBE.LOBBY_GAME(normalizedInviteCode),
+            (frame) => {
+                const messageType = parseSocketMessageType(frame.body);
+
+                if (messageType === SOCKET_MESSAGES.GAME_STARTED) {
+                    setGameStartedInviteCode(normalizedInviteCode);
+                }
+            },
+        );
+
+        void queryClient.invalidateQueries({
+            queryKey: lobbyDetailQueryKey(normalizedInviteCode),
+        });
+
+        return () => {
+            lobbySubscription.unsubscribe();
+            refreshSubscription.unsubscribe();
+            gameSubscription.unsubscribe();
+        };
+    }, [normalizedInviteCode, stompClient, connectionStatus, queryClient]);
+
+    const gameStatus: LobbyGameStatus =
+        gameStartedInviteCode === normalizedInviteCode ? 'started' : 'idle';
+
+    return {
+        connectionStatus,
+        gameStatus,
+    };
+}

--- a/src/pages/LobbyRoom.tsx
+++ b/src/pages/LobbyRoom.tsx
@@ -1,45 +1,508 @@
-import { useParams } from 'react-router-dom';
+import { useMemo, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate, useParams } from 'react-router-dom';
 
-/**
- * @description 실제 게임이 시작되기 전, 플레이어들이 모이는 '로비(방)' 컴포넌트입니다.
- * 6자리의 고유 초대 코드를 기반으로 특정 방을 식별합니다.
- */
+import { startLobbyGame, updateLobbyReady } from '../api/lobbyApi';
+import { NavigationBar } from '../components/common/NavigationBar';
+import { LobbyFooter } from '../components/lobby/LobbyFooter';
+import {
+    lobbyDetailQueryKey,
+    useLobbyDetail,
+} from '../hooks/useLobbyDetail';
+import { useLobbySocket } from '../hooks/useLobbySocket';
+import { useAuthStore } from '../store/useAuthStore';
 
-export function LobbyRoom() {
-    /**
-     * [React Router: useParams 활용]
-     * App.tsx에서 정의된 Route 경로가 "/lobby/:inviteCode"일 때,
-     * URL에 입력된 실제 값(예: /lobby/XK32WL -> XK32WL)을 객체 형태로 가져옵니다.
-     * * 기능명세서에 명시된 '6자리 고유 코드 기반 입장' 기능을 구현하는 핵심 훅입니다.
-     */
-    const { inviteCode } = useParams<{ inviteCode: string }>();
+import type { LobbyPlayerResponse } from '../types/lobby';
+
+interface LobbyActionMessage {
+    inviteCode: string;
+    message: string;
+}
+
+const SOCKET_STATUS_LABEL = {
+    connected: 'connected',
+    connecting: 'connecting',
+    disconnected: 'disconnected',
+} as const;
+
+const SOCKET_STATUS_CLASS_NAME = {
+    connected: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+    connecting: 'bg-amber-50 text-amber-700 ring-amber-200',
+    disconnected: 'bg-red-50 text-red-700 ring-red-200',
+} as const;
+
+function getErrorMessage(error: unknown, fallbackMessage: string) {
+    if (error instanceof Error && error.message) {
+        return error.message;
+    }
+
+    return fallbackMessage;
+}
+
+function maskUserIdentifier(userIdentifier: string) {
+    if (userIdentifier.length <= 10) {
+        return userIdentifier;
+    }
+
+    return `${userIdentifier.slice(0, 4)}...${userIdentifier.slice(-4)}`;
+}
+
+function formatMapInfo(
+    mapTitle: string | null,
+    mapCategory: string | null,
+) {
+    if (!mapTitle) {
+        return '선택된 맵 없음';
+    }
+
+    return mapCategory ? `${mapTitle} · ${mapCategory}` : mapTitle;
+}
+
+function PlayerReadyBadge({ player }: { player: LobbyPlayerResponse }) {
+    if (player.host) {
+        return (
+            <span className="rounded-full bg-blue-50 px-3 py-1 text-xs font-bold text-blue-700 ring-1 ring-blue-100">
+                방장
+            </span>
+        );
+    }
 
     return (
-        // 레이아웃: 화면 중앙 정렬 및 게임 서비스 특유의 다크 테마 적용
-        <div className="flex flex-col items-center justify-center min-h-screen bg-black text-white">
-            <h1 className="text-3xl font-bold text-green-400 mb-4">
-                🎮 게임 대기실
-            </h1>
+        <span
+            className={`rounded-full px-3 py-1 text-xs font-bold ring-1 ${
+                player.ready
+                    ? 'bg-emerald-50 text-emerald-700 ring-emerald-100'
+                    : 'bg-gray-100 text-gray-500 ring-gray-200'
+            }`}
+        >
+            {player.ready ? '준비 완료' : '대기 중'}
+        </span>
+    );
+}
 
-            <div className="bg-gray-900 p-6 rounded-xl border border-gray-800 shadow-2xl">
-                <p className="text-gray-300">
-                    현재 입장한 방의 초대 코드:
-                    {/* font-mono: 코드의 가독성을 높이기 위해 고정폭 글꼴 사용 */}
-                    <span className="ml-2 font-mono text-yellow-400 bg-gray-800 px-3 py-1 rounded-md border border-yellow-400/30">
-                        {inviteCode}
-                    </span>
-                </p>
+export function LobbyRoom() {
+    const { inviteCode: inviteCodeParam } = useParams<{
+        inviteCode: string;
+    }>();
+    const inviteCode = inviteCodeParam?.trim();
+    const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    const userIdentifier = useAuthStore((state) => state.userIdentifier);
+    const { connectionStatus, gameStatus } = useLobbySocket(inviteCode);
+    const {
+        data: lobbyDetail,
+        isLoading,
+        isError,
+        error,
+    } = useLobbyDetail(inviteCode);
 
-                {/* [아키텍처 참고]
-                    실제 구현 시에는 이 inviteCode를 사용하여
-                    1. 백엔드 API로 방 정보를 조회(TanStack Query)
-                    2. WebSocket 채널(/topic/lobby/{inviteCode})에 접속하는 로직이 추가됩니다.
-                */}
+    const [actionMessage, setActionMessage] =
+        useState<LobbyActionMessage | null>(null);
+    const [actionErrorMessage, setActionErrorMessage] =
+        useState<LobbyActionMessage | null>(null);
+
+    const currentPlayer = useMemo(() => {
+        if (!lobbyDetail || !userIdentifier) {
+            return null;
+        }
+
+        return lobbyDetail.players.find(
+            (player) => player.userIdentifier === userIdentifier,
+        ) ?? null;
+    }, [lobbyDetail, userIdentifier]);
+
+    const isHost = Boolean(
+        lobbyDetail &&
+        userIdentifier &&
+        lobbyDetail.hostId === userIdentifier,
+    );
+    const currentReady = currentPlayer?.ready ?? false;
+
+    const invalidateLobbyDetail = async () => {
+        if (!inviteCode) {
+            return;
+        }
+
+        await queryClient.invalidateQueries({
+            queryKey: lobbyDetailQueryKey(inviteCode),
+        });
+    };
+
+    const readyMutation = useMutation({
+        mutationFn: (ready: boolean) => {
+            if (!inviteCode) {
+                throw new Error('초대 코드가 올바르지 않습니다.');
+            }
+
+            return updateLobbyReady(inviteCode, { ready });
+        },
+        onMutate: () => {
+            setActionMessage(null);
+            setActionErrorMessage(null);
+        },
+        onSuccess: async () => {
+            await invalidateLobbyDetail();
+        },
+        onError: (mutationError) => {
+            if (!inviteCode) {
+                return;
+            }
+
+            setActionErrorMessage({
+                inviteCode,
+                message: getErrorMessage(
+                    mutationError,
+                    '준비 상태 변경에 실패했습니다.',
+                ),
+            });
+        },
+    });
+
+    const startMutation = useMutation({
+        mutationFn: () => {
+            if (!inviteCode) {
+                throw new Error('초대 코드가 올바르지 않습니다.');
+            }
+
+            return startLobbyGame(inviteCode);
+        },
+        onMutate: () => {
+            setActionMessage(null);
+            setActionErrorMessage(null);
+        },
+        onSuccess: async () => {
+            if (inviteCode) {
+                setActionMessage({
+                    inviteCode,
+                    message: '게임 시작 요청을 보냈습니다.',
+                });
+            }
+
+            await invalidateLobbyDetail();
+        },
+        onError: (mutationError) => {
+            if (!inviteCode) {
+                return;
+            }
+
+            setActionErrorMessage({
+                inviteCode,
+                message: getErrorMessage(
+                    mutationError,
+                    '게임 시작에 실패했습니다.',
+                ),
+            });
+        },
+    });
+
+    const handleReadyClick = () => {
+        if (!currentPlayer || isHost || readyMutation.isPending) {
+            return;
+        }
+
+        readyMutation.mutate(!currentReady);
+    };
+
+    const handleStartClick = () => {
+        if (!isHost || !lobbyDetail?.canStart || startMutation.isPending) {
+            return;
+        }
+
+        startMutation.mutate();
+    };
+
+    if (!inviteCode) {
+        return (
+            <div className="flex min-h-screen flex-col bg-[#F5F5F7]">
+                <NavigationBar />
+
+                <main className="flex flex-1 items-center justify-center px-9">
+                    <section className="w-full max-w-xl rounded-lg bg-white px-8 py-10 text-center shadow-sm ring-1 ring-gray-200">
+                        <h1 className="mb-4 text-2xl font-bold text-gray-900">
+                            잘못된 로비 접근입니다.
+                        </h1>
+                        <p className="mb-6 text-sm text-gray-500">
+                            초대 코드가 포함된 로비 주소로 다시 접속해주세요.
+                        </p>
+                        <button
+                            type="button"
+                            onClick={() => navigate('/lobbies')}
+                            className="rounded-lg bg-[#0B1E46] px-5 py-3 text-sm font-bold text-white hover:bg-[#12306B]"
+                        >
+                            로비 목록으로 이동
+                        </button>
+                    </section>
+                </main>
+
+                <LobbyFooter />
             </div>
+        );
+    }
 
-            <p className="mt-8 text-sm text-gray-500">
-                친구들에게 초대 코드를 공유하여 함께 게임을 즐겨보세요!
-            </p>
+    if (isLoading) {
+        return (
+            <div className="flex min-h-screen flex-col bg-[#F5F5F7]">
+                <NavigationBar />
+
+                <main className="flex flex-1 items-center justify-center text-gray-500">
+                    로비 정보를 불러오는 중...
+                </main>
+
+                <LobbyFooter />
+            </div>
+        );
+    }
+
+    if (isError || !lobbyDetail) {
+        return (
+            <div className="flex min-h-screen flex-col bg-[#F5F5F7]">
+                <NavigationBar />
+
+                <main className="flex flex-1 items-center justify-center px-9">
+                    <section className="w-full max-w-xl rounded-lg bg-white px-8 py-10 text-center shadow-sm ring-1 ring-gray-200">
+                        <h1 className="mb-4 text-2xl font-bold text-gray-900">
+                            로비 정보를 불러오지 못했습니다.
+                        </h1>
+                        <p className="mb-6 text-sm text-red-500">
+                            {getErrorMessage(
+                                error,
+                                '잠시 후 다시 시도해주세요.',
+                            )}
+                        </p>
+                        <button
+                            type="button"
+                            onClick={() => navigate('/lobbies')}
+                            className="rounded-lg bg-[#0B1E46] px-5 py-3 text-sm font-bold text-white hover:bg-[#12306B]"
+                        >
+                            로비 목록으로 이동
+                        </button>
+                    </section>
+                </main>
+
+                <LobbyFooter />
+            </div>
+        );
+    }
+
+    const isReadyButtonDisabled =
+        readyMutation.isPending || !currentPlayer || isHost;
+    const isStartButtonDisabled =
+        startMutation.isPending || !lobbyDetail.canStart;
+    const currentActionMessage =
+        actionMessage?.inviteCode === inviteCode ? actionMessage.message : null;
+    const currentActionErrorMessage =
+        actionErrorMessage?.inviteCode === inviteCode
+            ? actionErrorMessage.message
+            : null;
+
+    return (
+        <div className="flex min-h-screen flex-col bg-[#F5F5F7]">
+            <NavigationBar />
+
+            <main className="flex flex-1 flex-col gap-5 px-9 py-6 text-left">
+                <section className="flex items-start justify-between gap-6 rounded-lg bg-white px-8 py-7 shadow-sm ring-1 ring-gray-200">
+                    <div className="min-w-0">
+                        <div className="mb-3 flex flex-wrap items-center gap-3">
+                            <span className="rounded-full bg-gray-100 px-3 py-1 text-xs font-bold text-gray-600">
+                                {lobbyDetail.status}
+                            </span>
+                            <span
+                                className={`rounded-full px-3 py-1 text-xs font-bold ring-1 ${
+                                    SOCKET_STATUS_CLASS_NAME[connectionStatus]
+                                }`}
+                            >
+                                socket {SOCKET_STATUS_LABEL[connectionStatus]}
+                            </span>
+                        </div>
+
+                        <h1 className="m-0 truncate text-3xl font-bold text-gray-900">
+                            {lobbyDetail.title}
+                        </h1>
+
+                        <p className="mt-3 text-sm text-gray-500">
+                            초대 코드
+                            <span className="ml-2 rounded-md bg-gray-100 px-3 py-1 font-mono text-sm font-bold text-gray-900">
+                                {lobbyDetail.inviteCode}
+                            </span>
+                        </p>
+                    </div>
+
+                    <div className="grid min-w-[220px] grid-cols-2 gap-3 text-center">
+                        <div className="rounded-lg bg-[#F5F5F7] px-4 py-3">
+                            <p className="text-xs font-bold text-gray-500">
+                                현재 인원
+                            </p>
+                            <p className="mt-1 text-xl font-bold text-gray-900">
+                                {lobbyDetail.currentPlayers}/
+                                {lobbyDetail.maxPlayers}
+                            </p>
+                        </div>
+
+                        <div className="rounded-lg bg-[#F5F5F7] px-4 py-3">
+                            <p className="text-xs font-bold text-gray-500">
+                                내 역할
+                            </p>
+                            <p className="mt-1 text-xl font-bold text-gray-900">
+                                {isHost ? '방장' : '참가자'}
+                            </p>
+                        </div>
+                    </div>
+                </section>
+
+                {(currentActionErrorMessage ||
+                    currentActionMessage ||
+                    gameStatus === 'started') && (
+                    <section
+                        role={currentActionErrorMessage ? 'alert' : 'status'}
+                        className={`rounded-lg px-5 py-4 text-sm font-bold ${
+                            currentActionErrorMessage
+                                ? 'bg-red-50 text-red-600 ring-1 ring-red-100'
+                                : 'bg-blue-50 text-blue-700 ring-1 ring-blue-100'
+                        }`}
+                    >
+                        {currentActionErrorMessage ??
+                            (gameStatus === 'started'
+                                ? '게임이 시작되었습니다. 게임 화면 전환은 추후 연결됩니다.'
+                                : currentActionMessage)}
+                    </section>
+                )}
+
+                <section className="grid flex-1 grid-cols-[minmax(0,1fr)_360px] gap-5">
+                    <div className="rounded-lg bg-white p-6 shadow-sm ring-1 ring-gray-200">
+                        <div className="mb-5 flex items-center justify-between gap-4">
+                            <h2 className="m-0 text-xl font-bold text-gray-900">
+                                참여자
+                            </h2>
+                            <span className="text-sm font-semibold text-gray-500">
+                                {lobbyDetail.players.length}명 표시 중
+                            </span>
+                        </div>
+
+                        {lobbyDetail.players.length > 0 ? (
+                            <ul className="grid grid-cols-2 gap-3">
+                                {lobbyDetail.players.map((player) => (
+                                    <li
+                                        key={player.userIdentifier}
+                                        className="flex min-h-20 items-center justify-between gap-4 rounded-lg border border-gray-200 px-4 py-3"
+                                    >
+                                        <div className="min-w-0">
+                                            <p className="truncate font-mono text-sm font-bold text-gray-900">
+                                                {maskUserIdentifier(
+                                                    player.userIdentifier,
+                                                )}
+                                            </p>
+                                            <p className="mt-1 text-xs font-semibold text-gray-500">
+                                                {player.userIdentifier ===
+                                                userIdentifier
+                                                    ? '나'
+                                                    : '플레이어'}
+                                            </p>
+                                        </div>
+
+                                        <PlayerReadyBadge player={player} />
+                                    </li>
+                                ))}
+                            </ul>
+                        ) : (
+                            <div className="flex min-h-52 items-center justify-center rounded-lg border border-dashed border-gray-300 text-sm font-semibold text-gray-400">
+                                아직 표시할 참여자가 없습니다.
+                            </div>
+                        )}
+                    </div>
+
+                    <aside className="flex flex-col gap-5">
+                        <section className="rounded-lg bg-white p-6 shadow-sm ring-1 ring-gray-200">
+                            <h2 className="m-0 text-xl font-bold text-gray-900">
+                                로비 설정
+                            </h2>
+
+                            <dl className="mt-5 space-y-4 text-sm">
+                                <div className="flex justify-between gap-4">
+                                    <dt className="font-semibold text-gray-500">
+                                        맵
+                                    </dt>
+                                    <dd className="max-w-[190px] text-right font-bold text-gray-900">
+                                        {formatMapInfo(
+                                            lobbyDetail.mapTitle,
+                                            lobbyDetail.mapCategory,
+                                        )}
+                                    </dd>
+                                </div>
+
+                                <div className="flex justify-between gap-4">
+                                    <dt className="font-semibold text-gray-500">
+                                        라운드 수
+                                    </dt>
+                                    <dd className="font-bold text-gray-900">
+                                        {lobbyDetail.roundCount}라운드
+                                    </dd>
+                                </div>
+
+                                <div className="flex justify-between gap-4">
+                                    <dt className="font-semibold text-gray-500">
+                                        제한 시간
+                                    </dt>
+                                    <dd className="font-bold text-gray-900">
+                                        {lobbyDetail.timeLimitSeconds}초
+                                    </dd>
+                                </div>
+                            </dl>
+                        </section>
+
+                        <section className="rounded-lg bg-white p-6 shadow-sm ring-1 ring-gray-200">
+                            <h2 className="m-0 text-xl font-bold text-gray-900">
+                                액션
+                            </h2>
+
+                            {isHost ? (
+                                <div className="mt-5">
+                                    <button
+                                        type="button"
+                                        onClick={handleStartClick}
+                                        disabled={isStartButtonDisabled}
+                                        className="h-12 w-full rounded-lg bg-[#0B1E46] text-sm font-bold text-white hover:bg-[#12306B] disabled:cursor-not-allowed disabled:bg-gray-300"
+                                    >
+                                        {startMutation.isPending
+                                            ? '시작 요청 중...'
+                                            : '게임 시작'}
+                                    </button>
+                                    <p className="mt-3 text-xs font-semibold text-gray-500">
+                                        {lobbyDetail.canStart
+                                            ? '현재 조회 기준으로 시작할 수 있습니다.'
+                                            : '모든 참가자가 준비하면 시작할 수 있습니다.'}
+                                    </p>
+                                </div>
+                            ) : (
+                                <div className="mt-5">
+                                    <button
+                                        type="button"
+                                        onClick={handleReadyClick}
+                                        disabled={isReadyButtonDisabled}
+                                        className={`h-12 w-full rounded-lg text-sm font-bold text-white disabled:cursor-not-allowed disabled:bg-gray-300 ${
+                                            currentReady
+                                                ? 'bg-gray-700 hover:bg-gray-800'
+                                                : 'bg-[#0B1E46] hover:bg-[#12306B]'
+                                        }`}
+                                    >
+                                        {readyMutation.isPending
+                                            ? '변경 중...'
+                                            : currentReady
+                                                ? '준비 취소'
+                                                : '준비 완료'}
+                                    </button>
+                                    <p className="mt-3 text-xs font-semibold text-gray-500">
+                                        {currentPlayer
+                                            ? '준비 상태는 서버 이벤트로 다시 동기화됩니다.'
+                                            : '참여자 정보 동기화 후 준비할 수 있습니다.'}
+                                    </p>
+                                </div>
+                            )}
+                        </section>
+                    </aside>
+                </section>
+            </main>
+
+            <LobbyFooter />
         </div>
     );
 }

--- a/src/schemas/lobbySchema.ts
+++ b/src/schemas/lobbySchema.ts
@@ -42,6 +42,28 @@ export const lobbyListItemSchema = z.object({
     createdAtEpochMillis: z.number().int().nonnegative().nullable(),
 });
 
+export const lobbyPlayerResponseSchema = z.object({
+    userIdentifier: z.string().min(1),
+    host: z.boolean(),
+    ready: z.boolean(),
+});
+
+export const lobbyDetailResponseSchema = z.object({
+    inviteCode: z.string().min(1),
+    title: z.string().min(1),
+    hostId: z.string().min(1),
+    maxPlayers: z.number().int().positive(),
+    currentPlayers: z.number().int().min(0),
+    status: lobbyStatusSchema,
+    mapId: z.number().int().positive().nullable(),
+    mapTitle: z.string().min(1).nullable(),
+    mapCategory: lobbyCategorySchema.nullable(),
+    roundCount: z.number().int().positive(),
+    timeLimitSeconds: z.number().int().positive(),
+    players: z.array(lobbyPlayerResponseSchema),
+    canStart: z.boolean(),
+});
+
 export const lobbyPageResponseSchema = z.object({
     items: z.array(lobbyListItemSchema),
     page: z.number().int().min(0),

--- a/src/types/lobby.ts
+++ b/src/types/lobby.ts
@@ -64,6 +64,32 @@ export interface JoinLobbyResponse {
     mapCategory: LobbyCategory | null;
 }
 
+export interface LobbyPlayerResponse {
+    userIdentifier: string;
+    host: boolean;
+    ready: boolean;
+}
+
+export interface LobbyDetailResponse {
+    inviteCode: string;
+    title: string;
+    hostId: string;
+    maxPlayers: number;
+    currentPlayers: number;
+    status: LobbyStatus;
+    mapId: number | null;
+    mapTitle: string | null;
+    mapCategory: LobbyCategory | null;
+    roundCount: number;
+    timeLimitSeconds: number;
+    players: LobbyPlayerResponse[];
+    canStart: boolean;
+}
+
+export interface UpdateLobbyReadyRequest {
+    ready: boolean;
+}
+
 export interface CreateLobbyRequest {
     title: string;
     maxPlayers: number;


### PR DESCRIPTION
## 📣 Related Issue

- #38

## 📝 Summary

- `/lobby/:inviteCode` placeholder 화면을 실제 로비 대기실 UI로 교체했습니다.
- `GET /api/lobbies/{code}` 기반 로비 상세 조회 API와 `useLobbyDetail` 훅을 추가했습니다.
- 로비 제목, 초대 코드, 상태, 현재 인원/최대 인원, 맵 정보, 라운드 수, 제한 시간, 참여자 목록, 내 역할, 소켓 상태를 표시하도록 구현했습니다.
- BE 응답 계약에 맞춰 `LobbyDetailResponse`, `LobbyPlayerResponse` 타입과 Zod schema를 추가했습니다.
- `useLobbySocket` 훅을 추가하여 로비 WebSocket 구독을 처리했습니다.
- 실제 입장 처리가 발생하는 `/topic/lobby/{code}`를 먼저 구독하고, 이후 `/topic/lobby/{code}/refresh`, `/topic/lobby/{code}/game`을 구독하도록 구성했습니다.
- `REFRESH_LOBBY_INFO` 수신 시 로비 상세 query를 invalidate하여 최신 상태를 다시 조회하도록 구현했습니다.
- `GAME_STARTED` 수신 시 현재는 임시 안내 상태를 표시하도록 처리했습니다.
- 일반 참여자는 ready 버튼, 방장은 게임 시작 버튼을 볼 수 있도록 역할별 UI를 분기했습니다.
- `PATCH /api/lobbies/{code}/ready`와 `POST /api/lobbies/{code}/start` API를 추가했습니다.
- 요청 중 중복 클릭을 방지하고, 실패 시 BE 에러 메시지를 표시하도록 처리했습니다.

## 🙏PR point

- BE 기준 실제 로비 참여자 등록은 `POST /api/lobbies/join`이 아니라 `/topic/lobby/{code}` 구독 시점에 처리됩니다.
- 따라서 `useLobbySocket`에서 `/topic/lobby/{code}` 구독을 가장 먼저 수행하도록 구성했습니다.
- `/topic/lobby/{code}/refresh`만 구독하면 입장 처리가 되지 않으므로 이 순서가 중요합니다.
- 현재 BE `LobbyPlayerResponse`에는 닉네임이 없어 FE에서는 `userIdentifier`를 일부 마스킹해 표시합니다.
- 게임 시작 후 실제 인게임 화면 이동은 아직 구현하지 않았고, 이번 PR에서는 안내 메시지까지만 처리했습니다.
- 로비 내 맵 변경, 강퇴, 방장 위임, 인게임 화면은 이번 PR 범위에서 제외했습니다.
- `npm run lint`, `npm run build` 모두 통과했습니다.
- 기존 `public/mockServiceWorker.js` unused eslint-disable warning 1건은 남아 있습니다.
- 로컬 브라우저 확인은 BE/MSW 상세 API와 인증 세션이 없어 보호 라우트에서 홈으로 리다이렉트되었습니다. 실데이터 대기실 렌더링은 BE 실행 환경에서 추가 확인이 필요합니다.

## 📬 Reference

- BE 로비 상세 조회 API
  ```ts
  type LobbyDetailResponse = {
    inviteCode: string;
    title: string;
    hostId: string;
    maxPlayers: number;
    currentPlayers: number;
    status: string;
    mapId: number | null;
    mapTitle: string | null;
    mapCategory: string | null;
    roundCount: number;
    timeLimitSeconds: number;
    players: LobbyPlayerResponse[];
    canStart: boolean;
  };
  ```