### PR TITLE
[Feat/#59] 인증 플로우 UI 개편

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,15 +1,24 @@
 import { refreshAuthSession } from './authApi';
 import { ApiError } from './apiError';
-import { AUTH_MESSAGES } from '../constants/auth';
+import { AUTH_ERROR_CODES, AUTH_MESSAGES } from '../constants/auth';
 import { useAuthStore } from '../store/useAuthStore';
 
 import type {
     AuthSession,
+    RefreshSessionResponse,
     RefreshTokenResponse,
     UserType,
 } from '../types/auth';
 
 const AUTHORIZATION_HEADER = 'Authorization';
+const AUTH_ENTRY_PATH = '/';
+
+const AUTH_EXPIRED_ERROR_CODES = new Set<string>([
+    AUTH_ERROR_CODES.INVALID_REFRESH_TOKEN,
+    AUTH_ERROR_CODES.SESSION_EXPIRED,
+    AUTH_ERROR_CODES.UNAUTHENTICATED,
+    AUTH_ERROR_CODES.INVALID_AUTHORIZATION,
+]);
 
 let refreshPromise: Promise<AuthSession> | null = null;
 
@@ -59,6 +68,26 @@ function createRequestInit(
     };
 }
 
+function redirectToAuthEntry() {
+    if (
+        typeof window !== 'undefined' &&
+        window.location.pathname !== AUTH_ENTRY_PATH
+    ) {
+        window.location.replace(AUTH_ENTRY_PATH);
+    }
+}
+
+function shouldRedirectToAuthEntry(error: unknown) {
+    if (!(error instanceof ApiError)) {
+        return true;
+    }
+
+    return (
+        error.status === 401 ||
+        (error.code != null && AUTH_EXPIRED_ERROR_CODES.has(error.code))
+    );
+}
+
 function hasSessionIdentityFields(
     state: SessionIdentityState,
 ): state is ValidSessionIdentityState {
@@ -70,33 +99,48 @@ function hasSessionIdentityFields(
     );
 }
 
