### PR TITLE
[Feat/#63] 로비 리스트 화면 리디자인 및 회원/게스트 UI 분기

### DIFF
--- a/src/components/common/NavigationBar.tsx
+++ b/src/components/common/NavigationBar.tsx
@@ -54,18 +54,18 @@ export function NavigationBar() {
 
     return (
         <>
-            <header className="h-[75px] shrink-0 border border-[color:var(--monomat-border-default)] bg-white">
-                <div className="mx-auto flex h-full w-full max-w-[1440px] items-center justify-between px-[29px]">
+            <header className="min-h-[75px] shrink-0 border border-[color:var(--monomat-border-default)] bg-white">
+                <div className="mx-auto flex min-h-[75px] w-full max-w-[1440px] flex-wrap items-center justify-between gap-3 px-4 py-3 sm:px-6 lg:px-8 xl:px-10">
                     <button
                         type="button"
                         onClick={handleLogoClick}
-                        className="h-10 w-[190px]"
+                        className="h-10 w-[190px] shrink-0"
                         aria-label={LOBBY_NAVIGATION_LABELS.LOGO_ARIA_LABEL}
                     >
                         <MonomatLogo />
                     </button>
 
-                    <div className="flex items-center gap-[22px]">
+                    <div className="flex min-w-0 flex-wrap items-center justify-end gap-2 sm:gap-3 lg:gap-[22px]">
                         {canCreateMap && (
                             <button
                                 type="button"
@@ -76,7 +76,7 @@ export function NavigationBar() {
                                         ? undefined
                                         : LOBBY_NAVIGATION_LABELS.CREATE_MAP_PENDING_TITLE
                                 }
-                                className="flex h-10 w-[129px] items-center justify-center gap-[13px] rounded-lg border border-[color:var(--monomat-border-input)] bg-white text-base font-bold leading-none text-black transition hover:bg-[var(--monomat-page-bg)]"
+                                className="flex h-10 w-[130px] shrink-0 items-center justify-center gap-2 rounded-lg border border-[color:var(--monomat-border-input)] bg-white text-base font-bold leading-none text-black transition hover:bg-[var(--monomat-page-bg)]"
                             >
                                 <Map size={17} strokeWidth={2.4} />
                                 <span>
@@ -88,17 +88,17 @@ export function NavigationBar() {
                         <button
                             type="button"
                             onClick={() => setIsInviteCodeModalOpen(true)}
-                            className="flex h-10 w-[180px] items-center justify-start rounded-lg border border-[color:var(--monomat-border-input)] bg-white text-base leading-none transition hover:bg-[var(--monomat-page-bg)]"
+                            className="flex h-10 w-[180px] max-w-full shrink-0 items-center rounded-lg border border-[color:var(--monomat-border-input)] bg-white text-base leading-none transition hover:bg-[var(--monomat-page-bg)]"
                         >
                             <Copy
-                                className="ml-[13px] text-black"
+                                className="ml-[13px] shrink-0 text-black"
                                 size={18}
                                 strokeWidth={2.2}
                             />
-                            <span className="ml-[18px] text-[var(--monomat-border-input)]">
+                            <span className="ml-[18px] min-w-0 truncate text-[var(--monomat-border-input)]">
                                 {LOBBY_NAVIGATION_LABELS.INVITE_CODE}
                             </span>
-                            <span className="ml-[18px] flex h-[22px] w-9 items-center justify-center rounded-full bg-[var(--monomat-page-bg)] text-[11px] text-[var(--monomat-text-muted)]">
+                            <span className="ml-auto mr-[9px] flex h-[22px] w-9 shrink-0 items-center justify-center rounded-full bg-[var(--monomat-page-bg)] text-[11px] text-[var(--monomat-text-muted)]">
                                 {LOBBY_NAVIGATION_LABELS.INVITE_CODE_JOIN}
                             </span>
                         </button>
@@ -106,7 +106,7 @@ export function NavigationBar() {
                         <button
                             type="button"
                             onClick={handleCreateLobbyClick}
-                            className="flex h-10 w-[120px] items-center justify-center gap-1 rounded-lg bg-[var(--monomat-primary)] text-base font-bold leading-none text-white transition hover:bg-[var(--monomat-primary-hover)]"
+                            className="flex h-10 w-[120px] shrink-0 items-center justify-center gap-1 rounded-lg bg-[var(--monomat-primary)] text-base font-bold leading-none text-white transition hover:bg-[var(--monomat-primary-hover)]"
                         >
                             <Plus size={15} strokeWidth={2.8} />
                             <span>{LOBBY_NAVIGATION_LABELS.CREATE_LOBBY}</span>
@@ -115,7 +115,7 @@ export function NavigationBar() {
                         <button
                             type="button"
                             onClick={() => setIsAccountModalOpen(true)}
-                            className={`flex h-10 w-10 items-center justify-center rounded-full text-xl font-extrabold leading-none text-white ${avatarClassName}`}
+                            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-xl font-extrabold leading-none text-white ${avatarClassName}`}
                             aria-label={LOBBY_NAVIGATION_LABELS.ACCOUNT_ARIA_LABEL}
                         >
                             {avatarText}

--- a/src/components/lobby/GlobalChat.tsx
+++ b/src/components/lobby/GlobalChat.tsx
@@ -12,15 +12,16 @@ const CHAT_COOLDOWN_MS = 3000;
 const MAX_CHAT_LENGTH = 200;
 
 function formatTime(timestamp: string): string {
-    try {
-        return new Date(timestamp).toLocaleTimeString('ko-KR', {
-            hour: '2-digit',
-            minute: '2-digit',
-            hour12: false,
-        });
-    } catch {
+    const date = new Date(timestamp);
+
+    if (Number.isNaN(date.getTime())) {
         return '';
     }
+
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+
+    return `[${hours}:${minutes}]`;
 }
 
 function getConnectionLabel(
@@ -38,29 +39,42 @@ function getConnectionLabel(
     return GLOBAL_CHAT_COPY.DISCONNECTED;
 }
 
+function getSenderDisplayName(message: ChatMessage): string {
+    const nickname = message.senderNickname?.trim();
+
+    return nickname || GLOBAL_CHAT_COPY.UNKNOWN_SENDER;
+}
+
 function MessageItem({ message }: { message: ChatMessage }) {
-    const isSystemMessage = message.type === 'ENTER' || message.type === 'LEAVE';
+    const isSystemMessage =
+        message.type === 'SYSTEM' ||
+        message.type === 'ENTER' ||
+        message.type === 'LEAVE' ||
+        message.type === 'KICK' ||
+        message.type === 'READY_CHANGED' ||
+        message.type === 'HOST_CHANGED';
+    const sentTime = message.sentAt ?? message.timestamp;
 
     if (isSystemMessage) {
         return (
-            <div className="py-1 text-center text-xs text-[var(--monomat-text-muted)]">
+            <div className="whitespace-normal break-words break-all py-1 text-center text-xs text-[var(--monomat-text-muted)]">
                 {message.content}
             </div>
         );
     }
 
     return (
-        <div className="py-2">
-            <div className="flex items-baseline gap-3">
-                <span className="max-w-[170px] truncate text-[15px] font-semibold leading-none text-[var(--monomat-primary)]">
-                    {message.sender}
+        <div className="min-w-0 py-2">
+            <div className="flex min-w-0 items-baseline gap-2">
+                <span className="min-w-0 max-w-[calc(100%-64px)] overflow-hidden text-ellipsis whitespace-nowrap text-[15px] font-semibold leading-none text-[var(--monomat-primary)]">
+                    {getSenderDisplayName(message)}
                 </span>
-                <span className="shrink-0 text-xs leading-none text-[#73788A]">
-                    {formatTime(message.timestamp)}
+                <span className="shrink-0 whitespace-nowrap text-xs leading-none text-[#73788A]">
+                    {formatTime(sentTime)}
                 </span>
             </div>
 
-            <p className="mt-2 break-words text-base leading-[19px] text-black">
+            <p className="mt-2 min-w-0 whitespace-normal break-words break-all text-[15px] leading-5 text-black">
                 {message.content}
             </p>
         </div>
@@ -129,18 +143,18 @@ export function GlobalChat() {
         <div className="relative flex h-full flex-col overflow-hidden rounded-xl border border-[color:var(--monomat-border-input)] bg-white shadow-[0_4px_16px_rgba(0,0,0,0.06)]">
             {isReconnecting && <ReconnectOverlay />}
 
-            <div className="flex h-14 shrink-0 items-center justify-between border-b border-[color:var(--monomat-border-input)] px-[18px]">
-                <span className="text-base font-semibold leading-none text-black">
+            <div className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-[color:var(--monomat-border-input)] px-[18px]">
+                <span className="shrink-0 text-base font-semibold leading-none text-black">
                     {GLOBAL_CHAT_COPY.TITLE}
                 </span>
 
-                <div className="flex items-center gap-1.5">
+                <div className="flex min-w-0 items-center gap-1.5">
                     <span
                         className={`h-[9px] w-[9px] rounded-full ${
                             isConnected ? 'bg-[#00A259]' : 'bg-[var(--monomat-border-input)]'
                         }`}
                     />
-                    <span className="text-base leading-none text-[#B9B9B9]">
+                    <span className="truncate text-sm leading-none text-[#B9B9B9] sm:text-base">
                         {getConnectionLabel(isConnected, isReconnecting)}
                     </span>
                 </div>

--- a/src/components/lobby/LobbyCard.tsx
+++ b/src/components/lobby/LobbyCard.tsx
@@ -3,6 +3,7 @@ import {
     LOBBY_STATUS_META,
 } from '../../constants/lobby';
 import type { LobbyCategory, LobbyListItem } from '../../types/lobby';
+import { Flag, UserRound } from 'lucide-react';
 
 interface LobbyCardProps {
     lobby: LobbyListItem;
@@ -18,9 +19,7 @@ function StatusBadge({ status }: { status: LobbyListItem['status'] }) {
                 : LOBBY_STATUS_META.UNKNOWN;
 
     return (
-        <span
-            className={`inline-flex h-[22px] w-[60px] items-center justify-center rounded-full text-[11px] font-semibold leading-none ${meta.badgeClassName}`}
-        >
+        <span className={`inline-flex h-[22px] w-[60px] shrink-0 items-center justify-center rounded-full text-[11px] font-semibold leading-none ${meta.badgeClassName}`}>
             ● {meta.label}
         </span>
     );
@@ -36,7 +35,7 @@ function CategoryBadge({
     }
 
     return (
-        <span className="inline-flex h-[22px] min-w-[47px] items-center justify-center rounded-full bg-[var(--monomat-primary-light)] px-2 text-[11px] font-semibold leading-none text-[var(--monomat-primary)]">
+        <span className="inline-flex h-[22px] min-w-[50px] shrink-0 items-center justify-center rounded-full bg-[var(--monomat-primary-light)] px-2 text-[11px] font-semibold leading-none text-[var(--monomat-primary)]">
             {category}
         </span>
     );
@@ -62,7 +61,7 @@ function ProgressBar({
             : LOBBY_STATUS_META.WAITING.progressClassName;
 
     return (
-        <div className="h-[5px] w-[397px] rounded-full bg-[var(--monomat-page-bg)]">
+        <div className="h-[5px] w-full rounded-full bg-[var(--monomat-page-bg)]">
             <div
                 className={`h-[5px] rounded-full ${progressClassName}`}
                 style={{ width: `${percent}%` }}
@@ -72,33 +71,40 @@ function ProgressBar({
 }
 
 export function LobbyCard({ lobby, onEnter }: LobbyCardProps) {
-    const { code, hostId, title, status, maxPlayers, mapCategory } = lobby;
+    const { code, title, status, maxPlayers, mapCategory } = lobby;
 
     const { currentPlayers } = lobby;
     const isFull = currentPlayers >= maxPlayers;
     const isEnterDisabled = isFull || status === 'PLAYING';
 
     return (
-        <article className="relative h-[168px] overflow-hidden rounded-xl bg-white text-left shadow-[0_4px_16px_rgba(0,0,0,0.06)]">
-            <div className="absolute left-[14px] top-[14px] flex h-[22px] items-center gap-1.5">
+        <article className="flex min-h-[170px] min-w-0 flex-col rounded-xl bg-white p-[15px] text-left shadow-[0_4px_16px_rgba(0,0,0,0.12)]">
+            <div className="flex min-w-0 items-center gap-1.5">
                 <StatusBadge status={status} />
                 <CategoryBadge category={mapCategory} />
             </div>
 
-            <p className="absolute left-[14px] top-[70px] h-[14px] w-[328px] truncate text-sm font-bold leading-none text-[var(--monomat-text-strong)]">
-                {title}
-            </p>
+            <div className="mt-[34px] min-w-0">
+                <p className="truncate text-base font-extrabold leading-[19px] text-black">
+                    {title}
+                </p>
+            </div>
 
-            <p className="absolute left-[14px] top-[96px] max-w-[220px] truncate text-[13px] font-medium leading-4 text-[var(--monomat-text-muted)]">
-                👤 {hostId}
-            </p>
+            <div className="mt-1.5 flex min-w-0 items-center justify-between gap-3">
+                <p className="flex min-w-0 items-center gap-1 truncate text-xs font-medium leading-[14px] text-[var(--monomat-text-muted)]">
+                    <UserRound size={13} strokeWidth={2} aria-hidden="true" />
+                    <span className="min-w-0 truncate">
+                        {LOBBY_CARD_LABELS.UNKNOWN_HOST}
+                    </span>
+                </p>
 
-            <p className="absolute right-5 top-[101px] text-xs font-medium leading-[14px] text-[var(--monomat-text-muted)]">
-                {currentPlayers}/{maxPlayers}
-                {LOBBY_CARD_LABELS.PLAYER_UNIT}
-            </p>
+                <p className="shrink-0 text-[10px] font-medium leading-[14px] text-[var(--monomat-text-muted)]">
+                    {currentPlayers}/{maxPlayers}
+                    {LOBBY_CARD_LABELS.PLAYER_UNIT}
+                </p>
+            </div>
 
-            <div className="absolute left-[14px] top-[118px]">
+            <div className="mt-2">
                 <ProgressBar
                     current={currentPlayers}
                     max={maxPlayers}
@@ -106,24 +112,29 @@ export function LobbyCard({ lobby, onEnter }: LobbyCardProps) {
                 />
             </div>
 
-            <span className="absolute left-[316px] top-[135px] text-sm leading-[17px] text-[#CCD1D9]">
-                ⚑
-            </span>
+            <div className="mt-auto flex items-center justify-end gap-3 pt-3">
+                <Flag
+                    className="text-[#CCD1D9]"
+                    size={14}
+                    strokeWidth={2}
+                    aria-hidden="true"
+                />
 
-            <button
-                type="button"
-                onClick={() => onEnter(code)}
-                disabled={isEnterDisabled}
-                className={`absolute left-[335px] top-[130px] h-7 w-[76px] rounded-lg text-xs font-bold leading-none text-white transition ${
-                    isEnterDisabled
-                        ? 'cursor-not-allowed bg-[var(--monomat-border-input)]'
-                        : 'bg-[var(--monomat-primary)] hover:bg-[var(--monomat-primary-hover)]'
-                }`}
-            >
-                {isEnterDisabled
-                    ? LOBBY_CARD_LABELS.ENTER_UNAVAILABLE
-                    : LOBBY_CARD_LABELS.ENTER}
-            </button>
+                <button
+                    type="button"
+                    onClick={() => onEnter(code)}
+                    disabled={isEnterDisabled}
+                    className={`h-7 w-[76px] shrink-0 rounded-lg text-xs font-bold leading-none text-white transition ${
+                        isEnterDisabled
+                            ? 'cursor-not-allowed bg-[var(--monomat-border-input)]'
+                            : 'bg-[var(--monomat-primary)] hover:bg-[var(--monomat-primary-hover)]'
+                    }`}
+                >
+                    {isEnterDisabled
+                        ? LOBBY_CARD_LABELS.ENTER_UNAVAILABLE
+                        : LOBBY_CARD_LABELS.ENTER}
+                </button>
+            </div>
         </article>
     );
 }

--- a/src/components/lobby/LobbyCategoryFilter.tsx
+++ b/src/components/lobby/LobbyCategoryFilter.tsx
@@ -10,13 +10,13 @@ export function LobbyCategoryFilter<TCategory extends string>({
                                                               onChange,
                                                           }: LobbyCategoryFilterProps<TCategory>) {
     return (
-        <div className="mb-[18px] flex h-8 items-center gap-[9px]">
+        <div className="mb-[18px] flex min-w-0 flex-wrap items-center gap-[9px]">
             {categories.map((category) => (
                 <button
                     key={category}
                     type="button"
                     onClick={() => onChange(category)}
-                    className={`h-8 rounded-full px-[15px] text-[13px] leading-none transition ${
+                    className={`h-8 shrink-0 rounded-full px-[15px] text-[13px] leading-none transition ${
                         selectedCategory === category
                             ? 'bg-[var(--monomat-primary)] font-semibold text-white'
                             : 'border border-[color:var(--monomat-border-input)] bg-white font-normal text-[var(--monomat-text-muted)] hover:bg-[var(--monomat-page-bg)]'

--- a/src/components/lobby/LobbyEmptyState.tsx
+++ b/src/components/lobby/LobbyEmptyState.tsx
@@ -2,7 +2,7 @@ import { LOBBY_EMPTY_STATE_COPY } from '../../constants/lobby';
 
 export function LobbyEmptyState() {
     return (
-        <div className="flex h-[354px] flex-col items-center justify-center rounded-xl border border-[color:var(--monomat-border-default)] bg-white text-center shadow-[0_4px_16px_rgba(0,0,0,0.04)]">
+        <div className="flex min-h-[354px] flex-col items-center justify-center rounded-xl border border-[color:var(--monomat-border-default)] bg-white px-6 text-center shadow-[0_4px_16px_rgba(0,0,0,0.04)]">
             <p className="text-base font-bold text-[var(--monomat-text-strong)]">
                 {LOBBY_EMPTY_STATE_COPY.TITLE}
             </p>

--- a/src/components/lobby/LobbyFooter.tsx
+++ b/src/components/lobby/LobbyFooter.tsx
@@ -1,10 +1,10 @@
 export function LobbyFooter() {
     return (
-        <footer className="h-10 shrink-0 border border-[color:var(--monomat-border-default)] bg-white text-sm leading-none text-[var(--monomat-text-muted)]">
-            <div className="mx-auto flex h-full w-full max-w-[1440px] items-center justify-between px-[29px]">
+        <footer className="shrink-0 border border-[color:var(--monomat-border-default)] bg-white text-sm leading-none text-[var(--monomat-text-muted)]">
+            <div className="mx-auto flex min-h-10 w-full max-w-[1440px] flex-col gap-3 px-4 py-3 sm:px-6 md:flex-row md:items-center md:justify-between md:gap-4 md:py-0 lg:px-8 xl:px-10">
                 <span>© 2026 Monomat. 실시간 멀티플레이 퀴즈.</span>
 
-                <div className="flex items-center gap-[30px]">
+                <div className="flex flex-wrap items-center gap-x-[30px] gap-y-2">
                     <button type="button" className="hover:text-[var(--monomat-text-strong)]">
                         문의
                     </button>

--- a/src/components/lobby/LobbyHeader.tsx
+++ b/src/components/lobby/LobbyHeader.tsx
@@ -23,10 +23,10 @@ export function LobbyHeader<TCategory extends string>({
                                                           onSelectedCategoryChange,
                                                           sortOption,
                                                           onSortOptionChange,
-                                                      }: LobbyHeaderProps<TCategory>) {
+}: LobbyHeaderProps<TCategory>) {
     return (
-        <header className="mb-4">
-            <div className="mb-[18px] flex h-11 items-center gap-[5px]">
+        <header className="mb-[18px]">
+            <div className="mb-3 flex flex-col gap-2 sm:flex-row">
                 <LobbySearchInput
                     value={searchKeyword}
                     onChange={onSearchKeywordChange}

--- a/src/components/lobby/LobbyList.tsx
+++ b/src/components/lobby/LobbyList.tsx
@@ -2,18 +2,22 @@ import type { LobbyListItem } from '../../types/lobby';
 import { LOBBY_LIST_ERROR_COPY } from '../../constants/lobby';
 import { LobbyCard } from './LobbyCard';
 import { LobbyEmptyState } from './LobbyEmptyState';
+import { LobbyPagination } from './LobbyPagination';
 
 interface LobbyListProps {
     lobbies: LobbyListItem[];
     isLoading?: boolean;
     isError?: boolean;
+    page: number;
+    hasNext: boolean;
     onRetry?: () => void;
     onEnter: (code: string) => void;
+    onPageChange: (page: number) => void;
 }
 
 function LobbyCardSkeleton() {
     return (
-        <div className="h-[168px] rounded-xl bg-white p-[14px] shadow-[0_4px_16px_rgba(0,0,0,0.06)]">
+        <div className="min-h-[170px] rounded-xl bg-white p-[15px] shadow-[0_4px_16px_rgba(0,0,0,0.10)]">
             <div className="flex gap-1.5">
                 <div className="h-[22px] w-[60px] animate-pulse rounded-full bg-[var(--monomat-page-bg)]" />
                 <div className="h-[22px] w-[47px] animate-pulse rounded-full bg-[var(--monomat-page-bg)]" />
@@ -31,7 +35,7 @@ function LobbyCardSkeleton() {
 
 function LobbyErrorState({ onRetry }: { onRetry?: () => void }) {
     return (
-        <div className="flex h-[354px] flex-col items-center justify-center rounded-xl border border-[color:var(--monomat-border-default)] bg-white text-center shadow-[0_4px_16px_rgba(0,0,0,0.04)]">
+        <div className="flex min-h-[354px] flex-col items-center justify-center rounded-xl border border-[color:var(--monomat-border-default)] bg-white px-6 text-center shadow-[0_4px_16px_rgba(0,0,0,0.04)]">
             <p className="text-base font-bold text-[var(--monomat-text-strong)]">
                 {LOBBY_LIST_ERROR_COPY.TITLE}
             </p>
@@ -55,16 +59,26 @@ export function LobbyList({
     lobbies,
     isLoading = false,
     isError = false,
+    page,
+    hasNext,
     onRetry,
     onEnter,
+    onPageChange,
 }: LobbyListProps) {
     if (isLoading) {
         return (
-            <div className="grid grid-cols-2 gap-x-8 gap-y-[18px]">
-                {Array.from({ length: 6 }).map((_, index) => (
-                    <LobbyCardSkeleton key={index} />
-                ))}
-            </div>
+            <>
+                <div className="grid grid-cols-1 gap-[18px] lg:grid-cols-2">
+                    {Array.from({ length: 6 }).map((_, index) => (
+                        <LobbyCardSkeleton key={index} />
+                    ))}
+                </div>
+                <LobbyPagination
+                    page={page}
+                    hasNext={false}
+                    onPageChange={onPageChange}
+                />
+            </>
         );
     }
 
@@ -73,18 +87,34 @@ export function LobbyList({
     }
 
     if (lobbies.length === 0) {
-        return <LobbyEmptyState />;
+        return (
+            <>
+                <LobbyEmptyState />
+                <LobbyPagination
+                    page={page}
+                    hasNext={hasNext}
+                    onPageChange={onPageChange}
+                />
+            </>
+        );
     }
 
     return (
-        <div className="grid grid-cols-2 gap-x-8 gap-y-[18px]">
-            {lobbies.map((lobby) => (
-                <LobbyCard
-                    key={lobby.code}
-                    lobby={lobby}
-                    onEnter={onEnter}
-                />
-            ))}
-        </div>
+        <>
+            <div className="grid grid-cols-1 gap-[18px] lg:grid-cols-2">
+                {lobbies.map((lobby) => (
+                    <LobbyCard
+                        key={lobby.code}
+                        lobby={lobby}
+                        onEnter={onEnter}
+                    />
+                ))}
+            </div>
+            <LobbyPagination
+                page={page}
+                hasNext={hasNext}
+                onPageChange={onPageChange}
+            />
+        </>
     );
 }

--- a/src/components/lobby/LobbyPagination.tsx
+++ b/src/components/lobby/LobbyPagination.tsx
@@ -1,0 +1,73 @@
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+import { LOBBY_PAGINATION_LABELS } from '../../constants/lobby';
+
+interface LobbyPaginationProps {
+    page: number;
+    hasNext: boolean;
+    onPageChange: (page: number) => void;
+}
+
+function createKnownPages(page: number, hasNext: boolean) {
+    const lastKnownPage = hasNext ? page + 1 : page;
+
+    return Array.from({ length: lastKnownPage + 1 }, (_, index) => index);
+}
+
+export function LobbyPagination({
+    page,
+    hasNext,
+    onPageChange,
+}: LobbyPaginationProps) {
+    const pages = createKnownPages(page, hasNext);
+    const canGoPrevious = page > 0;
+
+    return (
+        <nav
+            className="mt-[30px] flex flex-wrap items-center gap-2"
+            aria-label="로비 목록 페이지"
+        >
+            <button
+                type="button"
+                onClick={() => onPageChange(page - 1)}
+                disabled={!canGoPrevious}
+                className="flex h-9 w-9 items-center justify-center rounded-lg border border-[color:var(--monomat-border-default)] bg-white text-[13px] text-[var(--monomat-text-muted)] transition hover:bg-[var(--monomat-page-bg)] disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label={LOBBY_PAGINATION_LABELS.PREVIOUS}
+            >
+                <ChevronLeft size={16} strokeWidth={2} aria-hidden="true" />
+            </button>
+
+            {pages.map((knownPage) => {
+                const isActive = knownPage === page;
+                const pageLabel = knownPage + 1;
+
+                return (
+                    <button
+                        key={knownPage}
+                        type="button"
+                        onClick={() => onPageChange(knownPage)}
+                        aria-current={isActive ? 'page' : undefined}
+                        aria-label={LOBBY_PAGINATION_LABELS.PAGE(pageLabel)}
+                        className={`flex h-9 w-9 items-center justify-center rounded-lg text-[13px] leading-none transition ${
+                            isActive
+                                ? 'bg-[var(--monomat-primary)] text-white'
+                                : 'border border-[color:var(--monomat-border-default)] bg-white text-[var(--monomat-text-muted)] hover:bg-[var(--monomat-page-bg)]'
+                        }`}
+                    >
+                        {pageLabel}
+                    </button>
+                );
+            })}
+
+            <button
+                type="button"
+                onClick={() => onPageChange(page + 1)}
+                disabled={!hasNext}
+                className="flex h-9 w-9 items-center justify-center rounded-lg border border-[color:var(--monomat-border-default)] bg-white text-[13px] text-[var(--monomat-text-muted)] transition hover:bg-[var(--monomat-page-bg)] disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label={LOBBY_PAGINATION_LABELS.NEXT}
+            >
+                <ChevronRight size={16} strokeWidth={2} aria-hidden="true" />
+            </button>
+        </nav>
+    );
+}

--- a/src/components/lobby/LobbySearchInput.tsx
+++ b/src/components/lobby/LobbySearchInput.tsx
@@ -12,7 +12,7 @@ export function LobbySearchInput({
                                      onChange,
                                  }: LobbySearchInputProps) {
     return (
-        <label className="flex h-11 w-[728px] items-center rounded-[10px] border border-[color:var(--monomat-border-input)] bg-white">
+        <label className="flex h-11 min-w-0 flex-1 items-center rounded-lg border border-[color:var(--monomat-border-input)] bg-white">
             <Search
                 className="ml-[11px] shrink-0 text-[#2B3F6C]"
                 size={24}

--- a/src/components/lobby/LobbySortDropdown.tsx
+++ b/src/components/lobby/LobbySortDropdown.tsx
@@ -24,15 +24,15 @@ export function LobbySortDropdown({
     };
 
     return (
-        <div className="relative">
+        <div className="relative w-full shrink-0 sm:w-[166px]">
             <button
                 type="button"
                 onClick={() => setIsOpen((prev) => !prev)}
-                className="flex h-11 w-[161px] items-center justify-center rounded-lg border border-[color:var(--monomat-border-input)] bg-white text-base font-normal leading-none text-[var(--monomat-text-muted)] transition hover:bg-[var(--monomat-page-bg)]"
+                className="flex h-11 w-full items-center justify-center rounded-lg border border-[color:var(--monomat-border-input)] bg-white px-4 text-base font-normal leading-none text-[var(--monomat-text-muted)] transition hover:bg-[var(--monomat-page-bg)]"
             >
-                <span>정렬: {LOBBY_SORT_LABELS[value]}</span>
+                <span className="min-w-0 truncate">{LOBBY_SORT_LABELS[value]}</span>
                 <ChevronDown
-                    className="ml-2"
+                    className="ml-auto shrink-0"
                     size={18}
                     strokeWidth={2}
                     aria-hidden="true"
@@ -40,7 +40,7 @@ export function LobbySortDropdown({
             </button>
 
             {isOpen && (
-                <div className="absolute right-0 z-20 mt-2 w-[188px] overflow-hidden rounded-lg border border-[color:var(--monomat-border-input)] bg-white shadow-[0_8px_24px_rgba(0,0,0,0.08)]">
+                <div className="absolute right-0 z-20 mt-2 w-full min-w-[188px] overflow-hidden rounded-lg border border-[color:var(--monomat-border-input)] bg-white shadow-[0_8px_24px_rgba(0,0,0,0.08)]">
                     {(Object.keys(LOBBY_SORT_LABELS) as LobbySortOption[]).map(
                         (option) => (
                             <button

--- a/src/constants/lobby.ts
+++ b/src/constants/lobby.ts
@@ -26,7 +26,6 @@ export const LOBBY_CATEGORY_FILTERS = [
     'K-POP',
     'J-POP',
     'POP',
-    'OST',
 ] as const;
 
 export const LOBBY_ALL_CATEGORY_FILTER = LOBBY_CATEGORY_FILTERS[0];
@@ -38,7 +37,7 @@ export const LOBBY_SORT_LABELS = {
 } as const;
 
 export const DEFAULT_LOBBY_LIST_PAGE = 0;
-export const DEFAULT_LOBBY_LIST_SIZE = 20;
+export const DEFAULT_LOBBY_LIST_SIZE = 6;
 
 export const LOBBY_NAVIGATION_LABELS = {
     LOGO_ARIA_LABEL: '로비 목록으로 이동',
@@ -79,6 +78,13 @@ export const LOBBY_CARD_LABELS = {
     ENTER: '입장',
     ENTER_UNAVAILABLE: '입장불가',
     PLAYER_UNIT: '명',
+    UNKNOWN_HOST: '방장 정보 없음',
+} as const;
+
+export const LOBBY_PAGINATION_LABELS = {
+    PREVIOUS: '이전 페이지',
+    NEXT: '다음 페이지',
+    PAGE: (page: number) => `${page}페이지`,
 } as const;
 
 export const LOBBY_LIST_ERROR_COPY = {
@@ -99,6 +105,7 @@ export const LOBBY_SEARCH_COPY = {
 export const GLOBAL_CHAT_COPY = {
     TITLE: '전체 채팅',
     EMPTY: '아직 채팅이 없습니다.',
+    UNKNOWN_SENDER: '알 수 없는 사용자',
     INPUT_PLACEHOLDER: '메시지 입력',
     CONNECTING_PLACEHOLDER: '연결 중...',
     CONNECTED: '연결됨',

--- a/src/mocks/handlers/lobby.ts
+++ b/src/mocks/handlers/lobby.ts
@@ -13,7 +13,7 @@ import type {
     LobbySortQuery,
 } from '../../types/lobby';
 
-const LOBBY_CATEGORIES = ['K-POP', 'J-POP', 'POP', 'OST'] as const;
+const LOBBY_CATEGORIES = ['K-POP', 'J-POP', 'POP'] as const;
 const LOBBY_SORT_QUERIES = [
     'latest',
     'most_players',

--- a/src/pages/Lobbies.tsx
+++ b/src/pages/Lobbies.tsx
@@ -36,6 +36,7 @@ export function Lobbies() {
         useState<LobbyCategoryFilter>(LOBBY_ALL_CATEGORY_FILTER);
     const [sortOption, setSortOption] =
         useState<LobbySortOption>('LATEST');
+    const [currentPage, setCurrentPage] = useState(DEFAULT_LOBBY_LIST_PAGE);
 
     const lobbyListQueryParams = useMemo(() => {
         const mapCategory = toMapCategory(selectedCategory);
@@ -44,10 +45,10 @@ export function Lobbies() {
             keyword: searchKeyword.trim(),
             ...(mapCategory ? { mapCategory } : {}),
             sort: SORT_QUERY_MAP[sortOption],
-            page: DEFAULT_LOBBY_LIST_PAGE,
+            page: currentPage,
             size: DEFAULT_LOBBY_LIST_SIZE,
         };
-    }, [searchKeyword, selectedCategory, sortOption]);
+    }, [currentPage, searchKeyword, selectedCategory, sortOption]);
 
     const {
         data,
@@ -56,37 +57,57 @@ export function Lobbies() {
         refetch,
     } = useLobbyList(lobbyListQueryParams);
     const lobbies = data?.items ?? [];
+    const page = data?.page ?? currentPage;
+    const hasNext = data?.hasNext ?? false;
+
+    const handleSearchKeywordChange = (value: string) => {
+        setSearchKeyword(value);
+        setCurrentPage(DEFAULT_LOBBY_LIST_PAGE);
+    };
+
+    const handleSelectedCategoryChange = (value: LobbyCategoryFilter) => {
+        setSelectedCategory(value);
+        setCurrentPage(DEFAULT_LOBBY_LIST_PAGE);
+    };
+
+    const handleSortOptionChange = (value: LobbySortOption) => {
+        setSortOption(value);
+        setCurrentPage(DEFAULT_LOBBY_LIST_PAGE);
+    };
 
     const handleEnter = (code: string) => {
         navigate(LOBBY_ROUTES.ROOM(code));
     };
 
     return (
-        <div className="flex min-h-screen min-w-[1440px] flex-col bg-[var(--monomat-page-bg)] text-left">
+        <div className="flex min-h-screen flex-col bg-[var(--monomat-page-bg)] text-left">
             <NavigationBar />
 
-            <main className="mx-auto grid w-[1440px] flex-1 grid-cols-[894px_451px] gap-[27px] px-[35px] pb-[25px] pt-6">
+            <main className="mx-auto grid w-full max-w-[1440px] flex-1 grid-cols-1 gap-5 px-4 pb-6 pt-5 sm:px-6 lg:px-8 xl:grid-cols-[minmax(0,880px)_minmax(320px,460px)] xl:gap-5 xl:px-10 xl:pb-[27px] xl:pt-7">
                 <section className="min-w-0">
                     <LobbyHeader
                         searchKeyword={searchKeyword}
-                        onSearchKeywordChange={setSearchKeyword}
+                        onSearchKeywordChange={handleSearchKeywordChange}
                         categories={LOBBY_CATEGORY_FILTERS}
                         selectedCategory={selectedCategory}
-                        onSelectedCategoryChange={setSelectedCategory}
+                        onSelectedCategoryChange={handleSelectedCategoryChange}
                         sortOption={sortOption}
-                        onSortOptionChange={setSortOption}
+                        onSortOptionChange={handleSortOptionChange}
                     />
 
                     <LobbyList
                         lobbies={lobbies}
                         isLoading={isLoading}
                         isError={isError}
+                        page={page}
+                        hasNext={hasNext}
                         onRetry={() => void refetch()}
                         onEnter={handleEnter}
+                        onPageChange={setCurrentPage}
                     />
                 </section>
 
-                <aside className="h-[733px] w-[451px] shrink-0">
+                <aside className="min-h-[520px] w-full min-w-0 xl:h-[730px]">
                     <GlobalChat />
                 </aside>
             </main>

--- a/src/schemas/lobbySchema.ts
+++ b/src/schemas/lobbySchema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const lobbyCategorySchema = z.enum(['K-POP', 'J-POP', 'POP', 'OST']);
+export const lobbyCategorySchema = z.enum(['K-POP', 'J-POP', 'POP']);
 
 export const lobbyStatusSchema = z.string().min(1);
 

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -3,14 +3,26 @@
 
 // 채팅 메시지의 종류를 정의한다.
 // 서버에서 오는 메시지가 어떤 종류인지에 따라 UI 표시 방식이 달라진다.
-export type ChatMessageType = 'CHAT' | 'ANSWER' | 'ENTER' | 'LEAVE';
+export type ChatMessageType =
+    | 'CHAT'
+    | 'ANSWER'
+    | 'SYSTEM'
+    | 'ENTER'
+    | 'LEAVE'
+    | 'KICK'
+    | 'READY_CHANGED'
+    | 'HOST_CHANGED';
 
 // BE ChatMessageDto와 동일한 구조
-// sender: 서버가 세션에서 추출한 UUID (위변조 방지)
+// sender: 서버가 세션에서 추출한 userIdentifier (위변조 방지)
 export interface ChatMessage {
+    messageId?: string;
     type: ChatMessageType;
     roomId: string;    // 전체 채팅은 "global"
-    sender: string;    // UUID 그대로 표시 (닉네임 조회 API 미구현 상태)
+    sender: string;    // 표시명으로 직접 사용하지 않는다.
+    senderId?: number;
+    senderNickname?: string;
     content: string;
     timestamp: string; // ISO 8601 형식
+    sentAt?: string;
 }

--- a/src/types/lobby.ts
+++ b/src/types/lobby.ts
@@ -1,6 +1,6 @@
 // 게임 로비 (대기방)와 관련된 타입을 정의한다.
 
-export type LobbyCategory = 'K-POP' | 'J-POP' | 'POP' | 'OST';
+export type LobbyCategory = 'K-POP' | 'J-POP' | 'POP';
 
 export type LobbyStatus = 'WAITING' | 'PLAYING' | (string & {});
 


### PR DESCRIPTION
## 📣 Related Issue

- #63

## 📝 Summary

- Figma 기준 로비 리스트 레이아웃, 검색, 필터, 정렬, 카드 UI를 반응형으로 정리했습니다.
- 회원/게스트 `userType` 기준 상단바 액션을 유지하고, 게스트에게 맵 만들기 버튼이 노출되지 않도록 했습니다.
- 로비 목록 카테고리를 BE 계약 기준 `K-POP`, `J-POP`, `POP`으로 정리했습니다.
- 한 페이지 로비 카드 수를 6개로 조정하고 `page`, `hasNext` 기반 페이지네이션을 추가했습니다.
- 채팅 시간 포맷을 `[HH:MM]` 24시간 표기로 고정하고, 긴 메시지/URL 줄바꿈을 보정했습니다.
- 채팅은 `senderNickname`을 우선 표시하고, 로비 카드에서는 닉네임 계약이 없는 `hostId` 직접 노출을 제거했습니다.

## 🙏PR point

- BE 로비 목록 응답에는 `totalPages`, `totalElements`, `totalCount`가 없어 전체 번호 페이지네이션은 구현하지 않았습니다. 현재 FE는 `hasNext`로 확실히 알 수 있는 페이지 번호만 표시합니다.
- 로비 카드 방장 닉네임을 완전히 표시하려면 BE 응답에 `hostNickname` 또는 `ownerNickname` 필드가 필요합니다.
- `ViewportGuard`는 이번 이슈 범위에서 수정하지 않았습니다.

## 📬 Reference

