### PR TITLE
[Feat/#65] 로비 카드 방장 닉네임 표시

### DIFF
--- a/src/components/lobby/LobbyCard.tsx
+++ b/src/components/lobby/LobbyCard.tsx
@@ -74,6 +74,8 @@ export function LobbyCard({ lobby, onEnter }: LobbyCardProps) {
     const { code, title, status, maxPlayers, mapCategory } = lobby;
 
     const { currentPlayers } = lobby;
+    const hostDisplayName =
+        lobby.hostNickname?.trim() || LOBBY_CARD_LABELS.UNKNOWN_HOST;
     const isFull = currentPlayers >= maxPlayers;
     const isEnterDisabled = isFull || status === 'PLAYING';
 
@@ -94,7 +96,7 @@ export function LobbyCard({ lobby, onEnter }: LobbyCardProps) {
                 <p className="flex min-w-0 items-center gap-1 truncate text-xs font-medium leading-[14px] text-[var(--monomat-text-muted)]">
                     <UserRound size={13} strokeWidth={2} aria-hidden="true" />
                     <span className="min-w-0 truncate">
-                        {LOBBY_CARD_LABELS.UNKNOWN_HOST}
+                        {hostDisplayName}
                     </span>
                 </p>
 

--- a/src/schemas/lobbySchema.ts
+++ b/src/schemas/lobbySchema.ts
@@ -30,7 +30,8 @@ export const createLobbyResponseSchema = z.object({
 
 export const lobbyListItemSchema = z.object({
     code: z.string().min(1),
-    hostId: z.string().min(1),
+    hostId: z.string().min(1).nullable().optional(),
+    hostNickname: z.string().nullable().optional(),
     title: z.string().min(1),
     mapId: z.number().int().positive().nullable(),
     mapTitle: z.string().min(1).nullable(),

--- a/src/types/lobby.ts
+++ b/src/types/lobby.ts
@@ -26,7 +26,8 @@ export interface LobbyPageResponse<T> {
 
 export interface LobbyListItem {
     code: string;
-    hostId: string;
+    hostId?: string | null;
+    hostNickname?: string | null;
     title: string;
     mapId: number | null;
     mapTitle: string | null;


### PR DESCRIPTION
## 📣 Related Issue

- #65

## 📝 Summary

- 로비 목록 응답 item의 `hostNickname` 필드를 FE 타입과 schema에 반영했습니다.
- Monomat-BE develop 기준 공개 로비 목록 응답에서 `hostId`가 누락될 수 있어 `LobbyListItem` 타입과 `lobbyListItemSchema`의 `hostId` required 검증을 완화했습니다.
- 로비 카드 방장 표시 영역에서 `hostNickname`을 우선 표시하고, 없거나 `null`이거나 빈 문자열이면 기존 fallback인 `방장 정보 없음`을 표시하도록 수정했습니다.
- `hostId`, `userIdentifier`는 사용자 표시명 fallback으로 사용하지 않도록 유지했습니다.

## 🙏PR point

- 기존 로비 카드의 높이, spacing, 아이콘, 색상, typography는 변경하지 않았습니다.
- `npm run lint` 통과: 기존 `public/mockServiceWorker.js` unused eslint-disable warning 1건만 발생했습니다.
- `npm run build` 통과했습니다.

## 📬 Reference

- Monomat-BE develop `LobbyListItemResponse`
- GitHub Issue #65