### PR TITLE
[Feat/#66] 상단바 스크롤 고정 처리

### DIFF
--- a/src/components/common/NavigationBar.tsx
+++ b/src/components/common/NavigationBar.tsx
@@ -54,7 +54,7 @@ export function NavigationBar() {
 
     return (
         <>
-            <header className="min-h-[75px] shrink-0 border border-[color:var(--monomat-border-default)] bg-white">
+            <header className="sticky top-0 z-30 min-h-[75px] shrink-0 border border-[color:var(--monomat-border-default)] bg-white">
                 <div className="mx-auto flex min-h-[75px] w-full max-w-[1440px] flex-wrap items-center justify-between gap-3 px-4 py-3 sm:px-6 lg:px-8 xl:px-10">
                     <button
                         type="button"


### PR DESCRIPTION
## 📣 Related Issue

- #66

## 📝 Summary

- NavigationBar header에 `sticky top-0 z-30`을 적용해 AppLayout 내부 화면에서 상단바가 스크롤 시 화면 상단에 유지되도록 수정했습니다.
- 기존 NavigationBar의 배경색, border, 높이, spacing은 유지했습니다.
- 모달 계층(`z-50`)보다 낮은 `z-30`을 사용해 계정/로비 생성/초대 코드 모달이 상단바보다 위에 표시되도록 유지했습니다.

## 🙏PR point

- 수정 범위는 `NavigationBar.tsx`로 제한했습니다.
- 인증, 세션, 라우팅, API, WebSocket 로직은 변경하지 않았습니다.
- `npm run lint`는 통과했으며, 기존 `public/mockServiceWorker.js`의 unused eslint-disable warning 1건이 표시됩니다.
- `npm run build`는 성공했습니다.

## 📬 Reference

