### PR TITLE
[Feat/#48] 로비 목록 상단바와 카드 UI 개선

### DIFF
--- a/src/components/common/MonomatLogo.tsx
+++ b/src/components/common/MonomatLogo.tsx
@@ -1,0 +1,79 @@
+interface MonomatLogoProps {
+    className?: string;
+}
+
+interface MonomatLogoMarkProps {
+    className?: string;
+}
+
+export function MonomatLogoMark({
+    className = 'h-[37px] w-[37px]',
+}: MonomatLogoMarkProps) {
+    return (
+        <svg
+            aria-hidden
+            className={`${className} shrink-0`}
+            viewBox="0 0 48 48"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <rect
+                x="1.5"
+                y="1.5"
+                width="45"
+                height="45"
+                rx="11"
+                fill="#FEFEFE"
+                stroke="var(--monomat-primary)"
+                strokeWidth="3"
+            />
+            <path
+                d="M20.25 8.95C18.75 8.08 16.88 9.16 16.88 10.89V25.11C16.88 26.84 18.75 27.92 20.25 27.05L32.58 19.94C34.08 19.07 34.08 16.93 32.58 16.06L20.25 8.95Z"
+                fill="var(--monomat-primary)"
+            />
+            <rect
+                x="11"
+                y="31"
+                width="3.5"
+                height="9"
+                rx="1.75"
+                fill="var(--monomat-primary)"
+            />
+            <rect
+                x="18"
+                y="28"
+                width="3.5"
+                height="12"
+                rx="1.75"
+                fill="var(--monomat-primary)"
+            />
+            <rect
+                x="26"
+                y="32"
+                width="3.5"
+                height="9"
+                rx="1.75"
+                fill="var(--monomat-primary)"
+            />
+            <rect
+                x="33.75"
+                y="30"
+                width="3.5"
+                height="10"
+                rx="1.75"
+                fill="var(--monomat-primary)"
+            />
+        </svg>
+    );
+}
+
+export function MonomatLogo({ className = '' }: MonomatLogoProps) {
+    return (
+        <span className={`flex items-center gap-3 ${className}`}>
+            <MonomatLogoMark />
+            <span className="text-[28px] font-extrabold leading-none text-black">
+                Monomat
+            </span>
+        </span>
+    );
+}

--- a/src/components/common/NavigationBar.tsx
+++ b/src/components/common/NavigationBar.tsx
@@ -1,17 +1,23 @@
 import { useState } from 'react';
+import { Copy, Map, Plus } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
 import { CreateLobbyModal } from '../lobby/CreateLobbyModal';
 import { InviteCodeJoinModal } from '../lobby/InviteCodeJoinModal';
+import {
+    LOBBY_NAVIGATION_LABELS,
+    LOBBY_ROUTES,
+} from '../../constants/lobby';
 import { useAuthStore } from '../../store/useAuthStore';
 import { AccountModal } from './AccountModal';
+import { MonomatLogo } from './MonomatLogo';
 import type { CreateLobbyResponse } from '../../types/lobby';
 
 export function NavigationBar() {
     const navigate = useNavigate();
 
     const nickname = useAuthStore((state) => state.nickname);
-    const isGuest = useAuthStore((state) => state.isGuest);
+    const userType = useAuthStore((state) => state.userType);
 
     const [isInviteCodeModalOpen, setIsInviteCodeModalOpen] = useState(false);
     const [isCreateLobbyModalOpen, setIsCreateLobbyModalOpen] = useState(false);
@@ -20,15 +26,19 @@ export function NavigationBar() {
     const displayNickname = nickname ?? 'Guest';
     const avatarText = displayNickname.charAt(0).toUpperCase();
 
-    const accountType = isGuest ? 'guest' : 'member';
-    const canCreateMap = accountType === 'member';
+    const accountType = userType === 'GUEST' ? 'guest' : 'member';
+    const canCreateMap = userType === 'REGISTERED';
+    const createMapRoute = LOBBY_ROUTES.CREATE_MAP;
+    const canNavigateToCreateMap = createMapRoute != null;
 
     const handleLogoClick = () => {
-        navigate('/lobbies');
+        navigate(LOBBY_ROUTES.LIST);
     };
 
     const handleCreateMapClick = () => {
-        alert('맵 만들기 기능은 정식 회원 전용 기능입니다.');
+        if (createMapRoute) {
+            navigate(createMapRoute);
+        }
     };
 
     const handleCreateLobbyClick = () => {
@@ -36,59 +46,78 @@ export function NavigationBar() {
     };
 
     const handleLobbyCreated = (response: CreateLobbyResponse) => {
-        navigate(`/lobby/${response.inviteCode}`);
+        navigate(LOBBY_ROUTES.ROOM(response.inviteCode));
     };
 
     return (
         <>
-            <header className="flex h-20 shrink-0 items-center justify-between border-b border-gray-200 bg-white px-9">
-                <button
-                    type="button"
-                    onClick={handleLogoClick}
-                    className="flex items-center gap-3"
-                    aria-label="로비 목록으로 이동"
-                >
-                    <div className="h-10 w-10 rounded-lg bg-[#0B1E46]" />
-                    <span className="text-2xl font-bold text-gray-800">
-                        Monomat
-                    </span>
-                </button>
+            <header className="h-[77px] shrink-0 border border-[color:var(--monomat-border-default)] bg-white">
+                <div className="mx-auto flex h-full w-[1440px] items-center justify-between px-[33px]">
+                    <button
+                        type="button"
+                        onClick={handleLogoClick}
+                        className="ml-[6px] h-[37px] w-[170px]"
+                        aria-label={LOBBY_NAVIGATION_LABELS.LOGO_ARIA_LABEL}
+                    >
+                        <MonomatLogo />
+                    </button>
 
-                <div className="flex items-center gap-4">
-                    {canCreateMap && (
+                    <div className="flex items-center gap-[22px]">
+                        {canCreateMap && (
+                            <button
+                                type="button"
+                                onClick={handleCreateMapClick}
+                                aria-disabled={!canNavigateToCreateMap}
+                                title={
+                                    canNavigateToCreateMap
+                                        ? undefined
+                                        : LOBBY_NAVIGATION_LABELS.CREATE_MAP_PENDING_TITLE
+                                }
+                                className="flex h-10 w-[129px] items-center justify-center gap-[13px] rounded-lg border border-[color:var(--monomat-border-input)] bg-white text-base font-bold leading-none text-black transition hover:bg-[var(--monomat-page-bg)]"
+                            >
+                                <Map size={17} strokeWidth={2.4} />
+                                <span>
+                                    {LOBBY_NAVIGATION_LABELS.CREATE_MAP}
+                                </span>
+                            </button>
+                        )}
+
                         <button
                             type="button"
-                            onClick={handleCreateMapClick}
-                            className="rounded-lg border border-gray-300 bg-white px-5 py-2.5 text-sm font-semibold text-gray-900 hover:bg-gray-50"
+                            onClick={() => setIsInviteCodeModalOpen(true)}
+                            className="flex h-10 w-[177px] items-center justify-start rounded-lg border border-[color:var(--monomat-border-input)] bg-white text-base leading-none transition hover:bg-[var(--monomat-page-bg)]"
                         >
-                            🗺️ 맵 만들기
+                            <Copy
+                                className="ml-[13px] text-black"
+                                size={18}
+                                strokeWidth={2.2}
+                            />
+                            <span className="ml-[18px] text-[var(--monomat-border-input)]">
+                                {LOBBY_NAVIGATION_LABELS.INVITE_CODE}
+                            </span>
+                            <span className="ml-[18px] flex h-[22px] w-9 items-center justify-center rounded-full bg-[var(--monomat-page-bg)] text-[11px] text-[var(--monomat-text-muted)]">
+                                {LOBBY_NAVIGATION_LABELS.INVITE_CODE_JOIN}
+                            </span>
                         </button>
-                    )}
 
-                    <button
-                        type="button"
-                        onClick={() => setIsInviteCodeModalOpen(true)}
-                        className="rounded-lg border border-gray-300 bg-white px-5 py-2.5 text-sm font-semibold text-gray-900 hover:bg-gray-50"
-                    >
-                        ▣ 초대 코드 입장
-                    </button>
+                        <button
+                            type="button"
+                            onClick={handleCreateLobbyClick}
+                            className="flex h-10 w-[120px] items-center justify-center gap-1 rounded-lg bg-[var(--monomat-primary)] text-base font-bold leading-none text-white transition hover:bg-[var(--monomat-primary-hover)]"
+                        >
+                            <Plus size={15} strokeWidth={2.8} />
+                            <span>{LOBBY_NAVIGATION_LABELS.CREATE_LOBBY}</span>
+                        </button>
 
-                    <button
-                        type="button"
-                        onClick={handleCreateLobbyClick}
-                        className="rounded-lg bg-[#0B1E46] px-5 py-2.5 text-sm font-semibold text-white hover:bg-[#12306B]"
-                    >
-                        + 로비 만들기
-                    </button>
-
-                    <button
-                        type="button"
-                        onClick={() => setIsAccountModalOpen(true)}
-                        className="flex h-10 w-10 items-center justify-center rounded-full bg-[#0B1E46] text-sm font-bold text-white"
-                        aria-label="내 계정 열기"
-                    >
-                        {avatarText}
-                    </button>
+                        <button
+                            type="button"
+                            onClick={() => setIsAccountModalOpen(true)}
+                            className="flex h-10 w-10 items-center justify-center rounded-full bg-[var(--monomat-primary)] text-xl font-extrabold leading-none text-white"
+                            aria-label={LOBBY_NAVIGATION_LABELS.ACCOUNT_ARIA_LABEL}
+                        >
+                            {avatarText}
+                        </button>
+                    </div>
                 </div>
             </header>
 

--- a/src/components/home/RegisterForm.tsx
+++ b/src/components/home/RegisterForm.tsx
@@ -4,6 +4,7 @@ import {
     AUTH_LABELS,
     REGISTER_POLICY,
 } from '../../constants/auth';
+import { MonomatLogoMark } from '../common/MonomatLogo';
 
 interface RegisterFormProps {
     loginId: string;
@@ -18,37 +19,6 @@ interface RegisterFormProps {
     onNicknameChange: (value: string) => void;
     onSubmit: () => void;
     onLoginClick: () => void;
-}
-
-function MonomatLogoMark() {
-    return (
-        <svg
-            aria-hidden
-            className="h-[37px] w-[37px] shrink-0"
-            viewBox="0 0 48 48"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-        >
-            <rect
-                x="1.5"
-                y="1.5"
-                width="45"
-                height="45"
-                rx="11"
-                fill="#FEFEFE"
-                stroke="#3873E5"
-                strokeWidth="3"
-            />
-            <path
-                d="M20.25 8.95C18.75 8.08 16.88 9.16 16.88 10.89V25.11C16.88 26.84 18.75 27.92 20.25 27.05L32.58 19.94C34.08 19.07 34.08 16.93 32.58 16.06L20.25 8.95Z"
-                fill="#3873E5"
-            />
-            <rect x="11" y="31" width="3.5" height="9" rx="1.75" fill="#3873E5" />
-            <rect x="18" y="28" width="3.5" height="12" rx="1.75" fill="#3873E5" />
-            <rect x="26" y="32" width="3.5" height="9" rx="1.75" fill="#3873E5" />
-            <rect x="33.75" y="30" width="3.5" height="10" rx="1.75" fill="#3873E5" />
-        </svg>
-    );
 }
 
 function RegisterErrorMessage({ message }: { message: string | null }) {

--- a/src/components/lobby/GlobalChat.tsx
+++ b/src/components/lobby/GlobalChat.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
+import { Send } from 'lucide-react';
 
 import { useChatCooldown } from '../../hooks/useChatCooldown';
 import { useGlobalChat } from '../../hooks/useGlobalChat';
 import { useSocketStore } from '../../store/useSocketStore';
+import { GLOBAL_CHAT_COPY } from '../../constants/lobby';
 import type { ChatMessage } from '../../types/chat';
 import { MonomatInput } from '../common/MonomatInput';
 
@@ -26,14 +28,14 @@ function getConnectionLabel(
     isReconnecting: boolean,
 ): string {
     if (isConnected) {
-        return '연결됨';
+        return GLOBAL_CHAT_COPY.CONNECTED;
     }
 
     if (isReconnecting) {
-        return '재연결 중...';
+        return GLOBAL_CHAT_COPY.RECONNECTING;
     }
 
-    return '연결 끊김';
+    return GLOBAL_CHAT_COPY.DISCONNECTED;
 }
 
 function MessageItem({ message }: { message: ChatMessage }) {
@@ -41,24 +43,24 @@ function MessageItem({ message }: { message: ChatMessage }) {
 
     if (isSystemMessage) {
         return (
-            <div className="py-0.5 text-center text-xs text-gray-400 italic">
+            <div className="py-1 text-center text-xs text-[var(--monomat-text-muted)]">
                 {message.content}
             </div>
         );
     }
 
     return (
-        <div className="py-1">
-            <div className="flex items-baseline gap-1.5">
-                <span className="max-w-[120px] truncate text-sm font-semibold text-blue-600">
+        <div className="py-2">
+            <div className="flex items-baseline gap-3">
+                <span className="max-w-[170px] truncate text-[15px] font-semibold leading-none text-[var(--monomat-primary)]">
                     {message.sender}
                 </span>
-                <span className="shrink-0 text-xs text-gray-400">
+                <span className="shrink-0 text-xs leading-none text-[#73788A]">
                     {formatTime(message.timestamp)}
                 </span>
             </div>
 
-            <p className="break-words text-sm leading-snug text-gray-800">
+            <p className="mt-2 break-words text-base leading-[19px] text-black">
                 {message.content}
             </p>
         </div>
@@ -67,13 +69,13 @@ function MessageItem({ message }: { message: ChatMessage }) {
 
 function ReconnectOverlay() {
     return (
-        <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-white/55 backdrop-blur-[1px]">
+        <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-white/65 backdrop-blur-[1px]">
             <div
-                className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-blue-500"
+                className="h-8 w-8 animate-spin rounded-full border-4 border-[var(--monomat-border-default)] border-t-[var(--monomat-primary)]"
                 aria-hidden="true"
             />
-            <p className="text-sm font-semibold text-gray-700">
-                재연결 중...
+            <p className="text-sm font-semibold text-[var(--monomat-text-strong)]">
+                {GLOBAL_CHAT_COPY.RECONNECTING}
             </p>
         </div>
     );
@@ -124,30 +126,30 @@ export function GlobalChat() {
     };
 
     return (
-        <div className="relative flex h-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div className="relative flex h-full flex-col overflow-hidden rounded-xl border border-[color:var(--monomat-border-input)] bg-white shadow-[0_4px_16px_rgba(0,0,0,0.06)]">
             {isReconnecting && <ReconnectOverlay />}
 
-            <div className="flex shrink-0 items-center justify-between border-b border-gray-100 px-4 py-3">
-                <span className="text-sm font-bold text-gray-800">
-                    전체 채팅
+            <div className="flex h-14 shrink-0 items-center justify-between border-b border-[color:var(--monomat-border-input)] px-[18px]">
+                <span className="text-base font-semibold leading-none text-black">
+                    {GLOBAL_CHAT_COPY.TITLE}
                 </span>
 
                 <div className="flex items-center gap-1.5">
                     <span
-                        className={`h-2 w-2 rounded-full ${
-                            isConnected ? 'bg-green-500' : 'bg-gray-300'
+                        className={`h-[9px] w-[9px] rounded-full ${
+                            isConnected ? 'bg-[#00A259]' : 'bg-[var(--monomat-border-input)]'
                         }`}
                     />
-                    <span className="text-xs text-gray-400">
+                    <span className="text-base leading-none text-[#B9B9B9]">
                         {getConnectionLabel(isConnected, isReconnecting)}
                     </span>
                 </div>
             </div>
 
-            <div className="min-h-0 flex-1 space-y-0.5 overflow-y-auto px-4 py-2">
+            <div className="min-h-0 flex-1 overflow-y-auto px-[18px] py-[9px]">
                 {messages.length === 0 ? (
-                    <p className="mt-8 text-center text-xs text-gray-400">
-                        아직 채팅이 없습니다.
+                    <p className="mt-8 text-center text-sm text-[var(--monomat-border-input)]">
+                        {GLOBAL_CHAT_COPY.EMPTY}
                     </p>
                 ) : (
                     messages.map((message, index) => (
@@ -158,21 +160,25 @@ export function GlobalChat() {
                 <div ref={messagesEndRef} />
             </div>
 
-            <div className="shrink-0 border-t border-gray-100 px-3 py-3">
-                <div className="flex items-center gap-2">
+            <div className="h-[70px] shrink-0 border-t border-[color:var(--monomat-border-input)] px-[22px] py-2.5">
+                <div className="flex h-[50px] items-center gap-[9px]">
                     <MonomatInput
                         type="text"
                         value={inputValue}
                         onChange={(event) => setInputValue(event.target.value)}
                         onEnter={handleSend}
-                        placeholder={isConnected ? '메시지를 입력하세요' : '연결 중...'}
+                        placeholder={
+                            isConnected
+                                ? GLOBAL_CHAT_COPY.INPUT_PLACEHOLDER
+                                : GLOBAL_CHAT_COPY.CONNECTING_PLACEHOLDER
+                        }
                         disabled={!isConnected || isCoolingDown}
                         maxLength={MAX_CHAT_LENGTH}
                         className="
-                            flex-1 rounded-lg border border-gray-300 bg-gray-50 px-3 py-2 text-sm
-                            text-gray-900 placeholder:text-gray-400
+                            h-[50px] min-w-0 flex-1 rounded-xl border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)]
+                            px-[11px] text-sm text-[var(--monomat-text-strong)] placeholder:text-[var(--monomat-border-input)]
                             outline-none transition-colors
-                            focus:border-blue-500
+                            focus:border-[color:var(--monomat-primary)]
                             disabled:cursor-not-allowed disabled:opacity-50
                         "
                     />
@@ -182,41 +188,26 @@ export function GlobalChat() {
                         onClick={() => handleSend(inputValue)}
                         disabled={!canSubmit}
                         className="
-                            flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-500
-                            transition-all hover:bg-blue-600 active:scale-95
-                            disabled:cursor-not-allowed disabled:bg-gray-200
+                            flex h-[50px] w-[50px] shrink-0 items-center justify-center rounded-xl bg-[var(--monomat-primary)]
+                            transition-all hover:bg-[var(--monomat-primary-hover)] active:scale-95
+                            disabled:cursor-not-allowed disabled:bg-[var(--monomat-border-input)]
                         "
-                        aria-label="메시지 전송"
+                        aria-label={GLOBAL_CHAT_COPY.SEND_ARIA_LABEL}
                     >
-                        <svg
-                            width="16"
-                            height="16"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            className="text-white"
+                        <Send
+                            className="-rotate-12 text-white"
+                            size={24}
+                            strokeWidth={2.2}
                             aria-hidden="true"
-                        >
-                            <path
-                                d="M22 2L11 13"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                            />
-                            <path
-                                d="M22 2L15 22L11 13L2 9L22 2Z"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                            />
-                        </svg>
+                        />
                     </button>
                 </div>
 
                 {isCoolingDown && (
-                    <p className="mt-2 text-xs text-orange-500">
-                        연속 전송 방지를 위해 {remainingSeconds}초 후 다시 보낼 수 있습니다.
+                    <p className="mt-1 text-xs text-[#F28C1A]">
+                        {GLOBAL_CHAT_COPY.COOLDOWN_PREFIX}{' '}
+                        {remainingSeconds}
+                        {GLOBAL_CHAT_COPY.COOLDOWN_SUFFIX}
                     </p>
                 )}
             </div>

--- a/src/components/lobby/LobbyCard.tsx
+++ b/src/components/lobby/LobbyCard.tsx
@@ -1,3 +1,7 @@
+import {
+    LOBBY_CARD_LABELS,
+    LOBBY_STATUS_META,
+} from '../../constants/lobby';
 import type { LobbyCategory, LobbyListItem } from '../../types/lobby';
 
 interface LobbyCardProps {
@@ -6,21 +10,18 @@ interface LobbyCardProps {
 }
 
 function StatusBadge({ status }: { status: LobbyListItem['status'] }) {
-    const isWaiting = status === 'WAITING';
-    const isPlaying = status === 'PLAYING';
-    const label = isWaiting ? '대기중' : isPlaying ? '진행중' : '상태확인중';
+    const meta =
+        status === 'WAITING'
+            ? LOBBY_STATUS_META.WAITING
+            : status === 'PLAYING'
+                ? LOBBY_STATUS_META.PLAYING
+                : LOBBY_STATUS_META.UNKNOWN;
 
     return (
         <span
-            className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                isWaiting
-                    ? 'bg-green-100 text-green-600'
-                    : isPlaying
-                        ? 'bg-yellow-100 text-yellow-600'
-                        : 'bg-gray-100 text-gray-500'
-            }`}
+            className={`inline-flex h-[22px] w-[60px] items-center justify-center rounded-full text-[11px] font-semibold leading-none ${meta.badgeClassName}`}
         >
-            ● {label}
+            ● {meta.label}
         </span>
     );
 }
@@ -35,7 +36,7 @@ function CategoryBadge({
     }
 
     return (
-        <span className="rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-500">
+        <span className="inline-flex h-[22px] min-w-[47px] items-center justify-center rounded-full bg-[var(--monomat-primary-light)] px-2 text-[11px] font-semibold leading-none text-[var(--monomat-primary)]">
             {category}
         </span>
     );
@@ -54,17 +55,16 @@ function ProgressBar({
     const percent = Math.min(Math.round((current / safeMax) * 100), 100);
     const isFull = current >= max;
 
-    const color =
-        status === 'PLAYING'
-            ? 'bg-yellow-400'
-            : isFull
-                ? 'bg-blue-500'
-                : 'bg-blue-400';
+    const progressClassName = isFull
+        ? LOBBY_STATUS_META.UNKNOWN.progressClassName
+        : status === 'PLAYING'
+            ? LOBBY_STATUS_META.PLAYING.progressClassName
+            : LOBBY_STATUS_META.WAITING.progressClassName;
 
     return (
-        <div className="h-1.5 w-full rounded-full bg-gray-100">
+        <div className="h-[5px] w-[397px] rounded-full bg-[var(--monomat-page-bg)]">
             <div
-                className={`h-1.5 rounded-full ${color}`}
+                className={`h-[5px] rounded-full ${progressClassName}`}
                 style={{ width: `${percent}%` }}
             />
         </div>
@@ -72,50 +72,58 @@ function ProgressBar({
 }
 
 export function LobbyCard({ lobby, onEnter }: LobbyCardProps) {
-    const { code, title, status, maxPlayers, mapCategory } = lobby;
+    const { code, hostId, title, status, maxPlayers, mapCategory } = lobby;
 
     const { currentPlayers } = lobby;
     const isFull = currentPlayers >= maxPlayers;
     const isEnterDisabled = isFull || status === 'PLAYING';
 
     return (
-        <div className="flex flex-col justify-between rounded-xl bg-white p-5 text-left shadow-sm">
-            <div className="mb-3 flex items-center gap-2">
+        <article className="relative h-[168px] overflow-hidden rounded-xl bg-white text-left shadow-[0_4px_16px_rgba(0,0,0,0.06)]">
+            <div className="absolute left-[14px] top-[14px] flex h-[22px] items-center gap-1.5">
                 <StatusBadge status={status} />
                 <CategoryBadge category={mapCategory} />
             </div>
 
-            <p className="mb-4 text-left text-base font-semibold text-gray-900">
+            <p className="absolute left-[14px] top-[70px] h-[14px] w-[328px] truncate text-sm font-bold leading-none text-[var(--monomat-text-strong)]">
                 {title}
             </p>
 
-            <div className="mb-2 flex items-center justify-between text-sm text-gray-500">
-                <span>👤 host</span>
-                <span>
-                    {currentPlayers}/{maxPlayers}명
-                </span>
+            <p className="absolute left-[14px] top-[96px] max-w-[220px] truncate text-[13px] font-medium leading-4 text-[var(--monomat-text-muted)]">
+                👤 {hostId}
+            </p>
+
+            <p className="absolute right-5 top-[101px] text-xs font-medium leading-[14px] text-[var(--monomat-text-muted)]">
+                {currentPlayers}/{maxPlayers}
+                {LOBBY_CARD_LABELS.PLAYER_UNIT}
+            </p>
+
+            <div className="absolute left-[14px] top-[118px]">
+                <ProgressBar
+                    current={currentPlayers}
+                    max={maxPlayers}
+                    status={status}
+                />
             </div>
 
-            <ProgressBar
-                current={currentPlayers}
-                max={maxPlayers}
-                status={status}
-            />
+            <span className="absolute left-[316px] top-[135px] text-sm leading-[17px] text-[#CCD1D9]">
+                ⚑
+            </span>
 
-            <div className="mt-4 flex justify-end">
-                <button
-                    type="button"
-                    onClick={() => onEnter(code)}
-                    disabled={isEnterDisabled}
-                    className={`rounded-lg px-5 py-2 text-sm font-medium text-white transition ${
-                        isEnterDisabled
-                            ? 'cursor-not-allowed bg-gray-300'
-                            : 'bg-blue-500 hover:bg-blue-600'
-                    }`}
-                >
-                    {isEnterDisabled ? '입장불가' : '입장'}
-                </button>
-            </div>
-        </div>
+            <button
+                type="button"
+                onClick={() => onEnter(code)}
+                disabled={isEnterDisabled}
+                className={`absolute left-[335px] top-[130px] h-7 w-[76px] rounded-lg text-xs font-bold leading-none text-white transition ${
+                    isEnterDisabled
+                        ? 'cursor-not-allowed bg-[var(--monomat-border-input)]'
+                        : 'bg-[var(--monomat-primary)] hover:bg-[var(--monomat-primary-hover)]'
+                }`}
+            >
+                {isEnterDisabled
+                    ? LOBBY_CARD_LABELS.ENTER_UNAVAILABLE
+                    : LOBBY_CARD_LABELS.ENTER}
+            </button>
+        </article>
     );
 }

--- a/src/components/lobby/LobbyCategoryFilter.tsx
+++ b/src/components/lobby/LobbyCategoryFilter.tsx
@@ -7,19 +7,19 @@ interface LobbyCategoryFilterProps<TCategory extends string> {
 export function LobbyCategoryFilter<TCategory extends string>({
                                                                   categories,
                                                                   selectedCategory,
-                                                                  onChange,
-                                                              }: LobbyCategoryFilterProps<TCategory>) {
+                                                              onChange,
+                                                          }: LobbyCategoryFilterProps<TCategory>) {
     return (
-        <div className="mb-5 flex gap-2">
+        <div className="mb-[18px] flex h-8 items-center gap-[9px]">
             {categories.map((category) => (
                 <button
                     key={category}
                     type="button"
                     onClick={() => onChange(category)}
-                    className={`rounded-full px-4 py-1.5 text-sm font-medium ${
+                    className={`h-8 rounded-full px-[15px] text-[13px] leading-none transition ${
                         selectedCategory === category
-                            ? 'bg-blue-500 text-white'
-                            : 'border border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
+                            ? 'bg-[var(--monomat-primary)] font-semibold text-white'
+                            : 'border border-[color:var(--monomat-border-input)] bg-white font-normal text-[var(--monomat-text-muted)] hover:bg-[var(--monomat-page-bg)]'
                     }`}
                 >
                     {category}

--- a/src/components/lobby/LobbyEmptyState.tsx
+++ b/src/components/lobby/LobbyEmptyState.tsx
@@ -1,9 +1,14 @@
+import { LOBBY_EMPTY_STATE_COPY } from '../../constants/lobby';
+
 export function LobbyEmptyState() {
     return (
-        <div className="grid grid-cols-2 gap-4">
-            <div className="col-span-2 flex h-40 items-center justify-center text-gray-400">
-                현재 조건에 맞는 로비가 없습니다.
-            </div>
+        <div className="flex h-[354px] flex-col items-center justify-center rounded-xl border border-[color:var(--monomat-border-default)] bg-white text-center shadow-[0_4px_16px_rgba(0,0,0,0.04)]">
+            <p className="text-base font-bold text-[var(--monomat-text-strong)]">
+                {LOBBY_EMPTY_STATE_COPY.TITLE}
+            </p>
+            <p className="mt-2 text-sm text-[var(--monomat-text-muted)]">
+                {LOBBY_EMPTY_STATE_COPY.DESCRIPTION}
+            </p>
         </div>
     );
 }

--- a/src/components/lobby/LobbyFooter.tsx
+++ b/src/components/lobby/LobbyFooter.tsx
@@ -1,18 +1,23 @@
 export function LobbyFooter() {
     return (
-        <footer className="flex h-10 shrink-0 items-center justify-between border-t border-gray-200 bg-white px-10 text-sm text-gray-500">
-            <span>© 2026 Monomat. 실시간 멀티플레이 퀴즈.</span>
+        <footer className="h-[41px] shrink-0 border border-[color:var(--monomat-border-default)] bg-white text-sm leading-none text-[var(--monomat-text-muted)]">
+            <div className="mx-auto flex h-full w-[1440px] items-center justify-between px-[35px]">
+                <span>© 2026 Monomat. 실시간 멀티플레이 퀴즈.</span>
 
-            <div className="flex items-center gap-6">
-                <button type="button" className="hover:text-gray-700">
-                    문제 신고
-                </button>
-                <button type="button" className="hover:text-gray-700">
-                    이용약관
-                </button>
-                <button type="button" className="hover:text-gray-700">
-                    개인정보처리방침
-                </button>
+                <div className="flex items-center gap-[30px]">
+                    <button type="button" className="hover:text-[var(--monomat-text-strong)]">
+                        문의
+                    </button>
+                    <button type="button" className="hover:text-[var(--monomat-text-strong)]">
+                        문제 신고
+                    </button>
+                    <button type="button" className="hover:text-[var(--monomat-text-strong)]">
+                        이용약관
+                    </button>
+                    <button type="button" className="hover:text-[var(--monomat-text-strong)]">
+                        개인정보처리방침
+                    </button>
+                </div>
             </div>
         </footer>
     );

--- a/src/components/lobby/LobbyHeader.tsx
+++ b/src/components/lobby/LobbyHeader.tsx
@@ -25,8 +25,8 @@ export function LobbyHeader<TCategory extends string>({
                                                           onSortOptionChange,
                                                       }: LobbyHeaderProps<TCategory>) {
     return (
-        <>
-            <div className="mb-4 flex items-center gap-3">
+        <header className="mb-4">
+            <div className="mb-[18px] flex h-11 items-center gap-[5px]">
                 <LobbySearchInput
                     value={searchKeyword}
                     onChange={onSearchKeywordChange}
@@ -43,6 +43,6 @@ export function LobbyHeader<TCategory extends string>({
                 selectedCategory={selectedCategory}
                 onChange={onSelectedCategoryChange}
             />
-        </>
+        </header>
     );
 }

--- a/src/components/lobby/LobbyList.tsx
+++ b/src/components/lobby/LobbyList.tsx
@@ -1,19 +1,83 @@
 import type { LobbyListItem } from '../../types/lobby';
+import { LOBBY_LIST_ERROR_COPY } from '../../constants/lobby';
 import { LobbyCard } from './LobbyCard';
 import { LobbyEmptyState } from './LobbyEmptyState';
 
 interface LobbyListProps {
     lobbies: LobbyListItem[];
+    isLoading?: boolean;
+    isError?: boolean;
+    onRetry?: () => void;
     onEnter: (code: string) => void;
 }
 
-export function LobbyList({ lobbies, onEnter }: LobbyListProps) {
+function LobbyCardSkeleton() {
+    return (
+        <div className="h-[168px] rounded-xl bg-white p-[14px] shadow-[0_4px_16px_rgba(0,0,0,0.06)]">
+            <div className="flex gap-1.5">
+                <div className="h-[22px] w-[60px] animate-pulse rounded-full bg-[var(--monomat-page-bg)]" />
+                <div className="h-[22px] w-[47px] animate-pulse rounded-full bg-[var(--monomat-page-bg)]" />
+            </div>
+            <div className="mt-[34px] h-4 w-56 animate-pulse rounded bg-[var(--monomat-page-bg)]" />
+            <div className="mt-5 flex items-center justify-between">
+                <div className="h-3 w-20 animate-pulse rounded bg-[var(--monomat-page-bg)]" />
+                <div className="h-3 w-10 animate-pulse rounded bg-[var(--monomat-page-bg)]" />
+            </div>
+            <div className="mt-3 h-[5px] animate-pulse rounded-full bg-[var(--monomat-page-bg)]" />
+            <div className="ml-auto mt-3 h-7 w-[76px] animate-pulse rounded-lg bg-[var(--monomat-page-bg)]" />
+        </div>
+    );
+}
+
+function LobbyErrorState({ onRetry }: { onRetry?: () => void }) {
+    return (
+        <div className="flex h-[354px] flex-col items-center justify-center rounded-xl border border-[color:var(--monomat-border-default)] bg-white text-center shadow-[0_4px_16px_rgba(0,0,0,0.04)]">
+            <p className="text-base font-bold text-[var(--monomat-text-strong)]">
+                {LOBBY_LIST_ERROR_COPY.TITLE}
+            </p>
+            <p className="mt-2 text-sm text-[var(--monomat-text-muted)]">
+                {LOBBY_LIST_ERROR_COPY.DESCRIPTION}
+            </p>
+            {onRetry && (
+                <button
+                    type="button"
+                    onClick={onRetry}
+                    className="mt-5 h-9 rounded-lg bg-[var(--monomat-primary)] px-5 text-sm font-bold text-white transition hover:bg-[var(--monomat-primary-hover)]"
+                >
+                    {LOBBY_LIST_ERROR_COPY.RETRY}
+                </button>
+            )}
+        </div>
+    );
+}
+
+export function LobbyList({
+    lobbies,
+    isLoading = false,
+    isError = false,
+    onRetry,
+    onEnter,
+}: LobbyListProps) {
+    if (isLoading) {
+        return (
+            <div className="grid grid-cols-2 gap-x-8 gap-y-[18px]">
+                {Array.from({ length: 6 }).map((_, index) => (
+                    <LobbyCardSkeleton key={index} />
+                ))}
+            </div>
+        );
+    }
+
+    if (isError) {
+        return <LobbyErrorState onRetry={onRetry} />;
+    }
+
     if (lobbies.length === 0) {
         return <LobbyEmptyState />;
     }
 
     return (
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-x-8 gap-y-[18px]">
             {lobbies.map((lobby) => (
                 <LobbyCard
                     key={lobby.code}

--- a/src/components/lobby/LobbySearchInput.tsx
+++ b/src/components/lobby/LobbySearchInput.tsx
@@ -1,3 +1,7 @@
+import { Search } from 'lucide-react';
+
+import { LOBBY_SEARCH_COPY } from '../../constants/lobby';
+
 interface LobbySearchInputProps {
     value: string;
     onChange: (value: string) => void;
@@ -8,12 +12,20 @@ export function LobbySearchInput({
                                      onChange,
                                  }: LobbySearchInputProps) {
     return (
-        <input
-            type="text"
-            value={value}
-            onChange={(event) => onChange(event.target.value)}
-            placeholder="로비 제목 검색"
-            className="flex-1 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm text-gray-700 placeholder:text-gray-400 shadow-sm focus:border-blue-400 focus:outline-none"
-        />
+        <label className="flex h-11 w-[728px] items-center rounded-[10px] border border-[color:var(--monomat-border-input)] bg-white">
+            <Search
+                className="ml-[11px] shrink-0 text-[#2B3F6C]"
+                size={24}
+                strokeWidth={1.6}
+                aria-hidden="true"
+            />
+            <input
+                type="text"
+                value={value}
+                onChange={(event) => onChange(event.target.value)}
+                placeholder={LOBBY_SEARCH_COPY.PLACEHOLDER}
+                className="h-full min-w-0 flex-1 bg-transparent px-[11px] text-sm leading-none text-[var(--monomat-text-strong)] outline-none placeholder:text-[var(--monomat-border-input)]"
+            />
+        </label>
     );
 }

--- a/src/components/lobby/LobbySortDropdown.tsx
+++ b/src/components/lobby/LobbySortDropdown.tsx
@@ -1,13 +1,11 @@
 import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+
+import { LOBBY_SORT_LABELS } from '../../constants/lobby';
+
 import type { LobbySortOption } from '../../types/lobby';
 
 export type { LobbySortOption } from '../../types/lobby';
-
-const SORT_LABELS: Record<LobbySortOption, string> = {
-    LATEST: '최신순',
-    MOST_PLAYERS: '인원 많은 순',
-    MOST_EMPTY_SLOTS: '빈 자리 많은 순',
-};
 
 interface LobbySortDropdownProps {
     value: LobbySortOption;
@@ -30,26 +28,32 @@ export function LobbySortDropdown({
             <button
                 type="button"
                 onClick={() => setIsOpen((prev) => !prev)}
-                className="min-w-36 rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-sm text-gray-600 shadow-sm hover:bg-gray-50"
+                className="flex h-11 w-[161px] items-center justify-center rounded-lg border border-[color:var(--monomat-border-input)] bg-white text-base font-normal leading-none text-[var(--monomat-text-muted)] transition hover:bg-[var(--monomat-page-bg)]"
             >
-                {SORT_LABELS[value]} ▼
+                <span>정렬: {LOBBY_SORT_LABELS[value]}</span>
+                <ChevronDown
+                    className="ml-2"
+                    size={18}
+                    strokeWidth={2}
+                    aria-hidden="true"
+                />
             </button>
 
             {isOpen && (
-                <div className="absolute right-0 z-20 mt-2 w-44 overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg">
-                    {(Object.keys(SORT_LABELS) as LobbySortOption[]).map(
+                <div className="absolute right-0 z-20 mt-2 w-[188px] overflow-hidden rounded-lg border border-[color:var(--monomat-border-input)] bg-white shadow-[0_8px_24px_rgba(0,0,0,0.08)]">
+                    {(Object.keys(LOBBY_SORT_LABELS) as LobbySortOption[]).map(
                         (option) => (
                             <button
                                 key={option}
                                 type="button"
                                 onClick={() => handleSelect(option)}
-                                className={`block w-full px-4 py-2.5 text-left text-sm hover:bg-gray-50 ${
+                                className={`block h-10 w-full px-4 text-left text-sm transition hover:bg-[var(--monomat-page-bg)] ${
                                     value === option
-                                        ? 'font-semibold text-blue-500'
-                                        : 'text-gray-600'
+                                        ? 'font-semibold text-[var(--monomat-primary)]'
+                                        : 'font-normal text-[var(--monomat-text-muted)]'
                                 }`}
                             >
-                                {SORT_LABELS[option]}
+                                {LOBBY_SORT_LABELS[option]}
                             </button>
                         ),
                     )}

--- a/src/constants/lobby.ts
+++ b/src/constants/lobby.ts
@@ -20,3 +20,91 @@ export const CREATE_LOBBY_POLICY = {
     MIN_TIME_LIMIT_SECONDS: 10,
     MAX_TIME_LIMIT_SECONDS: 120,
 } as const;
+
+export const LOBBY_CATEGORY_FILTERS = [
+    '전체',
+    'K-POP',
+    'J-POP',
+    'POP',
+    'OST',
+] as const;
+
+export const LOBBY_ALL_CATEGORY_FILTER = LOBBY_CATEGORY_FILTERS[0];
+
+export const LOBBY_SORT_LABELS = {
+    LATEST: '최신순',
+    MOST_PLAYERS: '인원 많은 순',
+    MOST_EMPTY_SLOTS: '빈 자리 많은 순',
+} as const;
+
+export const DEFAULT_LOBBY_LIST_PAGE = 0;
+export const DEFAULT_LOBBY_LIST_SIZE = 20;
+
+export const LOBBY_NAVIGATION_LABELS = {
+    LOGO_ARIA_LABEL: '로비 목록으로 이동',
+    ACCOUNT_ARIA_LABEL: '내 계정 열기',
+    CREATE_MAP: '맵 만들기',
+    CREATE_MAP_PENDING_TITLE: '맵 만들기 기능은 추후 제공 예정입니다.',
+    INVITE_CODE: '초대 코드',
+    INVITE_CODE_JOIN: '입장',
+    CREATE_LOBBY: '로비 만들기',
+} as const;
+
+export const LOBBY_ROUTES = {
+    LIST: '/lobbies',
+    ROOM: (inviteCode: string) => `/lobby/${inviteCode}`,
+    CREATE_MAP: null as string | null,
+} as const;
+
+export const LOBBY_STATUS_META = {
+    WAITING: {
+        label: '대기중',
+        badgeClassName: 'bg-[#E5F7ED] text-[#33A659]',
+        progressClassName: 'bg-[var(--monomat-primary)]',
+    },
+    PLAYING: {
+        label: '진행중',
+        badgeClassName: 'bg-[#FFF0E0] text-[#F28C1A]',
+        progressClassName: 'bg-[#F28C1A]',
+    },
+    UNKNOWN: {
+        label: '상태확인중',
+        badgeClassName:
+            'bg-[var(--monomat-page-bg)] text-[var(--monomat-text-muted)]',
+        progressClassName: 'bg-[var(--monomat-border-input)]',
+    },
+} as const;
+
+export const LOBBY_CARD_LABELS = {
+    ENTER: '입장',
+    ENTER_UNAVAILABLE: '입장불가',
+    PLAYER_UNIT: '명',
+} as const;
+
+export const LOBBY_LIST_ERROR_COPY = {
+    TITLE: '로비 목록을 불러오지 못했습니다.',
+    DESCRIPTION: '잠시 후 다시 시도해주세요.',
+    RETRY: '다시 불러오기',
+} as const;
+
+export const LOBBY_EMPTY_STATE_COPY = {
+    TITLE: '현재 조건에 맞는 로비가 없습니다.',
+    DESCRIPTION: '검색어나 카테고리 조건을 변경해보세요.',
+} as const;
+
+export const LOBBY_SEARCH_COPY = {
+    PLACEHOLDER: '로비 제목을 검색하세요.',
+} as const;
+
+export const GLOBAL_CHAT_COPY = {
+    TITLE: '전체 채팅',
+    EMPTY: '아직 채팅이 없습니다.',
+    INPUT_PLACEHOLDER: '메시지 입력',
+    CONNECTING_PLACEHOLDER: '연결 중...',
+    CONNECTED: '연결됨',
+    RECONNECTING: '재연결 중...',
+    DISCONNECTED: '연결 끊김',
+    SEND_ARIA_LABEL: '메시지 전송',
+    COOLDOWN_PREFIX: '연속 전송 방지를 위해',
+    COOLDOWN_SUFFIX: '초 후 다시 보낼 수 있습니다.',
+} as const;

--- a/src/hooks/useLobbyList.ts
+++ b/src/hooks/useLobbyList.ts
@@ -1,15 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { fetchLobbyList } from '../api/lobbyApi';
+import {
+    DEFAULT_LOBBY_LIST_PAGE,
+    DEFAULT_LOBBY_LIST_SIZE,
+} from '../constants/lobby';
 
 import type {
     LobbyListItem,
     LobbyListQueryParams,
     LobbyPageResponse,
 } from '../types/lobby';
-
-const DEFAULT_LOBBY_LIST_PAGE = 0;
-const DEFAULT_LOBBY_LIST_SIZE = 20;
 
 /**
  * 컴포넌트에서 로비 목록 데이터를 쉽게 가져오고 상태를 관리하기 위한 커스텀 훅

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -16,6 +16,7 @@ import {
     HOME_FEATURES,
 } from '../constants/home';
 import { useAuthStore } from '../store/useAuthStore';
+import { MonomatLogoMark } from '../components/common/MonomatLogo';
 
 const FEATURE_ICON: Record<
     (typeof HOME_FEATURES)[number]['iconName'],
@@ -25,37 +26,6 @@ const FEATURE_ICON: Record<
     rocket: Rocket,
     users: Users,
 };
-
-function MonomatLogoMark() {
-    return (
-        <svg
-            aria-hidden
-            className="h-10 w-10 shrink-0 lg:h-12 lg:w-12"
-            viewBox="0 0 48 48"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-        >
-            <rect
-                x="1.5"
-                y="1.5"
-                width="45"
-                height="45"
-                rx="11"
-                fill="#FEFEFE"
-                stroke="#3873E5"
-                strokeWidth="3"
-            />
-            <path
-                d="M20.25 8.95C18.75 8.08 16.88 9.16 16.88 10.89V25.11C16.88 26.84 18.75 27.92 20.25 27.05L32.58 19.94C34.08 19.07 34.08 16.93 32.58 16.06L20.25 8.95Z"
-                fill="#3873E5"
-            />
-            <rect x="11" y="31" width="3.5" height="9" rx="1.75" fill="#3873E5" />
-            <rect x="18" y="28" width="3.5" height="12" rx="1.75" fill="#3873E5" />
-            <rect x="26" y="32" width="3.5" height="9" rx="1.75" fill="#3873E5" />
-            <rect x="33.75" y="30" width="3.5" height="10" rx="1.75" fill="#3873E5" />
-        </svg>
-    );
-}
 
 export const Home = () => {
     const navigate = useNavigate();
@@ -94,7 +64,7 @@ export const Home = () => {
         <main className="grid min-h-screen min-w-0 grid-cols-1 bg-[var(--monomat-page-bg)] md:grid-cols-[minmax(300px,42vw)_minmax(0,1fr)] lg:grid-cols-[minmax(380px,42vw)_minmax(0,1fr)] xl:grid-cols-[600px_minmax(0,1fr)]">
             <section className="flex min-w-0 flex-col bg-[#1F2433] px-6 py-10 text-white sm:px-10 md:px-8 md:py-14 lg:px-12 lg:py-20 xl:px-[60px] xl:py-[106px]">
                 <div className="flex min-w-0 items-center gap-3 lg:gap-[13px]">
-                    <MonomatLogoMark />
+                    <MonomatLogoMark className="h-10 w-10 lg:h-12 lg:w-12" />
                     <span className="min-w-0 text-[24px] font-extrabold leading-none lg:text-[28px]">
                         {HOME_COPY.SERVICE_NAME}
                     </span>

--- a/src/pages/Lobbies.tsx
+++ b/src/pages/Lobbies.tsx
@@ -6,6 +6,13 @@ import { GlobalChat } from '../components/lobby/GlobalChat';
 import { LobbyFooter } from '../components/lobby/LobbyFooter';
 import { LobbyHeader } from '../components/lobby/LobbyHeader';
 import { LobbyList } from '../components/lobby/LobbyList';
+import {
+    DEFAULT_LOBBY_LIST_PAGE,
+    DEFAULT_LOBBY_LIST_SIZE,
+    LOBBY_ALL_CATEGORY_FILTER,
+    LOBBY_CATEGORY_FILTERS,
+    LOBBY_ROUTES,
+} from '../constants/lobby';
 import { useLobbyList } from '../hooks/useLobbyList';
 import {
     SORT_QUERY_MAP,
@@ -13,16 +20,12 @@ import {
     type LobbySortOption,
 } from '../types/lobby';
 
-const CATEGORY_FILTERS = ['전체', 'K-POP', 'J-POP', 'POP', 'OST'] as const;
-const DEFAULT_LOBBY_LIST_PAGE = 0;
-const DEFAULT_LOBBY_LIST_SIZE = 20;
-
-type LobbyCategoryFilter = (typeof CATEGORY_FILTERS)[number];
+type LobbyCategoryFilter = (typeof LOBBY_CATEGORY_FILTERS)[number];
 
 function toMapCategory(
     category: LobbyCategoryFilter,
 ): LobbyCategory | undefined {
-    return category === '전체' ? undefined : category;
+    return category === LOBBY_ALL_CATEGORY_FILTER ? undefined : category;
 }
 
 export function Lobbies() {
@@ -30,51 +33,44 @@ export function Lobbies() {
 
     const [searchKeyword, setSearchKeyword] = useState('');
     const [selectedCategory, setSelectedCategory] =
-        useState<LobbyCategoryFilter>('전체');
+        useState<LobbyCategoryFilter>(LOBBY_ALL_CATEGORY_FILTER);
     const [sortOption, setSortOption] =
         useState<LobbySortOption>('LATEST');
 
-    const lobbyListQueryParams = useMemo(() => ({
-        keyword: searchKeyword.trim(),
-        mapCategory: toMapCategory(selectedCategory),
-        sort: SORT_QUERY_MAP[sortOption],
-        page: DEFAULT_LOBBY_LIST_PAGE,
-        size: DEFAULT_LOBBY_LIST_SIZE,
-    }), [searchKeyword, selectedCategory, sortOption]);
+    const lobbyListQueryParams = useMemo(() => {
+        const mapCategory = toMapCategory(selectedCategory);
 
-    const { data, isLoading, isError } = useLobbyList(lobbyListQueryParams);
+        return {
+            keyword: searchKeyword.trim(),
+            ...(mapCategory ? { mapCategory } : {}),
+            sort: SORT_QUERY_MAP[sortOption],
+            page: DEFAULT_LOBBY_LIST_PAGE,
+            size: DEFAULT_LOBBY_LIST_SIZE,
+        };
+    }, [searchKeyword, selectedCategory, sortOption]);
+
+    const {
+        data,
+        isLoading,
+        isError,
+        refetch,
+    } = useLobbyList(lobbyListQueryParams);
     const lobbies = data?.items ?? [];
 
     const handleEnter = (code: string) => {
-        navigate(`/lobby/${code}`);
+        navigate(LOBBY_ROUTES.ROOM(code));
     };
 
-    if (isLoading) {
-        return (
-            <div className="flex min-h-screen items-center justify-center bg-[#F5F5F7] text-gray-400">
-                로비 목록을 불러오는 중...
-            </div>
-        );
-    }
-
-    if (isError) {
-        return (
-            <div className="flex min-h-screen items-center justify-center bg-[#F5F5F7] text-red-400">
-                로비 목록을 불러오지 못했습니다.
-            </div>
-        );
-    }
-
     return (
-        <div className="flex min-h-screen flex-col bg-[#F5F5F7]">
+        <div className="flex min-h-screen min-w-[1440px] flex-col bg-[var(--monomat-page-bg)] text-left">
             <NavigationBar />
 
-            <main className="flex flex-1 gap-5 px-9 py-6">
-                <section className="min-w-0 flex-1">
+            <main className="mx-auto grid w-[1440px] flex-1 grid-cols-[894px_451px] gap-[27px] px-[35px] pb-[25px] pt-6">
+                <section className="min-w-0">
                     <LobbyHeader
                         searchKeyword={searchKeyword}
                         onSearchKeywordChange={setSearchKeyword}
-                        categories={CATEGORY_FILTERS}
+                        categories={LOBBY_CATEGORY_FILTERS}
                         selectedCategory={selectedCategory}
                         onSelectedCategoryChange={setSelectedCategory}
                         sortOption={sortOption}
@@ -83,11 +79,14 @@ export function Lobbies() {
 
                     <LobbyList
                         lobbies={lobbies}
+                        isLoading={isLoading}
+                        isError={isError}
+                        onRetry={() => void refetch()}
                         onEnter={handleEnter}
                     />
                 </section>
 
-                <aside className="sticky top-6 h-[calc(100vh-8.5rem)] w-96 shrink-0 self-start">
+                <aside className="h-[733px] w-[451px] shrink-0">
                     <GlobalChat />
                 </aside>
             </main>


### PR DESCRIPTION
## 📣 Related Issue

- #48

## 📝 Summary

- 로비 목록 페이지 레이아웃을 Figma 1440px 데스크톱 기준으로 정리했습니다.
- 상단바, 검색창, 카테고리 필터, 정렬 드롭다운, 로비 카드, 채팅 영역, 푸터 UI를 개선했습니다.
- 회원(`REGISTERED`)에게만 `맵 만들기` 버튼이 노출되도록 처리했습니다.
- 게스트(`GUEST`)는 `맵 만들기` 버튼 없이 로비 목록 조회, 검색, 필터, 정렬, 입장이 가능하도록 유지했습니다.
- 로비 목록 로딩/에러/빈 상태 UI를 정리했습니다.
- 로비 관련 반복 문구, 라벨, 라우트, 상태 메타 값을 상수로 분리했습니다.
- 공통 Monomat 로고 컴포넌트를 추가하고 기존 중복 로고 구현을 정리했습니다.

## 🙏PR point

- `맵 만들기` 페이지/기능은 이번 이슈 범위가 아니므로 라우트 연결 없이 버튼 노출 조건과 위치만 정리했습니다.
- `전체` 카테고리 선택 시 `mapCategory` query를 보내지 않도록 처리했습니다.

## 📬 Reference

- Figma: Monomat AI 로비 목록 / 상단바 / 로비 카드 프레임