-function isAuthSession(response: RefreshTokenResponse): response is AuthSession {
+function isRefreshSessionResponse(
+    response: RefreshTokenResponse,
+): response is RefreshSessionResponse {
     return 'userId' in response;
 }
 
 function createSessionFromRefreshResponse(
     response: RefreshTokenResponse,
 ): AuthSession | null {
-    if (isAuthSession(response)) {
-        return response;
-    }
-
     const state = useAuthStore.getState();
 
-    if (!hasSessionIdentityFields(state)) {
-        return null;
+    if (isRefreshSessionResponse(response)) {
+        if (!state.nickname) {
+            return null;
+        }
+
+        return {
+            userId: response.userId,
+            nickname: state.nickname,
+            userType: response.userType,
+            userIdentifier: response.userIdentifier,
+            accessToken: response.accessToken,
+            accessTokenExpiresAt: response.accessTokenExpiresAt,
+            refreshToken: response.refreshToken,
+            refreshTokenExpiresAt: response.refreshTokenExpiresAt,
+        };
     }
 
-    return {
-        userId: state.userId,
-        nickname: state.nickname,
-        userType: state.userType,
-        userIdentifier: state.userIdentifier,
-        accessToken: response.accessToken,
-        accessTokenExpiresAt: response.accessTokenExpiresAt,
-        refreshToken: response.refreshToken,
-        refreshTokenExpiresAt: response.refreshTokenExpiresAt,
-    };
+    if (hasSessionIdentityFields(state)) {
+        return {
+            userId: state.userId,
+            nickname: state.nickname,
+            userType: state.userType,
+            userIdentifier: state.userIdentifier,
+            accessToken: response.accessToken,
+            accessTokenExpiresAt: response.accessTokenExpiresAt,
+            refreshToken: response.refreshToken,
+            refreshTokenExpiresAt: response.refreshTokenExpiresAt,
+        };
+    }
+
+    return null;
 }
 
 async function refreshSession(): Promise<AuthSession> {
@@ -104,7 +148,12 @@ async function refreshSession(): Promise<AuthSession> {
 
     if (!refreshToken) {
         useAuthStore.getState().clearSession();
-        throw new ApiError(401, AUTH_MESSAGES.SESSION_EXPIRED);
+        redirectToAuthEntry();
+        throw new ApiError(
+            401,
+            AUTH_MESSAGES.LOGIN_EXPIRED,
+            AUTH_ERROR_CODES.SESSION_EXPIRED,
+        );
     }
 
     try {
@@ -114,7 +163,11 @@ async function refreshSession(): Promise<AuthSession> {
         const nextSession = createSessionFromRefreshResponse(refreshResponse);
 
         if (!nextSession) {
-            throw new ApiError(401, AUTH_MESSAGES.INVALID_REFRESH_RESPONSE);
+            throw new ApiError(
+                401,
+                AUTH_MESSAGES.INVALID_REFRESH_RESPONSE,
+                AUTH_ERROR_CODES.SESSION_EXPIRED,
+            );
         }
 
         useAuthStore.getState().setSession(nextSession);
@@ -122,6 +175,9 @@ async function refreshSession(): Promise<AuthSession> {
         return nextSession;
     } catch (error) {
         useAuthStore.getState().clearSession();
+        if (shouldRedirectToAuthEntry(error)) {
+            redirectToAuthEntry();
+        }
         throw error;
     }
 }

--- a/src/api/apiError.ts
+++ b/src/api/apiError.ts
@@ -2,23 +2,53 @@ export const DEFAULT_API_ERROR_MESSAGE = '요청 처리 중 오류가 발생했�
 
 export class ApiError extends Error {
     status: number;
+    code?: string;
+    field?: string;
 
-    constructor(status: number, message: string) {
+    constructor(
+        status: number,
+        message: string,
+        code?: string,
+        field?: string,
+    ) {
         super(message);
         this.name = 'ApiError';
         this.status = status;
+        this.code = code;
+        this.field = field;
     }
+}
+
+interface ApiErrorPayload {
+    message: string;
+    code?: string;
+    field?: string;
 }
 
 function getStringField(
     payload: Record<string, unknown>,
-    fieldName: 'message' | 'error' | 'detail',
+    fieldName: 'message' | 'error' | 'detail' | 'code' | 'field',
 ) {
     const value = payload[fieldName];
 
     return typeof value === 'string' && value.trim()
         ? value
         : null;
+}
+
+function getNullableStringField(
+    payload: Record<string, unknown>,
+    fieldName: 'field',
+) {
+    const value = payload[fieldName];
+
+    if (value == null) {
+        return undefined;
+    }
+
+    return typeof value === 'string' && value.trim()
+        ? value
+        : undefined;
 }
 
 function getStringFromArrayField(
@@ -62,18 +92,49 @@ export async function parseApiErrorMessage(
             return fallbackMessage;
         }
 
-        const record = payload as Record<string, unknown>;
+        return parseApiErrorPayloadFromRecord(
+            payload as Record<string, unknown>,
+            fallbackMessage,
+        ).message;
+    } catch {
+        return fallbackMessage;
+    }
+}
 
-        return (
+function parseApiErrorPayloadFromRecord(
+    record: Record<string, unknown>,
+    fallbackMessage: string,
+): ApiErrorPayload {
+    return {
+        message:
             getStringField(record, 'message') ??
             getStringField(record, 'error') ??
             getStringField(record, 'detail') ??
             getStringFromArrayField(record, 'errors') ??
             getStringFromArrayField(record, 'fieldErrors') ??
-            fallbackMessage
+            fallbackMessage,
+        code: getStringField(record, 'code') ?? undefined,
+        field: getNullableStringField(record, 'field'),
+    };
+}
+
+async function parseApiErrorPayload(
+    response: Response,
+    fallbackMessage = DEFAULT_API_ERROR_MESSAGE,
+): Promise<ApiErrorPayload> {
+    try {
+        const payload = await response.clone().json() as unknown;
+
+        if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+            return { message: fallbackMessage };
+        }
+
+        return parseApiErrorPayloadFromRecord(
+            payload as Record<string, unknown>,
+            fallbackMessage,
         );
     } catch {
-        return fallbackMessage;
+        return { message: fallbackMessage };
     }
 }
 
@@ -81,8 +142,12 @@ export async function createApiError(
     response: Response,
     fallbackMessage = DEFAULT_API_ERROR_MESSAGE,
 ): Promise<ApiError> {
+    const payload = await parseApiErrorPayload(response, fallbackMessage);
+
     return new ApiError(
         response.status,
-        await parseApiErrorMessage(response, fallbackMessage),
+        payload.message,
+        payload.code,
+        payload.field,
     );
 }

--- a/src/components/common/MonomatLogo.tsx
+++ b/src/components/common/MonomatLogo.tsx
@@ -1,5 +1,7 @@
 interface MonomatLogoProps {
     className?: string;
+    variant?: 'black' | 'white';
+    size?: 'default' | 'small';
 }
 
 interface MonomatLogoMarkProps {
@@ -67,11 +69,22 @@ export function MonomatLogoMark({
     );
 }
 
-export function MonomatLogo({ className = '' }: MonomatLogoProps) {
+export function MonomatLogo({
+    className = '',
+    variant = 'black',
+    size = 'default',
+}: MonomatLogoProps) {
+    const isSmall = size === 'small';
+    const markClassName = isSmall ? 'h-9 w-9' : 'h-10 w-10';
+    const textClassName = isSmall
+        ? 'text-[26px]'
+        : 'text-[28px]';
+    const textColorClassName = variant === 'white' ? 'text-white' : 'text-black';
+
     return (
-        <span className={`flex items-center gap-3 ${className}`}>
-            <MonomatLogoMark />
-            <span className="text-[28px] font-extrabold leading-none text-black">
+        <span className={`flex items-center gap-[10px] ${className}`}>
+            <MonomatLogoMark className={markClassName} />
+            <span className={`${textClassName} font-extrabold leading-none ${textColorClassName}`}>
                 Monomat
             </span>
         </span>

--- a/src/components/common/NavigationBar.tsx
+++ b/src/components/common/NavigationBar.tsx
@@ -25,6 +25,9 @@ export function NavigationBar() {
 
     const displayNickname = nickname ?? 'Guest';
     const avatarText = displayNickname.charAt(0).toUpperCase();
+    const avatarClassName = userType === 'GUEST'
+        ? 'bg-[#7359D9]'
+        : 'bg-[var(--monomat-primary)]';
 
     const accountType = userType === 'GUEST' ? 'guest' : 'member';
     const canCreateMap = userType === 'REGISTERED';
@@ -51,12 +54,12 @@ export function NavigationBar() {
 
     return (
         <>
-            <header className="h-[77px] shrink-0 border border-[color:var(--monomat-border-default)] bg-white">
-                <div className="mx-auto flex h-full w-[1440px] items-center justify-between px-[33px]">
+            <header className="h-[75px] shrink-0 border border-[color:var(--monomat-border-default)] bg-white">
+                <div className="mx-auto flex h-full w-full max-w-[1440px] items-center justify-between px-[29px]">
                     <button
                         type="button"
                         onClick={handleLogoClick}
-                        className="ml-[6px] h-[37px] w-[170px]"
+                        className="h-10 w-[190px]"
                         aria-label={LOBBY_NAVIGATION_LABELS.LOGO_ARIA_LABEL}
                     >
                         <MonomatLogo />
@@ -85,7 +88,7 @@ export function NavigationBar() {
                         <button
                             type="button"
                             onClick={() => setIsInviteCodeModalOpen(true)}
-                            className="flex h-10 w-[177px] items-center justify-start rounded-lg border border-[color:var(--monomat-border-input)] bg-white text-base leading-none transition hover:bg-[var(--monomat-page-bg)]"
+                            className="flex h-10 w-[180px] items-center justify-start rounded-lg border border-[color:var(--monomat-border-input)] bg-white text-base leading-none transition hover:bg-[var(--monomat-page-bg)]"
                         >
                             <Copy
                                 className="ml-[13px] text-black"
@@ -112,7 +115,7 @@ export function NavigationBar() {
                         <button
                             type="button"
                             onClick={() => setIsAccountModalOpen(true)}
-                            className="flex h-10 w-10 items-center justify-center rounded-full bg-[var(--monomat-primary)] text-xl font-extrabold leading-none text-white"
+                            className={`flex h-10 w-10 items-center justify-center rounded-full text-xl font-extrabold leading-none text-white ${avatarClassName}`}
                             aria-label={LOBBY_NAVIGATION_LABELS.ACCOUNT_ARIA_LABEL}
                         >
                             {avatarText}

--- a/src/components/home/AuthEntryForm.tsx
+++ b/src/components/home/AuthEntryForm.tsx
@@ -4,6 +4,7 @@ import { useGuestSession } from '../../hooks/useGuestSession';
 import { useMemberLoginSession } from '../../hooks/useMemberLoginSession';
 import { useRegisterSession } from '../../hooks/useRegisterSession';
 import { AUTH_LABELS, AUTH_MESSAGES } from '../../constants/auth';
+import { AuthGlobalErrorMessage } from './AuthErrorMessage';
 import { GuestForm } from './GuestForm';
 import { LoginForm } from './LoginForm';
 import { RegisterForm } from './RegisterForm';
@@ -22,23 +23,20 @@ const MODE_LABEL: Record<Exclude<AuthMode, 'register'>, string> = {
     guest: AUTH_LABELS.GUEST_LOGIN,
 };
 
-function FeedbackMessage({
+function SuccessMessage({
     message,
-    variant,
 }: {
     message: string | null;
-    variant: 'error' | 'success';
 }) {
     if (!message) {
         return null;
     }
 
-    const className = variant === 'error'
-        ? 'mb-4 rounded-lg bg-[#FFEAEC] px-3 py-2 text-left text-[11px] font-medium leading-[15px] text-[#FD2B48]'
-        : 'mb-4 rounded-lg bg-[var(--monomat-primary-light)] px-3 py-2 text-left text-[11px] font-medium leading-[15px] text-[var(--monomat-primary)]';
-
     return (
-        <div role="alert" className={className}>
+        <div
+            role="status"
+            className="mb-4 rounded-lg bg-[var(--monomat-primary-light)] px-3 py-2 text-left text-[11px] font-medium leading-[15px] text-[var(--monomat-primary)]"
+        >
             {message}
         </div>
     );
@@ -76,9 +74,16 @@ export function AuthEntryForm({
     const activeErrorMessage = isMemberMode
         ? memberSession.errorMessage
         : guestSession.errorMessage;
+    const activeErrorField = isMemberMode
+        ? memberSession.errorField
+        : guestSession.errorField;
+    const activeGlobalErrorMessage = activeErrorField
+        ? null
+        : activeErrorMessage;
     const isActiveSubmitting = isMemberMode
         ? memberSession.isSubmitting
         : guestSession.isSubmitting;
+    const hasTopFeedback = Boolean(activeGlobalErrorMessage || successMessage);
 
     const clearAllFeedback = () => {
         memberSession.clearErrorMessage();
@@ -145,6 +150,7 @@ export function AuthEntryForm({
                 nickname={registerNickname}
                 isSubmitting={registerSession.isSubmitting}
                 errorMessage={registerSession.errorMessage}
+                errorField={registerSession.errorField}
                 onLoginIdChange={(value) => {
                     registerSession.clearErrorMessage();
                     setLoginId(value);
@@ -168,15 +174,15 @@ export function AuthEntryForm({
     }
 
     return (
-        <div className="w-full max-w-[480px] min-w-0 rounded-2xl bg-[var(--monomat-surface)] px-5 pb-8 pt-8 text-[var(--monomat-text-strong)] shadow-[0_18px_42px_rgba(12,17,28,0.12)] sm:px-8 sm:pb-10 sm:pt-10 lg:px-10 lg:pb-12 lg:pt-11">
-            <header className="mb-[22px] text-center">
-                <h2 className="mb-2 break-keep text-2xl font-extrabold leading-9 !text-[var(--monomat-text-strong)] lg:leading-10">
+        <div className="w-full max-w-[480px] min-w-0 rounded-2xl bg-[var(--monomat-surface)] px-5 py-8 text-[var(--monomat-text-strong)] shadow-[0_4px_24px_rgba(0,0,0,0.18)] sm:min-h-[690px] sm:px-[30px] sm:pb-[57px] sm:pt-14">
+            <header className="mb-[24px] text-center">
+                <h2 className="mb-[21px] break-keep text-2xl font-extrabold leading-7 !text-black">
                     {isMemberMode
                         ? AUTH_LABELS.LOGIN
                         : AUTH_LABELS.GUEST_LOGIN}
                 </h2>
 
-                <p className="break-keep text-sm font-medium leading-5 text-[var(--monomat-text-muted)]">
+                <p className="break-keep text-sm font-medium leading-[17px] text-[var(--monomat-text-muted)]">
                     {AUTH_LABELS.WELCOME}
                 </p>
             </header>
@@ -184,7 +190,9 @@ export function AuthEntryForm({
             <div
                 role="tablist"
                 aria-label="로그인 방식 선택"
-                className="mb-6 grid min-h-11 grid-cols-2 rounded-[10px] bg-[var(--monomat-page-bg)] p-1"
+                className={`grid min-h-[45px] grid-cols-2 rounded-lg bg-[var(--monomat-page-bg)] p-[5px] ${
+                    hasTopFeedback ? 'mb-[19px]' : 'mb-[43px]'
+                }`}
             >
                 {ENTRY_MODES.map((authMode) => {
                     const isSelected = mode === authMode;
@@ -199,8 +207,8 @@ export function AuthEntryForm({
                             onClick={() => handleModeChange(authMode)}
                             className={`min-h-9 min-w-0 rounded-lg px-2 text-sm leading-5 transition disabled:cursor-not-allowed ${
                                 isSelected
-                                    ? 'bg-white font-semibold text-[var(--monomat-text-strong)] shadow-sm'
-                                    : 'font-medium text-[var(--monomat-text-muted)] hover:text-[var(--monomat-text-strong)]'
+                                    ? 'bg-white font-semibold text-black shadow-[0_1px_4px_rgba(0,0,0,0.22)]'
+                                    : 'font-semibold text-[var(--monomat-text-muted)] hover:text-[var(--monomat-text-strong)]'
                             }`}
                         >
                             {MODE_LABEL[authMode]}
@@ -209,8 +217,11 @@ export function AuthEntryForm({
                 })}
             </div>
 
-            <FeedbackMessage message={activeErrorMessage} variant="error" />
-            <FeedbackMessage message={successMessage} variant="success" />
+            <AuthGlobalErrorMessage
+                message={activeGlobalErrorMessage}
+                className="mb-[19px]"
+            />
+            <SuccessMessage message={successMessage} />
 
             {isMemberMode ? (
                 <LoginForm
@@ -218,6 +229,8 @@ export function AuthEntryForm({
                     password={memberPassword}
                     autoLogin={autoLogin}
                     isSubmitting={memberSession.isSubmitting}
+                    errorMessage={memberSession.errorMessage}
+                    errorField={memberSession.errorField}
                     onLoginIdChange={(value) => {
                         memberSession.clearErrorMessage();
                         setSuccessMessage(null);
@@ -237,6 +250,8 @@ export function AuthEntryForm({
                 <GuestForm
                     nickname={guestNickname}
                     isSubmitting={guestSession.isSubmitting}
+                    errorMessage={guestSession.errorMessage}
+                    errorField={guestSession.errorField}
                     onNicknameChange={(value) => {
                         guestSession.clearErrorMessage();
                         setSuccessMessage(null);

--- a/src/components/home/AuthErrorMessage.tsx
+++ b/src/components/home/AuthErrorMessage.tsx
@@ -1,0 +1,60 @@
+interface AuthGlobalErrorMessageProps {
+    message: string | null;
+    className?: string;
+}
+
+interface AuthFieldHeaderProps {
+    htmlFor: string;
+    label: string;
+    errorMessage: string | null;
+    labelClassName?: string;
+}
+
+export function AuthGlobalErrorMessage({
+    message,
+    className = '',
+}: AuthGlobalErrorMessageProps) {
+    if (!message) {
+        return null;
+    }
+
+    return (
+        <div
+            role="alert"
+            className={`flex min-h-5 w-full max-w-[420px] items-center justify-center rounded-lg bg-[var(--monomat-danger-light)] px-2 py-[3px] text-center text-[10px] font-medium leading-[14px] text-[var(--monomat-danger)] sm:h-5 sm:overflow-hidden sm:py-0 ${className}`}
+        >
+            <span className="min-w-0 break-words sm:truncate">
+                {message}
+            </span>
+        </div>
+    );
+}
+
+export function AuthFieldHeader({
+    htmlFor,
+    label,
+    errorMessage,
+    labelClassName = 'text-[var(--monomat-text-muted)]',
+}: AuthFieldHeaderProps) {
+    return (
+        <div className="mb-[7px] flex min-h-[14px] min-w-0 items-start gap-2">
+            <label
+                htmlFor={htmlFor}
+                className={`shrink-0 text-xs font-medium leading-[14px] ${labelClassName}`}
+            >
+                {label}
+            </label>
+
+            {errorMessage ? (
+                <p
+                    role="alert"
+                    className="flex h-[14px] min-w-0 flex-1 items-center justify-center overflow-hidden rounded-lg bg-[var(--monomat-danger-light)] px-2 text-center text-[9px] font-medium leading-[14px] text-[var(--monomat-danger)]"
+                >
+                    <span className="min-w-0 truncate">
+                        {errorMessage}
+                    </span>
+                </p>
+            ) : null}
+        </div>
+    );
+}

--- a/src/components/home/GuestForm.tsx
+++ b/src/components/home/GuestForm.tsx
@@ -5,10 +5,13 @@ import {
     GUEST_NICKNAME_GUIDE,
     GUEST_NICKNAME_POLICY,
 } from '../../constants/auth';
+import { AuthFieldHeader } from './AuthErrorMessage';
 
 interface GuestFormProps {
     nickname: string;
     isSubmitting: boolean;
+    errorMessage: string | null;
+    errorField: string | null;
     onNicknameChange: (value: string) => void;
     onSubmit: () => void;
 }
@@ -16,6 +19,8 @@ interface GuestFormProps {
 export function GuestForm({
     nickname,
     isSubmitting,
+    errorMessage,
+    errorField,
     onNicknameChange,
     onSubmit,
 }: GuestFormProps) {
@@ -23,15 +28,15 @@ export function GuestForm({
         event.preventDefault();
         onSubmit();
     };
+    const nicknameError = errorField === 'nickname' ? errorMessage : null;
 
     return (
         <form onSubmit={handleSubmit} className="min-w-0 text-left">
-            <label
+            <AuthFieldHeader
                 htmlFor="guest-nickname"
-                className="mb-2 block text-xs font-semibold text-[var(--monomat-text-muted)]"
-            >
-                {AUTH_LABELS.NICKNAME}
-            </label>
+                label={AUTH_LABELS.NICKNAME}
+                errorMessage={nicknameError}
+            />
             <input
                 id="guest-nickname"
                 type="text"
@@ -41,13 +46,13 @@ export function GuestForm({
                 disabled={isSubmitting}
                 placeholder={AUTH_LABELS.NICKNAME_PLACEHOLDER}
                 onChange={(event) => onNicknameChange(event.target.value)}
-                className="h-11 w-full rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-4 text-sm text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                className="h-11 w-full min-w-0 rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-5 text-sm font-medium text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
             />
 
-            <ul className="mt-5 space-y-[6px] text-[13px] leading-5 text-[var(--monomat-text-muted)]">
+            <ul className="mt-10 space-y-[11px] text-[13px] leading-4 text-[var(--monomat-text-muted)]">
                 {GUEST_NICKNAME_GUIDE.map((guide) => (
                     <li key={guide} className="break-keep">
-                        - {guide}
+                        {guide}
                     </li>
                 ))}
             </ul>
@@ -55,7 +60,7 @@ export function GuestForm({
             <button
                 type="submit"
                 disabled={isSubmitting}
-                className="mt-8 min-h-12 w-full min-w-0 rounded-lg bg-[var(--monomat-primary)] px-3 text-[15px] font-bold leading-5 text-white transition hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:bg-[var(--monomat-primary-disabled)]"
+                className="mt-[30px] min-h-12 w-full min-w-0 rounded-lg bg-[var(--monomat-primary)] px-3 text-[15px] font-bold leading-5 text-white transition hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:bg-[var(--monomat-primary-disabled)]"
             >
                 {isSubmitting
                     ? AUTH_LABELS.SUBMITTING

--- a/src/components/home/LoginForm.tsx
+++ b/src/components/home/LoginForm.tsx
@@ -1,12 +1,15 @@
 import { type FormEvent } from 'react';
 
 import { AUTH_LABELS } from '../../constants/auth';
+import { AuthFieldHeader } from './AuthErrorMessage';
 
 interface LoginFormProps {
     loginId: string;
     password: string;
     autoLogin: boolean;
     isSubmitting: boolean;
+    errorMessage: string | null;
+    errorField: string | null;
     onLoginIdChange: (value: string) => void;
     onPasswordChange: (value: string) => void;
     onAutoLoginChange: (value: boolean) => void;
@@ -18,6 +21,8 @@ export function LoginForm({
     password,
     autoLogin,
     isSubmitting,
+    errorMessage,
+    errorField,
     onLoginIdChange,
     onPasswordChange,
     onAutoLoginChange,
@@ -27,15 +32,16 @@ export function LoginForm({
         event.preventDefault();
         onSubmit();
     };
+    const loginIdError = errorField === 'loginId' ? errorMessage : null;
+    const passwordError = errorField === 'password' ? errorMessage : null;
 
     return (
         <form onSubmit={handleSubmit} className="min-w-0 text-left">
-            <label
+            <AuthFieldHeader
                 htmlFor="login-id"
-                className="mb-2 block text-xs font-semibold text-[var(--monomat-text-muted)]"
-            >
-                {AUTH_LABELS.LOGIN_ID}
-            </label>
+                label={AUTH_LABELS.LOGIN_ID}
+                errorMessage={loginIdError}
+            />
             <input
                 id="login-id"
                 type="text"
@@ -44,15 +50,15 @@ export function LoginForm({
                 disabled={isSubmitting}
                 placeholder={AUTH_LABELS.LOGIN_ID_PLACEHOLDER}
                 onChange={(event) => onLoginIdChange(event.target.value)}
-                className="h-11 w-full rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-4 text-sm text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                className="h-11 w-full min-w-0 rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-5 text-sm font-medium text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
             />
 
-            <label
+            <div className="mt-[27px]" />
+            <AuthFieldHeader
                 htmlFor="login-password"
-                className="mb-2 mt-[22px] block text-xs font-semibold text-[var(--monomat-text-muted)]"
-            >
-                {AUTH_LABELS.PASSWORD}
-            </label>
+                label={AUTH_LABELS.PASSWORD}
+                errorMessage={passwordError}
+            />
             <input
                 id="login-password"
                 type="password"
@@ -60,10 +66,10 @@ export function LoginForm({
                 disabled={isSubmitting}
                 placeholder={AUTH_LABELS.PASSWORD_PLACEHOLDER}
                 onChange={(event) => onPasswordChange(event.target.value)}
-                className="h-11 w-full rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-4 text-sm text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                className="h-11 w-full min-w-0 rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-5 text-sm font-medium text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
             />
 
-            <label className="mt-[18px] flex h-5 items-center gap-2 text-[13px] font-medium text-[var(--monomat-text-muted)]">
+            <label className="mt-[22px] flex h-4 items-center gap-[6px] text-xs font-medium text-[var(--monomat-text-muted)]">
                 <input
                     type="checkbox"
                     checked={autoLogin}
@@ -77,7 +83,7 @@ export function LoginForm({
             <button
                 type="submit"
                 disabled={isSubmitting}
-                className="mt-[22px] min-h-12 w-full min-w-0 rounded-lg bg-[var(--monomat-primary)] px-3 text-[15px] font-bold leading-5 text-white transition hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:bg-[var(--monomat-primary-disabled)]"
+                className="mt-[27px] min-h-12 w-full min-w-0 rounded-lg bg-[var(--monomat-primary)] px-3 text-[15px] font-bold leading-5 text-white transition hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:bg-[var(--monomat-primary-disabled)]"
             >
                 {isSubmitting
                     ? AUTH_LABELS.LOGIN_SUBMITTING

--- a/src/components/home/RegisterForm.tsx
+++ b/src/components/home/RegisterForm.tsx
@@ -2,10 +2,13 @@ import { type FormEvent } from 'react';
 
 import {
     AUTH_LABELS,
-    AUTH_MESSAGES,
     REGISTER_POLICY,
 } from '../../constants/auth';
-import { MonomatLogoMark } from '../common/MonomatLogo';
+import { MonomatLogo } from '../common/MonomatLogo';
+import {
+    AuthFieldHeader,
+    AuthGlobalErrorMessage,
+} from './AuthErrorMessage';
 
 interface RegisterFormProps {
     loginId: string;
@@ -14,32 +17,13 @@ interface RegisterFormProps {
     nickname: string;
     isSubmitting: boolean;
     errorMessage: string | null;
+    errorField: string | null;
     onLoginIdChange: (value: string) => void;
     onPasswordChange: (value: string) => void;
     onPasswordConfirmChange: (value: string) => void;
     onNicknameChange: (value: string) => void;
     onSubmit: () => void;
     onLoginClick: () => void;
-}
-
-function RegisterErrorMessage({ message }: { message: string | null }) {
-    if (!message) {
-        return null;
-    }
-
-    return (
-        <div
-            role="alert"
-            className="mb-[10px] min-h-[31px] rounded-md bg-[#FFEAEC] px-3 py-[9px] text-left text-[11px] font-medium leading-[13px] text-[#FD2B48]"
-        >
-            {message}
-        </div>
-    );
-}
-
-function isPasswordConfirmError(message: string | null) {
-    return message === AUTH_MESSAGES.EMPTY_PASSWORD_CONFIRM ||
-        message === AUTH_MESSAGES.PASSWORD_CONFIRM_MISMATCH;
 }
 
 function SignupDivider() {
@@ -57,6 +41,7 @@ export function RegisterForm({
     nickname,
     isSubmitting,
     errorMessage,
+    errorField,
     onLoginIdChange,
     onPasswordChange,
     onPasswordConfirmChange,
@@ -68,40 +53,38 @@ export function RegisterForm({
         event.preventDefault();
         onSubmit();
     };
-    const passwordConfirmErrorMessage = isPasswordConfirmError(errorMessage)
-        ? errorMessage
-        : null;
-    const formErrorMessage = passwordConfirmErrorMessage
-        ? null
-        : errorMessage;
+    const getFieldError = (field: string) => (
+        errorField === field ? errorMessage : null
+    );
+    const formErrorMessage = errorField ? null : errorMessage;
 
     return (
-        <div className="min-h-[651px] w-full max-w-[480px] min-w-0 rounded-2xl bg-white px-10 pb-5 pt-[27px] text-[var(--monomat-text-strong)] shadow-[0_4px_24px_rgba(0,0,0,0.08)]">
-            <div className="mx-auto flex h-[37px] w-[170px] items-center justify-center gap-[10px]">
-                <MonomatLogoMark />
-                <span className="text-[28px] font-extrabold leading-none text-black">
-                    Monomat
-                </span>
+        <div className="w-full max-w-[480px] min-w-0 rounded-2xl bg-white px-5 pb-8 pt-8 text-[var(--monomat-text-strong)] shadow-[0_4px_24px_rgba(0,0,0,0.16)] sm:px-[30px] sm:pb-12 sm:pt-[47px]">
+            <div className="flex h-9 min-w-0 items-center justify-start">
+                <MonomatLogo size="small" />
             </div>
 
-            <header className="mt-[11px] text-center">
-                <h2 className="m-0 text-xl font-bold leading-10 !text-[var(--monomat-text-strong)]">
+            <header className="mt-[15px] text-center sm:mt-[15px]">
+                <h2 className="m-0 text-2xl font-extrabold leading-7 !text-black">
                     {AUTH_LABELS.SIGNUP}
                 </h2>
-                <p className="text-sm font-normal leading-5 text-[var(--monomat-text-muted)]">
+                <p className="mt-[7px] break-keep text-sm font-medium leading-[17px] text-[var(--monomat-text-muted)]">
                     {AUTH_LABELS.SIGNUP_DESCRIPTION}
                 </p>
             </header>
 
             <form onSubmit={handleSubmit} className="mt-[15px] min-w-0 text-left">
-                <RegisterErrorMessage message={formErrorMessage} />
+                <AuthGlobalErrorMessage
+                    message={formErrorMessage}
+                    className="mb-[15px]"
+                />
 
-                <label
+                <AuthFieldHeader
                     htmlFor="register-login-id"
-                    className="mb-[5px] block text-sm font-medium leading-[17px] text-black"
-                >
-                    {AUTH_LABELS.LOGIN_ID}
-                </label>
+                    label={AUTH_LABELS.LOGIN_ID}
+                    errorMessage={getFieldError('loginId')}
+                    labelClassName="text-black"
+                />
                 <input
                     id="register-login-id"
                     type="text"
@@ -111,15 +94,16 @@ export function RegisterForm({
                     disabled={isSubmitting}
                     placeholder={AUTH_LABELS.REGISTER_LOGIN_ID_PLACEHOLDER}
                     onChange={(event) => onLoginIdChange(event.target.value)}
-                    className="h-11 w-full rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-3 text-sm text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                    className="h-11 w-full min-w-0 rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-5 text-sm font-medium text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
                 />
 
-                <label
+                <div className="mt-[23px]" />
+                <AuthFieldHeader
                     htmlFor="register-password"
-                    className="mb-[5px] mt-[15px] block text-sm font-medium leading-[17px] text-black"
-                >
-                    {AUTH_LABELS.PASSWORD}
-                </label>
+                    label={AUTH_LABELS.PASSWORD}
+                    errorMessage={getFieldError('password')}
+                    labelClassName="text-black"
+                />
                 <input
                     id="register-password"
                     type="password"
@@ -128,26 +112,16 @@ export function RegisterForm({
                     disabled={isSubmitting}
                     placeholder={AUTH_LABELS.REGISTER_PASSWORD_PLACEHOLDER}
                     onChange={(event) => onPasswordChange(event.target.value)}
-                    className="h-11 w-full rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-3 text-sm text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                    className="h-11 w-full min-w-0 rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-5 text-sm font-medium text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
                 />
 
-                <div className="mb-[5px] mt-[15px] grid min-h-[17px] min-w-0 grid-cols-[77px_minmax(0,1fr)] items-start gap-4">
-                    <label
-                        htmlFor="register-password-confirm"
-                        className="whitespace-nowrap text-sm font-medium leading-[17px] text-black"
-                    >
-                        {AUTH_LABELS.PASSWORD_CONFIRM}
-                    </label>
-
-                    {passwordConfirmErrorMessage ? (
-                        <p
-                            role="alert"
-                            className="flex h-[17px] min-w-0 items-center justify-center rounded-lg bg-[#FFEAEC] px-2 text-center text-[10px] font-medium leading-[17px] text-[#FD2B48]"
-                        >
-                            {passwordConfirmErrorMessage}
-                        </p>
-                    ) : null}
-                </div>
+                <div className="mt-[23px]" />
+                <AuthFieldHeader
+                    htmlFor="register-password-confirm"
+                    label={AUTH_LABELS.PASSWORD_CONFIRM}
+                    errorMessage={getFieldError('passwordConfirm')}
+                    labelClassName="text-black"
+                />
                 <input
                     id="register-password-confirm"
                     type="password"
@@ -156,19 +130,20 @@ export function RegisterForm({
                     disabled={isSubmitting}
                     placeholder={AUTH_LABELS.PASSWORD_CONFIRM_PLACEHOLDER}
                     onChange={(event) => onPasswordConfirmChange(event.target.value)}
-                    className="h-11 w-full rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-3 text-sm text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                    className="h-11 w-full min-w-0 rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-5 text-sm font-medium text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
                 />
 
-                <div className="mt-[18px]">
+                <div className="mt-[15px]">
                     <SignupDivider />
                 </div>
 
-                <label
+                <div className="mt-[15px]" />
+                <AuthFieldHeader
                     htmlFor="register-nickname"
-                    className="mb-[5px] mt-[9px] block text-sm font-medium leading-[17px] text-black"
-                >
-                    {AUTH_LABELS.NICKNAME}
-                </label>
+                    label={AUTH_LABELS.NICKNAME}
+                    errorMessage={getFieldError('nickname')}
+                    labelClassName="text-black"
+                />
                 <input
                     id="register-nickname"
                     type="text"
@@ -177,17 +152,17 @@ export function RegisterForm({
                     disabled={isSubmitting}
                     placeholder={AUTH_LABELS.REGISTER_NICKNAME_PLACEHOLDER}
                     onChange={(event) => onNicknameChange(event.target.value)}
-                    className="h-11 w-full rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-3 text-sm text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                    className="h-11 w-full min-w-0 rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-5 text-sm font-medium text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
                 />
 
-                <div className="mt-[8px]">
+                <div className="mt-[15px]">
                     <SignupDivider />
                 </div>
 
                 <button
                     type="submit"
                     disabled={isSubmitting}
-                    className="mt-[9px] h-12 w-full min-w-0 rounded-lg bg-[var(--monomat-primary)] px-3 text-[15px] font-bold leading-5 text-white transition hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:bg-[var(--monomat-primary-disabled)]"
+                    className="mt-[15px] h-12 w-full min-w-0 rounded-lg bg-[var(--monomat-primary)] px-3 text-[15px] font-bold leading-5 text-white transition hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:bg-[var(--monomat-primary-disabled)]"
                 >
                     {isSubmitting
                         ? AUTH_LABELS.SIGNUP_SUBMITTING
@@ -195,7 +170,7 @@ export function RegisterForm({
                 </button>
             </form>
 
-            <footer className="mt-[14px] flex h-6 min-w-0 items-center justify-between gap-4 text-[13px] leading-4">
+            <footer className="mt-[15px] flex min-h-4 min-w-0 items-center justify-between gap-4 text-xs leading-4">
                 <span className="min-w-0 break-keep text-[var(--monomat-text-muted)]">
                     {AUTH_LABELS.ALREADY_HAVE_ACCOUNT}
                 </span>
@@ -204,7 +179,7 @@ export function RegisterForm({
                     type="button"
                     disabled={isSubmitting}
                     onClick={onLoginClick}
-                    className="font-semibold text-[var(--monomat-primary)] underline underline-offset-2 transition hover:text-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:opacity-60"
+                    className="shrink-0 font-semibold text-[var(--monomat-primary)] underline underline-offset-2 transition hover:text-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:opacity-60"
                 >
                     {AUTH_LABELS.LOGIN}
                 </button>

--- a/src/components/lobby/LobbyFooter.tsx
+++ b/src/components/lobby/LobbyFooter.tsx
@@ -1,7 +1,7 @@
 export function LobbyFooter() {
     return (
-        <footer className="h-[41px] shrink-0 border border-[color:var(--monomat-border-default)] bg-white text-sm leading-none text-[var(--monomat-text-muted)]">
-            <div className="mx-auto flex h-full w-[1440px] items-center justify-between px-[35px]">
+        <footer className="h-10 shrink-0 border border-[color:var(--monomat-border-default)] bg-white text-sm leading-none text-[var(--monomat-text-muted)]">
+            <div className="mx-auto flex h-full w-full max-w-[1440px] items-center justify-between px-[29px]">
                 <span>© 2026 Monomat. 실시간 멀티플레이 퀴즈.</span>
 
                 <div className="flex items-center gap-[30px]">

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -11,19 +11,28 @@ export const GUEST_NICKNAME_POLICY = {
 } as const;
 
 export const REGISTER_POLICY = {
+    LOGIN_ID_MIN_LENGTH: 4,
     LOGIN_ID_MAX_LENGTH: 50,
+    LOGIN_ID_PATTERN: /^[A-Za-z0-9]+$/,
+    PASSWORD_MIN_LENGTH: 8,
     PASSWORD_MAX_LENGTH: 100,
-    NICKNAME_MAX_LENGTH: 8,
+    PASSWORD_WHITESPACE_PATTERN: /\s/,
+    NICKNAME_MIN_LENGTH: 2,
+    NICKNAME_MAX_LENGTH: 12,
 } as const;
 
 export const AUTH_MESSAGES = {
-    EMPTY_NICKNAME: '닉네임을 입력해주세요.',
-    INVALID_NICKNAME_LENGTH: `닉네임은 ${GUEST_NICKNAME_POLICY.MIN_LENGTH}~${GUEST_NICKNAME_POLICY.MAX_LENGTH}자 이내로 입력해주세요.`,
+    EMPTY_NICKNAME: '닉네임은 비어 있을 수 없습니다.',
+    INVALID_NICKNAME_LENGTH: `닉네임은 ${GUEST_NICKNAME_POLICY.MIN_LENGTH}자 이상 ${GUEST_NICKNAME_POLICY.MAX_LENGTH}자 이하로 입력해주세요.`,
     INVALID_NICKNAME_WHITESPACE: '공백이 포함된 닉네임은 사용할 수 없습니다.',
     GUEST_LOGIN_FAILED: '게스트 입장에 실패했습니다. 잠시 후 다시 시도해주세요.',
     INVALID_GUEST_LOGIN_RESPONSE: '서버 응답 형식이 올바르지 않습니다.',
-    EMPTY_LOGIN_ID: '아이디를 입력해주세요.',
-    EMPTY_PASSWORD: '비밀번호를 입력해주세요.',
+    EMPTY_LOGIN_ID: '로그인 ID를 입력해주세요.',
+    INVALID_LOGIN_ID_LENGTH: `로그인 ID는 ${REGISTER_POLICY.LOGIN_ID_MIN_LENGTH}자 이상 ${REGISTER_POLICY.LOGIN_ID_MAX_LENGTH}자 이하로 입력해주세요.`,
+    INVALID_LOGIN_ID_FORMAT: '로그인 ID는 영문과 숫자만 사용할 수 있습니다.',
+    EMPTY_PASSWORD: '비밀번호는 비어 있을 수 없습니다.',
+    INVALID_PASSWORD_LENGTH: `비밀번호는 ${REGISTER_POLICY.PASSWORD_MIN_LENGTH}자 이상 ${REGISTER_POLICY.PASSWORD_MAX_LENGTH}자 이하여야 합니다.`,
+    INVALID_PASSWORD_WHITESPACE: '비밀번호에는 공백을 사용할 수 없습니다.',
     EMPTY_PASSWORD_CONFIRM: '비밀번호 확인을 입력해주세요.',
     PASSWORD_CONFIRM_MISMATCH: '비밀번호가 일치하지 않습니다.',
     LOGIN_FAILED: '로그인에 실패했습니다. 아이디와 비밀번호를 확인해주세요.',
@@ -35,6 +44,14 @@ export const AUTH_MESSAGES = {
     SESSION_REFRESH_FAILED: '인증 세션 갱신에 실패했습니다.',
     INVALID_REFRESH_RESPONSE: '토큰 갱신 응답 형식이 올바르지 않습니다.',
     SESSION_RESTORE_FAILED: '저장된 인증 세션을 복구하지 못했습니다.',
+    LOGIN_EXPIRED: '로그인이 만료되었습니다. 다시 로그인해주세요.',
+} as const;
+
+export const AUTH_ERROR_CODES = {
+    INVALID_REFRESH_TOKEN: 'AUTH_INVALID_REFRESH_TOKEN',
+    SESSION_EXPIRED: 'AUTH_SESSION_EXPIRED',
+    UNAUTHENTICATED: 'AUTH_UNAUTHENTICATED',
+    INVALID_AUTHORIZATION: 'AUTH_INVALID_AUTHORIZATION',
 } as const;
 
 export const AUTH_LABELS = {
@@ -42,7 +59,7 @@ export const AUTH_LABELS = {
     GUEST_LOGIN: '게스트 입장',
     WELCOME: 'Monomat에 오신 것을 환영합니다',
     LOGIN_ID: '아이디',
-    LOGIN_ID_PLACEHOLDER: '로그인 ID를 입력하세요',
+    LOGIN_ID_PLACEHOLDER: '아이디를 입력하세요',
     REGISTER_LOGIN_ID_PLACEHOLDER: '영문/숫자 4자 이상 입력해주세요',
     PASSWORD: '비밀번호',
     PASSWORD_PLACEHOLDER: '비밀번호를 입력하세요',
@@ -55,13 +72,13 @@ export const AUTH_LABELS = {
     QUICK_GUEST_START: '게스트로 빠르게 시작',
     NICKNAME: '닉네임',
     NICKNAME_PLACEHOLDER: '게임에서 사용할 닉네임을 입력하세요',
-    REGISTER_NICKNAME_PLACEHOLDER: '게임에서 사용할 닉네임을 입력해주세요',
-    SUBMIT: '게임 참가하기',
+    REGISTER_NICKNAME_PLACEHOLDER: '게임에서 사용할 닉네임을 입력하세요',
+    SUBMIT: '게임 참여하기',
     SUBMITTING: '입장 중...',
     OR: '또는',
     SIGNUP_HINT: '계정이 없으신가요?',
     SIGNUP: '회원가입',
-    SIGNUP_DESCRIPTION: '회원가입하고 나만의 맵을 만들어보세요.',
+    SIGNUP_DESCRIPTION: '회원가입하고 나만의 맵을 만들어보세요',
     SIGNUP_BUTTON: '가입하기',
     SIGNUP_SUBMITTING: '가입 중...',
     ALREADY_HAVE_ACCOUNT: '이미 계정이 있으신가요?',

--- a/src/constants/home.ts
+++ b/src/constants/home.ts
@@ -3,7 +3,7 @@
 export const HOME_COPY = {
     SERVICE_NAME: 'Monomat',
     TITLE: '실시간 YouTube\n음악 퀴즈 게임',
-    LOGIN_DESCRIPTION: '친구들과 함께 노래를 맞춰보세요.\n방을 만들거나 게스트로 바로 참가할 수 있습니다.',
+    LOGIN_DESCRIPTION: '친구들과 함께 노래를 맞춰보세요.\n로비를 만들거나 게스트로 바로 참가할 수 있습니다.',
     GUEST_DESCRIPTION: '닉네임만 입력하면 바로 시작!\n회원가입 없이 게스트로 즉시 참가할 수 있습니다.',
 } as const;
 
@@ -18,6 +18,6 @@ export const HOME_FEATURES = [
     },
     {
         iconName: 'users',
-        label: '최대 N인 동시 플레이',
+        label: '최대 8인 동시 플레이',
     },
 ] as const;

--- a/src/hooks/useGuestSession.ts
+++ b/src/hooks/useGuestSession.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { loginAsGuest } from '../api/authApi';
+import { ApiError } from '../api/apiError';
 import { AUTH_MESSAGES } from '../constants/auth';
 import { useAuthStore } from '../store/useAuthStore';
 import { validateGuestNickname } from '../utils/validateNickname';
@@ -10,6 +11,7 @@ interface UseGuestSessionReturn {
     createGuestSession: (nickname: string) => Promise<void>;
     isSubmitting: boolean;
     errorMessage: string | null;
+    errorField: string | null;
     clearErrorMessage: () => void;
 }
 
@@ -27,9 +29,11 @@ export function useGuestSession(): UseGuestSessionReturn {
 
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [errorField, setErrorField] = useState<string | null>(null);
 
     const clearErrorMessage = () => {
         setErrorMessage(null);
+        setErrorField(null);
     };
 
     const createGuestSession = async (nickname: string) => {
@@ -38,6 +42,7 @@ export function useGuestSession(): UseGuestSessionReturn {
 
         if (validationMessage) {
             setErrorMessage(validationMessage);
+            setErrorField('nickname');
             return;
         }
 
@@ -48,6 +53,7 @@ export function useGuestSession(): UseGuestSessionReturn {
         try {
             setIsSubmitting(true);
             setErrorMessage(null);
+            setErrorField(null);
 
             const session = await loginAsGuest({
                 nickname: trimmedNickname,
@@ -57,6 +63,7 @@ export function useGuestSession(): UseGuestSessionReturn {
             navigate('/lobbies');
         } catch (error) {
             setErrorMessage(getErrorMessage(error));
+            setErrorField(error instanceof ApiError ? error.field ?? null : null);
         } finally {
             setIsSubmitting(false);
         }
@@ -66,6 +73,7 @@ export function useGuestSession(): UseGuestSessionReturn {
         createGuestSession,
         isSubmitting,
         errorMessage,
+        errorField,
         clearErrorMessage,
     };
 }

--- a/src/hooks/useMemberLoginSession.ts
+++ b/src/hooks/useMemberLoginSession.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { login } from '../api/authApi';
+import { ApiError } from '../api/apiError';
 import { AUTH_MESSAGES } from '../constants/auth';
 import { useAuthStore } from '../store/useAuthStore';
 
@@ -9,6 +10,7 @@ interface UseMemberLoginSessionReturn {
     loginWithAccount: (loginId: string, password: string) => Promise<void>;
     isSubmitting: boolean;
     errorMessage: string | null;
+    errorField: string | null;
     clearErrorMessage: () => void;
 }
 
@@ -26,9 +28,11 @@ export function useMemberLoginSession(): UseMemberLoginSessionReturn {
 
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [errorField, setErrorField] = useState<string | null>(null);
 
     const clearErrorMessage = () => {
         setErrorMessage(null);
+        setErrorField(null);
     };
 
     const loginWithAccount = async (loginId: string, password: string) => {
@@ -36,11 +40,13 @@ export function useMemberLoginSession(): UseMemberLoginSessionReturn {
 
         if (!trimmedLoginId) {
             setErrorMessage(AUTH_MESSAGES.EMPTY_LOGIN_ID);
+            setErrorField('loginId');
             return;
         }
 
         if (!password) {
             setErrorMessage(AUTH_MESSAGES.EMPTY_PASSWORD);
+            setErrorField('password');
             return;
         }
 
@@ -51,6 +57,7 @@ export function useMemberLoginSession(): UseMemberLoginSessionReturn {
         try {
             setIsSubmitting(true);
             setErrorMessage(null);
+            setErrorField(null);
 
             const session = await login({
                 loginId: trimmedLoginId,
@@ -61,6 +68,7 @@ export function useMemberLoginSession(): UseMemberLoginSessionReturn {
             navigate('/lobbies');
         } catch (error) {
             setErrorMessage(getErrorMessage(error));
+            setErrorField(error instanceof ApiError ? error.field ?? null : null);
         } finally {
             setIsSubmitting(false);
         }
@@ -70,6 +78,7 @@ export function useMemberLoginSession(): UseMemberLoginSessionReturn {
         loginWithAccount,
         isSubmitting,
         errorMessage,
+        errorField,
         clearErrorMessage,
     };
 }

--- a/src/hooks/useRegisterSession.ts
+++ b/src/hooks/useRegisterSession.ts
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 
 import { register } from '../api/authApi';
-import { AUTH_MESSAGES } from '../constants/auth';
+import { ApiError } from '../api/apiError';
+import { AUTH_MESSAGES, REGISTER_POLICY } from '../constants/auth';
 
 interface RegisterFormValues {
     loginId: string;
@@ -14,6 +15,7 @@ interface UseRegisterSessionReturn {
     registerWithAccount: (values: RegisterFormValues) => Promise<string | null>;
     isSubmitting: boolean;
     errorMessage: string | null;
+    errorField: string | null;
     clearErrorMessage: () => void;
 }
 
@@ -28,9 +30,11 @@ function getErrorMessage(error: unknown): string {
 export function useRegisterSession(): UseRegisterSessionReturn {
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [errorField, setErrorField] = useState<string | null>(null);
 
     const clearErrorMessage = () => {
         setErrorMessage(null);
+        setErrorField(null);
     };
 
     const registerWithAccount = async ({
@@ -44,26 +48,70 @@ export function useRegisterSession(): UseRegisterSessionReturn {
 
         if (!trimmedLoginId) {
             setErrorMessage(AUTH_MESSAGES.EMPTY_LOGIN_ID);
+            setErrorField('loginId');
+            return null;
+        }
+
+        if (
+            trimmedLoginId.length < REGISTER_POLICY.LOGIN_ID_MIN_LENGTH ||
+            trimmedLoginId.length > REGISTER_POLICY.LOGIN_ID_MAX_LENGTH
+        ) {
+            setErrorMessage(AUTH_MESSAGES.INVALID_LOGIN_ID_LENGTH);
+            setErrorField('loginId');
+            return null;
+        }
+
+        if (!REGISTER_POLICY.LOGIN_ID_PATTERN.test(trimmedLoginId)) {
+            setErrorMessage(AUTH_MESSAGES.INVALID_LOGIN_ID_FORMAT);
+            setErrorField('loginId');
             return null;
         }
 
         if (!password.trim()) {
             setErrorMessage(AUTH_MESSAGES.EMPTY_PASSWORD);
+            setErrorField('password');
+            return null;
+        }
+
+        if (
+            password.length < REGISTER_POLICY.PASSWORD_MIN_LENGTH ||
+            password.length > REGISTER_POLICY.PASSWORD_MAX_LENGTH
+        ) {
+            setErrorMessage(AUTH_MESSAGES.INVALID_PASSWORD_LENGTH);
+            setErrorField('password');
+            return null;
+        }
+
+        if (REGISTER_POLICY.PASSWORD_WHITESPACE_PATTERN.test(password)) {
+            setErrorMessage(AUTH_MESSAGES.INVALID_PASSWORD_WHITESPACE);
+            setErrorField('password');
             return null;
         }
 
         if (!passwordConfirm.trim()) {
             setErrorMessage(AUTH_MESSAGES.EMPTY_PASSWORD_CONFIRM);
+            setErrorField('passwordConfirm');
             return null;
         }
 
         if (password !== passwordConfirm) {
             setErrorMessage(AUTH_MESSAGES.PASSWORD_CONFIRM_MISMATCH);
+            setErrorField('passwordConfirm');
             return null;
         }
 
         if (!trimmedNickname) {
             setErrorMessage(AUTH_MESSAGES.EMPTY_NICKNAME);
+            setErrorField('nickname');
+            return null;
+        }
+
+        if (
+            trimmedNickname.length < REGISTER_POLICY.NICKNAME_MIN_LENGTH ||
+            trimmedNickname.length > REGISTER_POLICY.NICKNAME_MAX_LENGTH
+        ) {
+            setErrorMessage(AUTH_MESSAGES.INVALID_NICKNAME_LENGTH);
+            setErrorField('nickname');
             return null;
         }
 
@@ -74,6 +122,7 @@ export function useRegisterSession(): UseRegisterSessionReturn {
         try {
             setIsSubmitting(true);
             setErrorMessage(null);
+            setErrorField(null);
 
             await register({
                 loginId: trimmedLoginId,
@@ -84,6 +133,7 @@ export function useRegisterSession(): UseRegisterSessionReturn {
             return trimmedLoginId;
         } catch (error) {
             setErrorMessage(getErrorMessage(error));
+            setErrorField(error instanceof ApiError ? error.field ?? null : null);
             return null;
         } finally {
             setIsSubmitting(false);
@@ -94,6 +144,7 @@ export function useRegisterSession(): UseRegisterSessionReturn {
         registerWithAccount,
         isSubmitting,
         errorMessage,
+        errorField,
         clearErrorMessage,
     };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,8 @@
   --monomat-border-default: #e0e0e5;
   --monomat-border-card: #e4e5e8;
   --monomat-border-input: #ccccd1;
+  --monomat-danger: #fd2b48;
+  --monomat-danger-light: #ffeaec;
 
   --text: #6b6375;
   --text-h: #08060d;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -16,7 +16,7 @@ import {
     HOME_FEATURES,
 } from '../constants/home';
 import { useAuthStore } from '../store/useAuthStore';
-import { MonomatLogoMark } from '../components/common/MonomatLogo';
+import { MonomatLogo } from '../components/common/MonomatLogo';
 
 const FEATURE_ICON: Record<
     (typeof HOME_FEATURES)[number]['iconName'],
@@ -51,7 +51,7 @@ export const Home = () => {
 
     if (isRegisterMode) {
         return (
-            <main className="flex min-h-screen min-w-0 items-start justify-center bg-[var(--monomat-page-bg)] px-5 pt-[124px]">
+            <main className="flex min-h-screen min-w-0 items-start justify-center bg-[var(--monomat-page-bg)] px-5 py-8 sm:py-[72px] lg:pt-[105px]">
                 <NicknameForm
                     mode={authMode}
                     onModeChange={setAuthMode}
@@ -61,14 +61,12 @@ export const Home = () => {
     }
 
     return (
-        <main className="grid min-h-screen min-w-0 grid-cols-1 bg-[var(--monomat-page-bg)] md:grid-cols-[minmax(300px,42vw)_minmax(0,1fr)] lg:grid-cols-[minmax(380px,42vw)_minmax(0,1fr)] xl:grid-cols-[600px_minmax(0,1fr)]">
-            <section className="flex min-w-0 flex-col bg-[#1F2433] px-6 py-10 text-white sm:px-10 md:px-8 md:py-14 lg:px-12 lg:py-20 xl:px-[60px] xl:py-[106px]">
-                <div className="flex min-w-0 items-center gap-3 lg:gap-[13px]">
-                    <MonomatLogoMark className="h-10 w-10 lg:h-12 lg:w-12" />
-                    <span className="min-w-0 text-[24px] font-extrabold leading-none lg:text-[28px]">
-                        {HOME_COPY.SERVICE_NAME}
-                    </span>
-                </div>
+        <main className="grid min-h-screen min-w-0 grid-cols-1 bg-[var(--monomat-page-bg)] md:grid-cols-[minmax(360px,39vw)_minmax(0,1fr)] xl:grid-cols-[560px_minmax(0,1fr)]">
+            <section className="flex min-w-0 flex-col bg-[#0F172A] px-5 py-8 text-white sm:px-10 sm:py-12 md:px-8 md:py-14 lg:px-12 lg:py-20 xl:px-[60px] xl:py-[140px]">
+                <MonomatLogo
+                    variant="white"
+                    className="min-w-0"
+                />
 
                 <div className="mt-10 min-w-0 max-w-[440px] text-left sm:mt-14 md:mt-16 lg:mt-20 xl:mt-[98px]">
                     <h1 className="m-0 whitespace-pre-line break-keep text-[32px] font-extrabold leading-[44px] tracking-normal !text-white sm:text-[36px] sm:leading-[50px] md:text-[34px] md:leading-[48px] lg:text-[40px] lg:leading-[56px]">
@@ -104,7 +102,7 @@ export const Home = () => {
                 </div>
             </section>
 
-            <section className="flex min-w-0 items-start justify-center bg-[var(--monomat-page-bg)] px-5 py-8 sm:px-8 sm:py-10 md:px-6 md:pt-14 lg:px-8 lg:pt-20 xl:px-10 xl:pt-[106px]">
+            <section className="flex min-w-0 items-start justify-center bg-[var(--monomat-page-bg)] px-5 py-8 sm:px-8 sm:py-12 md:px-6 md:pt-[72px] lg:px-8 lg:pt-[105px] xl:px-10">
                 <NicknameForm
                     mode={authMode}
                     onModeChange={setAuthMode}

--- a/src/schemas/authSchema.ts
+++ b/src/schemas/authSchema.ts
@@ -16,6 +16,12 @@ export const authSessionSchema = authTokenSetSchema.extend({
     userIdentifier: z.uuid(),
 });
 
+export const refreshSessionResponseSchema = authTokenSetSchema.extend({
+    userId: z.number().int().positive(),
+    userType: z.enum(['REGISTERED', 'GUEST']),
+    userIdentifier: z.uuid(),
+});
+
 export const guestSessionSchema = authSessionSchema;
 
 export const loginResponseSchema = authSessionSchema.extend({
@@ -30,6 +36,17 @@ export const registerResponseSchema = z.object({
 });
 
 export const refreshTokenResponseSchema = z.union([
-    authSessionSchema,
+    refreshSessionResponseSchema,
     authTokenSetSchema,
 ]);
+
+export const authErrorResponseSchema = z.object({
+    code: z.string().min(1).optional(),
+    message: z.string().min(1),
+    field: z.enum([
+        'loginId',
+        'password',
+        'nickname',
+        'refreshToken',
+    ]).nullable().optional(),
+});

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -31,11 +31,17 @@ export interface AuthSession extends AuthTokenSet {
     userIdentifier: string;
 }
 
+export interface RefreshSessionResponse extends AuthTokenSet {
+    userId: number;
+    userType: UserType;
+    userIdentifier: string;
+}
+
 export interface RefreshTokenRequest {
     refreshToken: string;
 }
 
-export type RefreshTokenResponse = AuthSession | AuthTokenSet;
+export type RefreshTokenResponse = RefreshSessionResponse | AuthTokenSet;
 
 export type GuestSession = AuthSession;
 
@@ -48,4 +54,10 @@ export interface RegisterResponse {
     loginId: string;
     nickname: string;
     userType: 'REGISTERED';
+}
+
+export interface AuthErrorResponse {
+    code?: string;
+    message: string;
+    field?: 'loginId' | 'password' | 'nickname' | 'refreshToken' | null;
 }


### PR DESCRIPTION
## 📣 Related Issue

- #59

## 📝 Summary

- 로그인, 게스트 로그인, 회원가입 화면을 Figma 기준으로 개편했습니다.
- BE `docs/AUTH_API.md` 기준으로 인증 API 응답 타입과 validation 정책을 반영했습니다.
- `ApiError`에 optional `code`, `field`를 추가하고, `field` 값에 따라 field error/global error를 분리해 표시하도록 정리했습니다.
- 회원가입 `passwordConfirm`은 FE에서만 검증하고 BE 요청 body에는 포함하지 않도록 유지했습니다.
- refresh 응답에 `nickname`이 없는 BE 계약에 맞춰 기존 store의 nickname을 유지해 세션을 재구성하도록 처리했습니다.
- 인증 에러 메시지 UI를 공통 컴포넌트로 정리하고 Figma 기준 pill 형태로 맞췄습니다.

## 🙏PR point

- `ApiError.code`, `ApiError.field`는 기존 호출부가 깨지지 않도록 optional 필드로만 확장했습니다.
- field error는 Figma 기준으로 label row 우측에 표시됩니다.
- global error는 카드 내부 상단 pill 형태로 표시됩니다.
- `npm run lint`는 통과했으며, 기존 `public/mockServiceWorker.js`의 unused eslint-disable warning 1건만 남아 있습니다.
- `npm run build` 통과했습니다.
- 인증 외 화면은 임의로 리팩토링하지 않았고, 공통 로고/상단바/하단바는 인증 화면 적용에 필요한 범위에서만 조정했습니다.

## 📬 Reference
