### PR TITLE
[Feat/#56] 1024px 미만 모바일 미지원 안내 화면 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { useSocket } from './hooks/useSocket';
 // 공통 컴포넌트
 import { ProtectedRoute } from './components/common/ProtectedRoute';
 import { AppLayout } from './components/common/AppLayout';
+import { ViewportGuard } from './components/common/ViewportGuard';
 
 // 페이지 컴포넌트
 import { Home } from './pages/Home';
@@ -18,9 +19,10 @@ import { LobbyRoom } from './pages/LobbyRoom';
  * [애플리케이션 루트 컴포넌트]
  *
  * 이 컴포넌트의 책임:
- *   1. 앱 최초 진입 시 localStorage에서 게스트 세션을 복구 (initializeSession)
- *   2. 세션이 확인된 후 WebSocket 연결 시작 (useSocket)
- *   3. URL 경로에 따라 적절한 페이지 컴포넌트를 렌더링 (Routes/Route)
+ *   1. 지원 viewport인지 확인한 뒤 기존 앱을 마운트 (ViewportGuard)
+ *   2. guard 통과 후 localStorage에서 게스트 세션을 복구 (initializeSession)
+ *   3. 세션이 확인된 후 WebSocket 연결 시작 (useSocket)
+ *   4. URL 경로에 따라 적절한 페이지 컴포넌트를 렌더링 (Routes/Route)
  *
  * 이 컴포넌트가 하지 않는 것:
  *   - 인증 가드 로직 → ProtectedRoute가 담당
@@ -28,6 +30,14 @@ import { LobbyRoom } from './pages/LobbyRoom';
  *   - 전역 레이아웃 기준 → AppLayout이 담당
  */
 function App() {
+    return (
+        <ViewportGuard>
+            <AppRoutes />
+        </ViewportGuard>
+    );
+}
+
+function AppRoutes() {
     const initializeSession = useAuthStore((state) => state.initializeSession);
 
     useEffect(() => {

--- a/src/components/common/ViewportGuard.tsx
+++ b/src/components/common/ViewportGuard.tsx
@@ -1,0 +1,20 @@
+import { type ReactNode } from 'react';
+
+import { BREAKPOINTS } from '../../constants/layout';
+import { useWindowSize } from '../../hooks/useWindowSize';
+import { MobileUnsupportedPage } from '../../pages/MobileUnsupportedPage';
+
+interface ViewportGuardProps {
+    children: ReactNode;
+}
+
+export function ViewportGuard({ children }: ViewportGuardProps) {
+    const { width } = useWindowSize();
+    const isUnsupportedViewport = width < BREAKPOINTS.MIN_PC;
+
+    if (isUnsupportedViewport) {
+        return <MobileUnsupportedPage />;
+    }
+
+    return children;
+}

--- a/src/pages/MobileUnsupportedPage.tsx
+++ b/src/pages/MobileUnsupportedPage.tsx
@@ -1,0 +1,67 @@
+import { MonomatLogo } from '../components/common/MonomatLogo';
+
+const MOBILE_UNSUPPORTED_COPY = {
+    TITLE: 'Monomat은 현재 데스크톱 환경에 최적화되어 있습니다.',
+    TITLE_PREFIX: 'Monomat은 현재 ',
+    TITLE_HIGHLIGHT: '데스크톱',
+    TITLE_SUFFIX: ' 환경에',
+    TITLE_SECOND_LINE: '최적화되어 있습니다.',
+    DESCRIPTION:
+        '원활한 실시간 음악 퀴즈 플레이를 위해 PC 또는 태블릿 가로 화면에서 접속해주세요.',
+    DESCRIPTION_FIRST_LINE: '원활한 실시간 음악 퀴즈 플레이를 위해',
+    DESCRIPTION_SECOND_LINE: 'PC 또는 태블릿 가로 화면에서 접속해주세요.',
+    FOOTER: '© 2026 Monomat. 실시간 멀티플레이 퀴즈.',
+} as const;
+
+export function MobileUnsupportedPage() {
+    return (
+        <div className="flex min-h-screen flex-col bg-[var(--monomat-page-bg)] text-[var(--monomat-text-strong)]">
+            <header className="h-[75px] shrink-0 border border-[color:var(--monomat-border-default)] bg-white">
+                <div className="mx-auto flex h-full w-full max-w-[768px] items-center px-6 sm:px-[42px]">
+                    <MonomatLogo className="h-[37px] w-[170px]" />
+                </div>
+            </header>
+
+            <main className="relative min-h-[640px] flex-1 text-center">
+                <section
+                    className="absolute left-1/2 top-[243px] flex h-[188px] w-full max-w-[768px] -translate-x-1/2 items-center justify-center px-6"
+                    aria-labelledby="mobile-unsupported-title"
+                >
+                    <div
+                        id="mobile-unsupported-title"
+                        role="heading"
+                        aria-level={1}
+                        aria-label={MOBILE_UNSUPPORTED_COPY.TITLE}
+                        className="text-[30px] font-extrabold leading-[1.28] tracking-normal text-[var(--monomat-text-strong)] sm:text-[37px] sm:leading-normal"
+                    >
+                        <span>{MOBILE_UNSUPPORTED_COPY.TITLE_PREFIX}</span>
+                        <span className="text-[33px] text-[var(--monomat-primary)] sm:text-[40px]">
+                            {MOBILE_UNSUPPORTED_COPY.TITLE_HIGHLIGHT}
+                        </span>
+                        <span>{MOBILE_UNSUPPORTED_COPY.TITLE_SUFFIX}</span>
+                        <br />
+                        <span>{MOBILE_UNSUPPORTED_COPY.TITLE_SECOND_LINE}</span>
+                    </div>
+                </section>
+
+                <div
+                    aria-label={MOBILE_UNSUPPORTED_COPY.DESCRIPTION}
+                    className="absolute left-1/2 top-[431px] flex h-[73px] w-full max-w-[768px] -translate-x-1/2 flex-col items-center justify-center px-6 text-[18px] font-medium leading-normal text-[var(--monomat-text-muted)] sm:text-xl"
+                >
+                    <span className="block">
+                        {MOBILE_UNSUPPORTED_COPY.DESCRIPTION_FIRST_LINE}
+                    </span>
+                    <span className="block">
+                        {MOBILE_UNSUPPORTED_COPY.DESCRIPTION_SECOND_LINE}
+                    </span>
+                </div>
+            </main>
+
+            <footer className="h-10 shrink-0 border border-[color:var(--monomat-border-default)] bg-white text-left text-sm leading-none text-[var(--monomat-text-muted)]">
+                <div className="mx-auto flex h-full w-full max-w-[768px] items-center px-6 sm:px-[42px]">
+                    <span>{MOBILE_UNSUPPORTED_COPY.FOOTER}</span>
+                </div>
+            </footer>
+        </div>
+    );
+}


### PR DESCRIPTION
## 📣 Related Issue

- #56

## 📝 Summary

- 1024px 미만 viewport에서 모바일 미지원 안내 화면이 표시되도록 `ViewportGuard`를 추가했습니다.
- 기존 `useWindowSize`와 `BREAKPOINTS.MIN_PC`를 재사용해 viewport 기준을 관리했습니다.
- guard 통과 후에만 기존 라우팅, 세션 초기화, 소켓 연결이 실행되도록 `App` 구조를 분리했습니다.
- Figma 기준 모바일 미지원 안내 화면을 추가했습니다.
  - 기존 `MonomatLogo` 컴포넌트 재사용
  - 상단 로고, 중앙 안내 문구, 하단 copyright 배치
  - design token 기반 색상 적용

## 🙏PR point

- 1024px 미만에서는 기존 인증/로비/인게임 UI가 노출되지 않고 안내 화면만 표시됩니다.
- 1024px 이상에서는 기존 앱 라우팅과 화면 흐름을 유지합니다.
- `1024` 값은 하드코딩하지 않고 `BREAKPOINTS.MIN_PC`를 사용했습니다.
- `npm run lint` 실행 시 기존 `public/mockServiceWorker.js`의 unused eslint-disable warning 1건이 발생하지만, 신규 lint error는 없습니다.
- `npm run build`는 정상 통과했습니다.

## 📬 Reference

- Figma: 기타 | 1024px 미만: 모바일 미지원 안내 화면
- `design.md` 지원 화면 크기 정책