### PR TITLE
[Feat/#68] 정식 회원 프로필 모달 개선

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -13,7 +13,7 @@ import type {
 const AUTHORIZATION_HEADER = 'Authorization';
 const AUTH_ENTRY_PATH = '/';
 
-const AUTH_EXPIRED_ERROR_CODES = new Set<string>([
+const AUTH_REFRESHABLE_ERROR_CODES = new Set<string>([
     AUTH_ERROR_CODES.INVALID_REFRESH_TOKEN,
     AUTH_ERROR_CODES.SESSION_EXPIRED,
     AUTH_ERROR_CODES.UNAUTHENTICATED,
@@ -84,8 +84,38 @@ function shouldRedirectToAuthEntry(error: unknown) {
 
     return (
         error.status === 401 ||
-        (error.code != null && AUTH_EXPIRED_ERROR_CODES.has(error.code))
+        (error.code != null && AUTH_REFRESHABLE_ERROR_CODES.has(error.code))
     );
+}
+
+async function resolveErrorCode(response: Response): Promise<string | null> {
+    try {
+        const payload = await response.clone().json() as unknown;
+
+        if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+            return null;
+        }
+
+        const code = (payload as Record<string, unknown>).code;
+
+        return typeof code === 'string' && code.trim()
+            ? code
+            : null;
+    } catch {
+        return null;
+    }
+}
+
+async function shouldRefreshForUnauthorizedResponse(
+    response: Response,
+): Promise<boolean> {
+    const code = await resolveErrorCode(response);
+
+    if (!code) {
+        return true;
+    }
+
+    return AUTH_REFRESHABLE_ERROR_CODES.has(code);
 }
 
 function hasSessionIdentityFields(
@@ -206,6 +236,10 @@ export async function fetchWithAuth(
         return response;
     }
 
+    if (!(await shouldRefreshForUnauthorizedResponse(response))) {
+        return response;
+    }
+
     const currentAccessToken = useAuthStore.getState().accessToken;
     const retryAccessToken =
         currentAccessToken && currentAccessToken !== requestAccessToken
@@ -217,7 +251,10 @@ export async function fetchWithAuth(
         createRequestInit(input, init, retryAccessToken),
     );
 
-    if (retryResponse.status === 401) {
+    if (
+        retryResponse.status === 401 &&
+        await shouldRefreshForUnauthorizedResponse(retryResponse)
+    ) {
         useAuthStore.getState().clearSession();
         redirectToAuthEntry();
     }

--- a/src/api/userApi.ts
+++ b/src/api/userApi.ts
@@ -1,0 +1,81 @@
+import { API_ENDPOINTS } from '../constants/endpoints';
+import { fetchWithAuth } from './apiClient';
+import { ApiError, createApiError } from './apiError';
+import { myUserInfoResponseSchema } from '../schemas/userSchema';
+
+import type {
+    ChangePasswordRequest,
+    MyUserInfoResponse,
+    UpdateNicknameRequest,
+} from '../types/user';
+
+const JSON_CONTENT_TYPE = 'application/json';
+
+const DEFAULT_UPDATE_NICKNAME_ERROR_MESSAGE = '닉네임 변경에 실패했습니다.';
+const DEFAULT_CHANGE_PASSWORD_ERROR_MESSAGE = '비밀번호 변경에 실패했습니다.';
+const INVALID_USER_INFO_RESPONSE_MESSAGE =
+    '사용자 정보 응답 형식이 올바르지 않습니다.';
+
+export async function updateMyNickname(
+    request: UpdateNicknameRequest,
+): Promise<MyUserInfoResponse> {
+    const response = await fetchWithAuth(API_ENDPOINTS.USER.NICKNAME, {
+        method: 'PATCH',
+        headers: {
+            'Content-Type': JSON_CONTENT_TYPE,
+        },
+        body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            DEFAULT_UPDATE_NICKNAME_ERROR_MESSAGE,
+        );
+    }
+
+    let payload: unknown;
+
+    try {
+        payload = await response.json() as unknown;
+    } catch (error) {
+        console.error(
+            '[userApi] 닉네임 변경 응답 JSON 파싱 실패:',
+            error,
+        );
+
+        throw new ApiError(500, INVALID_USER_INFO_RESPONSE_MESSAGE);
+    }
+
+    const parsed = myUserInfoResponseSchema.safeParse(payload);
+
+    if (!parsed.success) {
+        console.error(
+            '[userApi] 닉네임 변경 응답 검증 실패:',
+            parsed.error,
+        );
+
+        throw new ApiError(500, INVALID_USER_INFO_RESPONSE_MESSAGE);
+    }
+
+    return parsed.data;
+}
+
+export async function changeMyPassword(
+    request: ChangePasswordRequest,
+): Promise<void> {
+    const response = await fetchWithAuth(API_ENDPOINTS.USER.PASSWORD, {
+        method: 'PATCH',
+        headers: {
+            'Content-Type': JSON_CONTENT_TYPE,
+        },
+        body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            DEFAULT_CHANGE_PASSWORD_ERROR_MESSAGE,
+        );
+    }
+}

--- a/src/components/common/AccountModal.tsx
+++ b/src/components/common/AccountModal.tsx
@@ -1,9 +1,24 @@
-import { useState } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useState,
+    type FormEvent,
+    type ReactNode,
+} from 'react';
+import { Edit2, LockOpen } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
+import { ApiError } from '../../api/apiError';
+import {
+    changeMyPassword,
+    updateMyNickname,
+} from '../../api/userApi';
+import { GUEST_NICKNAME_POLICY } from '../../constants/auth';
 import { useAuthStore } from '../../store/useAuthStore';
+import { MonomatInput } from './MonomatInput';
 
 type AccountType = 'guest' | 'member';
+type MessageTone = 'error' | 'success';
 
 interface AccountModalProps {
     isOpen: boolean;
@@ -16,13 +31,74 @@ interface AccountModalContentProps {
     onClose: () => void;
 }
 
+interface FeedbackMessage {
+    tone: MessageTone;
+    text: string;
+}
+
 const ACCOUNT_TYPE_LABEL: Record<AccountType, string> = {
     guest: '게스트',
     member: '정식 회원',
 };
 
-const NICKNAME_MAX_LENGTH = 12;
-const PASSWORD_MIN_LENGTH = 6;
+const MEMBER_NICKNAME_MAX_LENGTH = 50;
+
+function getErrorMessage(error: unknown, fallbackMessage: string) {
+    if (error instanceof Error && error.message) {
+        return error.message;
+    }
+
+    return fallbackMessage;
+}
+
+function getPasswordChangeErrorMessage(error: unknown) {
+    if (error instanceof ApiError && error.status >= 500) {
+        return '비밀번호 변경에 실패했습니다.';
+    }
+
+    return getErrorMessage(error, '비밀번호 변경에 실패했습니다.');
+}
+
+function FeedbackBadge({ message }: { message: FeedbackMessage | null }) {
+    if (!message) {
+        return null;
+    }
+
+    const toneClassName = message.tone === 'success'
+        ? 'bg-[var(--monomat-primary-light)] text-[var(--monomat-primary)]'
+        : 'bg-[var(--monomat-danger-light)] text-[var(--monomat-danger)]';
+
+    return (
+        <p
+            role={message.tone === 'error' ? 'alert' : 'status'}
+            className={`flex h-6 min-w-0 flex-1 items-center justify-center rounded-[12px] px-2 text-center text-[10px] font-semibold leading-none ${toneClassName}`}
+        >
+            <span className="min-w-0 truncate">
+                {message.text}
+            </span>
+        </p>
+    );
+}
+
+function SectionTitle({
+                          children,
+                          message,
+                      }: {
+    children: ReactNode;
+    message?: FeedbackMessage | null;
+}) {
+    return (
+        <div className="mb-[17px] flex h-6 min-w-0 items-center gap-4 text-black">
+            <div className="flex shrink-0 items-center gap-2">
+                <Edit2 size={24} strokeWidth={1.9} />
+                <p className="text-base font-semibold leading-6">
+                    {children}
+                </p>
+            </div>
+            <FeedbackBadge message={message ?? null} />
+        </div>
+    );
+}
 
 function AccountModalContent({
                                  accountType,
@@ -34,32 +110,58 @@ function AccountModalContent({
     const updateNickname = useAuthStore((state) => state.updateNickname);
     const clearSession = useAuthStore((state) => state.clearSession);
 
-    const [nicknameInput, setNicknameInput] = useState(nickname ?? '');
+    const displayNickname = nickname?.trim() || 'Guest';
+    const avatarText = displayNickname.charAt(0).toUpperCase() || 'G';
+
+    const [nicknameInput, setNicknameInput] = useState(displayNickname);
     const [currentPassword, setCurrentPassword] = useState('');
     const [newPassword, setNewPassword] = useState('');
     const [newPasswordConfirm, setNewPasswordConfirm] = useState('');
+    const [nicknameMessage, setNicknameMessage] =
+        useState<FeedbackMessage | null>(null);
+    const [passwordMessage, setPasswordMessage] =
+        useState<FeedbackMessage | null>(null);
+    const [isNicknameSubmitting, setIsNicknameSubmitting] = useState(false);
+    const [isPasswordSubmitting, setIsPasswordSubmitting] = useState(false);
 
-    const displayNickname = nickname ?? 'Guest';
-    const avatarText = displayNickname.charAt(0).toUpperCase();
+    const isSubmitting = isNicknameSubmitting || isPasswordSubmitting;
 
-    const handleNicknameSave = () => {
-        const trimmedNickname = nicknameInput.trim();
-
-        if (!trimmedNickname) {
-            alert('닉네임을 입력해주세요.');
+    const handleClose = useCallback(() => {
+        if (isSubmitting) {
             return;
         }
 
-        if (trimmedNickname.length > NICKNAME_MAX_LENGTH) {
-            alert(`닉네임은 ${NICKNAME_MAX_LENGTH}자 이내로 입력해주세요.`);
+        setCurrentPassword('');
+        setNewPassword('');
+        setNewPasswordConfirm('');
+        onClose();
+    }, [isSubmitting, onClose]);
+
+    useEffect(() => {
+        setNicknameInput(displayNickname);
+        setNicknameMessage(null);
+    }, [displayNickname]);
+
+    useEffect(() => {
+        if (isSubmitting) {
             return;
         }
 
-        updateNickname(trimmedNickname);
-    };
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                handleClose();
+            }
+        };
+
+        window.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [handleClose, isSubmitting]);
 
     const handleRegisterClick = () => {
-        onClose();
+        handleClose();
         navigate('/register');
     };
 
@@ -69,157 +171,366 @@ function AccountModalContent({
         navigate('/');
     };
 
-    const handlePasswordChange = () => {
-        if (!currentPassword || !newPassword || !newPasswordConfirm) {
-            alert('비밀번호 정보를 모두 입력해주세요.');
+    const handleGuestNicknameSave = () => {
+        const trimmedNickname = nicknameInput.trim();
+
+        if (!trimmedNickname) {
+            setNicknameMessage({
+                tone: 'error',
+                text: '닉네임을 입력해주세요.',
+            });
             return;
         }
 
-        if (newPassword.length < PASSWORD_MIN_LENGTH) {
-            alert(`새 비밀번호는 ${PASSWORD_MIN_LENGTH}자 이상이어야 합니다.`);
+        if (trimmedNickname.length > GUEST_NICKNAME_POLICY.MAX_LENGTH) {
+            setNicknameMessage({
+                tone: 'error',
+                text: `닉네임은 ${GUEST_NICKNAME_POLICY.MAX_LENGTH}자 이내로 입력해주세요.`,
+            });
+            return;
+        }
+
+        updateNickname(trimmedNickname);
+        setNicknameMessage({
+            tone: 'success',
+            text: '닉네임이 변경되었습니다.',
+        });
+    };
+
+    const handleNicknameSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        if (isNicknameSubmitting) {
+            return;
+        }
+
+        const trimmedNickname = nicknameInput.trim();
+
+        if (!trimmedNickname) {
+            setNicknameMessage({
+                tone: 'error',
+                text: '닉네임을 입력해주세요.',
+            });
+            return;
+        }
+
+        if (trimmedNickname === (nickname?.trim() ?? '')) {
+            setNicknameMessage({
+                tone: 'success',
+                text: '현재 닉네임과 동일합니다.',
+            });
+            return;
+        }
+
+        try {
+            setIsNicknameSubmitting(true);
+            setNicknameMessage(null);
+
+            const response = await updateMyNickname({
+                username: trimmedNickname,
+            });
+
+            updateNickname(response.username);
+            setNicknameMessage({
+                tone: 'success',
+                text: '닉네임이 변경되었습니다.',
+            });
+        } catch (error) {
+            setNicknameMessage({
+                tone: 'error',
+                text: getErrorMessage(error, '닉네임 변경에 실패했습니다.'),
+            });
+        } finally {
+            setIsNicknameSubmitting(false);
+        }
+    };
+
+    const handlePasswordSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        if (isPasswordSubmitting) {
+            return;
+        }
+
+        if (
+            !currentPassword.trim() ||
+            !newPassword.trim() ||
+            !newPasswordConfirm.trim()
+        ) {
+            setPasswordMessage({
+                tone: 'error',
+                text: '비밀번호 정보를 모두 입력해주세요.',
+            });
             return;
         }
 
         if (newPassword !== newPasswordConfirm) {
-            alert('새 비밀번호와 새 비밀번호 확인이 일치하지 않습니다.');
+            setPasswordMessage({
+                tone: 'error',
+                text: '새 비밀번호와 새 비밀번호 확인이 일치하지 않습니다.',
+            });
             return;
         }
 
-        alert('비밀번호 변경 API 연동 후 처리할 기능입니다.');
+        try {
+            setIsPasswordSubmitting(true);
+            setPasswordMessage(null);
+
+            await changeMyPassword({
+                currentPassword,
+                newPassword,
+                newPasswordConfirm,
+            });
+
+            clearSession();
+            onClose();
+            navigate('/');
+        } catch (error) {
+            setPasswordMessage({
+                tone: 'error',
+                text: getPasswordChangeErrorMessage(error),
+            });
+            setIsPasswordSubmitting(false);
+        }
     };
+
+    if (accountType === 'guest') {
+        return (
+            <div
+                className="relative w-[480px] max-w-[calc(100vw-32px)] rounded-2xl bg-white px-10 py-8 text-[var(--monomat-text-strong)] shadow-xl"
+                onClick={(event) => event.stopPropagation()}
+            >
+                <button
+                    type="button"
+                    onClick={handleClose}
+                    disabled={isSubmitting}
+                    className="absolute right-6 top-6 text-3xl leading-none text-[var(--monomat-text-muted)] transition hover:text-[var(--monomat-text-strong)] disabled:cursor-not-allowed disabled:opacity-40"
+                    aria-label="계정 모달 닫기"
+                >
+                    ×
+                </button>
+
+                <p
+                    id="account-modal-title"
+                    role="heading"
+                    aria-level={2}
+                    className="mb-10 text-center text-2xl font-bold text-black"
+                >
+                    내 계정
+                </p>
+
+                <section className="mb-8 flex items-center gap-5 rounded-lg bg-[var(--monomat-page-bg)] px-4 py-4">
+                    <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#7359D9] text-xl font-bold text-white">
+                        {avatarText}
+                    </div>
+
+                    <div className="min-w-0 text-left">
+                        <p className="truncate text-lg font-bold text-[var(--monomat-text-strong)]">
+                            {displayNickname}
+                        </p>
+                        <p className="text-sm text-[var(--monomat-text-muted)]">
+                            {ACCOUNT_TYPE_LABEL.guest}
+                        </p>
+                    </div>
+                </section>
+
+                <section className="mb-8 text-left">
+                    <label
+                        htmlFor="account-guest-nickname"
+                        className="mb-3 block text-base font-bold text-[var(--monomat-text-strong)]"
+                    >
+                        닉네임 변경
+                    </label>
+
+                    <div className="flex gap-2">
+                        <MonomatInput
+                            id="account-guest-nickname"
+                            type="text"
+                            value={nicknameInput}
+                            maxLength={GUEST_NICKNAME_POLICY.MAX_LENGTH}
+                            onChange={(event) =>
+                                setNicknameInput(event.target.value)
+                            }
+                            className="h-12 min-w-0 flex-1 rounded-lg border border-[color:var(--monomat-border-input)] px-4 text-base font-semibold text-[var(--monomat-text-strong)] outline-none transition focus:border-[color:var(--monomat-primary)]"
+                        />
+
+                        <button
+                            type="button"
+                            onClick={handleGuestNicknameSave}
+                            className="h-12 rounded-lg bg-[var(--monomat-primary)] px-6 font-bold text-white transition hover:bg-[var(--monomat-primary-hover)]"
+                        >
+                            저장
+                        </button>
+                    </div>
+
+                    <div className="mt-2">
+                        <FeedbackBadge message={nicknameMessage} />
+                    </div>
+                </section>
+
+                <button
+                    type="button"
+                    onClick={handleRegisterClick}
+                    className="mx-auto block font-bold text-[var(--monomat-primary)] underline underline-offset-2 transition hover:text-[var(--monomat-primary-hover)]"
+                >
+                    회원가입
+                </button>
+            </div>
+        );
+    }
 
     return (
         <div
-            className={`relative w-[480px] rounded-2xl bg-white px-10 py-8 text-[#333338] shadow-xl ${
-                accountType === 'member' ? 'min-h-[690px]' : 'min-h-[375px]'
-            }`}
+            className="relative flex h-[700px] w-[480px] max-w-[calc(100vw-32px)] flex-col overflow-hidden rounded-2xl bg-white px-[29px] pb-[38px] pt-7 text-[var(--monomat-text-strong)] shadow-xl"
+            onClick={(event) => event.stopPropagation()}
         >
             <button
                 type="button"
-                onClick={onClose}
-                className="absolute right-6 top-6 text-3xl leading-none text-[#808085] hover:text-[#333338]"
+                onClick={handleClose}
+                disabled={isSubmitting}
+                className="absolute right-[29px] top-[29px] flex h-6 w-6 items-center justify-center text-[18px] leading-none text-[var(--monomat-text-muted)] transition hover:text-[var(--monomat-text-strong)] disabled:cursor-not-allowed disabled:opacity-40"
                 aria-label="계정 모달 닫기"
             >
                 ×
             </button>
 
-            <h2
+            <p
                 id="account-modal-title"
-                className="mb-10 text-center text-2xl font-bold text-[#333338]"
+                role="heading"
+                aria-level={2}
+                className="mb-9 h-[33px] text-center text-[22px] font-extrabold leading-[33px] text-black"
             >
                 내 계정
-            </h2>
+            </p>
 
-            <section className="mb-8 flex items-center gap-5 rounded-lg bg-[#F5F5F7] px-4 py-4">
-                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#3873E6] text-xl font-bold text-white">
-                    {avatarText}
-                </div>
+            <div className="flex flex-1 flex-col justify-center pb-[4px] pt-[24px]">
+                <section className="mb-[18px] flex h-[77px] items-center rounded-lg bg-[var(--monomat-page-bg)] px-[25px]">
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[var(--monomat-primary)] text-xl font-extrabold leading-none text-white">
+                        {avatarText}
+                    </div>
 
-                <div>
-                    <p className="text-lg font-bold text-[#333338]">
-                        {displayNickname}
-                    </p>
-                    <p className="text-sm text-[#B9B9B9]">
-                        {ACCOUNT_TYPE_LABEL[accountType]}
-                    </p>
-                </div>
-            </section>
-
-            <section className="mb-8">
-                <label
-                    htmlFor="account-nickname"
-                    className="mb-3 block text-base font-bold text-[#333338]"
-                >
-                    📝 닉네임 변경
-                </label>
-
-                <div className="flex gap-2">
-                    <input
-                        id="account-nickname"
-                        type="text"
-                        value={nicknameInput}
-                        maxLength={NICKNAME_MAX_LENGTH}
-                        onChange={(event) =>
-                            setNicknameInput(event.target.value)
-                        }
-                        className="h-12 flex-1 rounded-lg border border-[#CCCCD1] px-4 text-base font-semibold text-[#333338] outline-none focus:border-[#3873E6]"
-                    />
-
-                    <button
-                        type="button"
-                        onClick={handleNicknameSave}
-                        className="h-12 rounded-lg bg-[#3873E6] px-6 font-bold text-white hover:bg-blue-600"
-                    >
-                        저장
-                    </button>
-                </div>
-            </section>
-
-            {accountType === 'member' ? (
-                <>
-                    <section className="mb-8 border-t border-[#E0E0E6] pt-6">
-                        <p className="mb-5 text-base font-bold text-[#333338]">
-                            🔑 비밀번호 변경
+                    <div className="ml-[21px] min-w-0 text-left">
+                        <p className="truncate text-lg font-bold leading-[21px] text-black">
+                            {displayNickname}
                         </p>
+                        <p className="mt-0.5 text-xs font-medium leading-[17px] text-[var(--monomat-text-muted)]">
+                            {ACCOUNT_TYPE_LABEL.member}
+                        </p>
+                    </div>
+                </section>
 
-                        <div className="flex flex-col gap-4">
-                            <input
-                                type="password"
-                                value={currentPassword}
-                                onChange={(event) =>
-                                    setCurrentPassword(event.target.value)
-                                }
-                                placeholder="현재 비밀번호"
-                                className="h-12 rounded-lg border border-[#CCCCD1] px-4 text-[#333338] outline-none placeholder:text-[#CCCCD1] focus:border-[#3873E6]"
-                            />
+                <form
+                    className="text-left"
+                    onSubmit={handleNicknameSubmit}
+                >
+                    <SectionTitle message={nicknameMessage}>
+                        닉네임 변경
+                    </SectionTitle>
 
-                            <input
-                                type="password"
-                                value={newPassword}
-                                onChange={(event) =>
-                                    setNewPassword(event.target.value)
-                                }
-                                placeholder="새 비밀번호 (6자 이상)"
-                                className="h-12 rounded-lg border border-[#CCCCD1] px-4 text-[#333338] outline-none placeholder:text-[#CCCCD1] focus:border-[#3873E6]"
-                            />
+                    <div className="flex gap-2">
+                        <MonomatInput
+                            id="account-member-nickname"
+                            type="text"
+                            value={nicknameInput}
+                            maxLength={MEMBER_NICKNAME_MAX_LENGTH}
+                            disabled={isNicknameSubmitting || isPasswordSubmitting}
+                            preventEnterSubmit={false}
+                            onChange={(event) => {
+                                setNicknameInput(event.target.value);
+                                setNicknameMessage(null);
+                            }}
+                            placeholder="변경할 닉네임을 입력하세요"
+                            className="h-[46px] min-w-0 flex-1 rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-5 text-sm font-medium text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                        />
 
-                            <input
-                                type="password"
-                                value={newPasswordConfirm}
-                                onChange={(event) =>
-                                    setNewPasswordConfirm(event.target.value)
-                                }
-                                placeholder="새 비밀번호 확인"
-                                className="h-12 rounded-lg border border-[#CCCCD1] px-4 text-[#333338] outline-none placeholder:text-[#CCCCD1] focus:border-[#3873E6]"
-                            />
+                        <button
+                            type="submit"
+                            disabled={isNicknameSubmitting || isPasswordSubmitting}
+                            className="h-11 w-[69px] shrink-0 rounded-lg bg-[var(--monomat-primary)] text-[15px] font-bold leading-none text-white transition hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:bg-[var(--monomat-primary-disabled)]"
+                        >
+                            {isNicknameSubmitting ? '저장중' : '저장'}
+                        </button>
+                    </div>
 
-                            <button
-                                type="button"
-                                onClick={handlePasswordChange}
-                                className="h-12 rounded-lg border border-[#CCCCD1] font-bold text-[#333338] hover:bg-[#F5F5F7]"
-                            >
-                                🔑 비밀번호 변경
-                            </button>
-                        </div>
-                    </section>
+                </form>
+
+                <div className="my-[7px] h-4 w-full">
+                    <div className="relative top-[7px] h-px w-full bg-[var(--monomat-border-default)]" />
+                </div>
+
+                <form
+                    className="text-left"
+                    onSubmit={handlePasswordSubmit}
+                >
+                    <SectionTitle message={passwordMessage}>
+                        비밀번호 변경
+                    </SectionTitle>
+
+                    <div className="flex flex-col gap-[17px]">
+                        <MonomatInput
+                            type="password"
+                            value={currentPassword}
+                            disabled={isNicknameSubmitting || isPasswordSubmitting}
+                            preventEnterSubmit={false}
+                            onChange={(event) => {
+                                setCurrentPassword(event.target.value);
+                                setPasswordMessage(null);
+                            }}
+                            placeholder="현재 비밀번호를 입력하세요"
+                            className="h-[46px] rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-5 text-sm font-medium text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                        />
+
+                        <MonomatInput
+                            type="password"
+                            value={newPassword}
+                            disabled={isNicknameSubmitting || isPasswordSubmitting}
+                            preventEnterSubmit={false}
+                            onChange={(event) => {
+                                setNewPassword(event.target.value);
+                                setPasswordMessage(null);
+                            }}
+                            placeholder="새 비밀번호"
+                            className="h-[46px] rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-5 text-sm font-medium text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                        />
+
+                        <MonomatInput
+                            type="password"
+                            value={newPasswordConfirm}
+                            disabled={isNicknameSubmitting || isPasswordSubmitting}
+                            preventEnterSubmit={false}
+                            onChange={(event) => {
+                                setNewPasswordConfirm(event.target.value);
+                                setPasswordMessage(null);
+                            }}
+                            placeholder="새 비밀번호 확인"
+                            className="h-[46px] rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-5 text-sm font-medium text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[color:var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                        />
+                    </div>
 
                     <button
-                        type="button"
-                        onClick={handleLogout}
-                        className="h-12 w-full rounded-lg bg-red-50 font-bold text-red-600 hover:bg-red-100"
+                        type="submit"
+                        disabled={isNicknameSubmitting || isPasswordSubmitting}
+                        className="mt-[18px] h-11 w-full rounded-lg bg-[var(--monomat-primary)] text-[15px] font-bold leading-none text-white transition hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:bg-[var(--monomat-primary-disabled)]"
                     >
-                        로그아웃
+                        {isPasswordSubmitting ? '변경 중...' : '비밀번호 변경'}
                     </button>
-                </>
-            ) : (
-                <button
-                    type="button"
-                    onClick={handleRegisterClick}
-                    className="mx-auto block font-bold text-[#3873E6] underline underline-offset-2"
-                >
-                    회원가입
-                </button>
-            )}
+
+                </form>
+            </div>
+
+            <div className="h-4 w-full">
+                <div className="relative top-[7px] h-px w-full bg-[var(--monomat-border-default)]" />
+            </div>
+
+            <button
+                type="button"
+                onClick={handleLogout}
+                disabled={isSubmitting}
+                className="mx-auto mt-[17px] flex h-5 items-center justify-center gap-2 text-sm font-semibold leading-[18px] text-[var(--monomat-danger)] transition hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+                <LockOpen size={16} strokeWidth={2} />
+                <span>로그아웃</span>
+            </button>
         </div>
     );
 }
@@ -239,6 +550,7 @@ export function AccountModal({
             role="dialog"
             aria-modal="true"
             aria-labelledby="account-modal-title"
+            onClick={onClose}
         >
             <AccountModalContent
                 accountType={accountType}

--- a/src/components/common/NavigationBar.tsx
+++ b/src/components/common/NavigationBar.tsx
@@ -29,7 +29,7 @@ export function NavigationBar() {
         ? 'bg-[#7359D9]'
         : 'bg-[var(--monomat-primary)]';
 
-    const accountType = userType === 'GUEST' ? 'guest' : 'member';
+    const accountType = userType === 'REGISTERED' ? 'member' : 'guest';
     const canCreateMap = userType === 'REGISTERED';
     const createMapRoute = LOBBY_ROUTES.CREATE_MAP;
     const canNavigateToCreateMap = createMapRoute != null;

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -47,4 +47,10 @@ export const API_ENDPOINTS = {
         READY: (code: string) => createApiEndpoint(`/api/lobbies/${code}/ready`),
         START: (code: string) => createApiEndpoint(`/api/lobbies/${code}/start`),
     },
+
+    USER: {
+        ME: createApiEndpoint('/api/users/me'),
+        NICKNAME: createApiEndpoint('/api/users/me/nickname'),
+        PASSWORD: createApiEndpoint('/api/users/me/password'),
+    },
 } as const;

--- a/src/schemas/userSchema.ts
+++ b/src/schemas/userSchema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const userStatusSchema = z.enum(['ACTIVE', 'BANNED', 'DELETED']);
+
+export const myUserInfoResponseSchema = z.object({
+    userId: z.number().int().positive(),
+    username: z.string().min(1),
+    userType: z.enum(['REGISTERED', 'GUEST']),
+    status: userStatusSchema,
+    createdAt: z.string().min(1),
+});

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,21 @@
+import type { UserType } from './auth';
+
+export type UserStatus = 'ACTIVE' | 'BANNED' | 'DELETED';
+
+export interface MyUserInfoResponse {
+    userId: number;
+    username: string;
+    userType: UserType;
+    status: UserStatus;
+    createdAt: string;
+}
+
+export interface UpdateNicknameRequest {
+    username: string;
+}
+
+export interface ChangePasswordRequest {
+    currentPassword: string;
+    newPassword: string;
+    newPasswordConfirm: string;
+}


### PR DESCRIPTION
## 📣 Related Issue

- #68

## 📝 Summary

- 정식 회원 프로필 모달 UI를 Figma 기준 레이아웃으로 개선했습니다.
- 닉네임 변경 API(`PATCH /api/users/me/nickname`)를 연동하고, 성공 응답의 `username`을 기존 `nickname` 세션 표시값에 동기화했습니다.
- 비밀번호 변경 API(`PATCH /api/users/me/password`)를 연동하고, 성공 시 세션을 비운 뒤 로그인 화면으로 이동하도록 처리했습니다.
- 비밀번호 변경의 FE 사전 검증은 빈 값과 새 비밀번호 확인 일치 여부로 제한했습니다.
- 401 응답의 `code`를 확인해 세션 만료성 401만 refresh하도록 `fetchWithAuth`를 개선했습니다.

## 🙏PR point

- `AUTH_CURRENT_PASSWORD_MISMATCH`처럼 비즈니스 검증 실패 성격의 401은 refresh하지 않고 호출부로 원 응답을 반환합니다.
- 비밀번호 변경 관련 BE 에러 메시지는 `createApiError` 기반으로 모달 내부에 표시됩니다.
- 게스트 모달은 이번 이슈 범위에 맞춰 전면 개편하지 않고 기존 흐름을 최대한 유지했습니다.
- `npm run lint`, `npm run build` 모두 통과했으며, 기존 `public/mockServiceWorker.js` warning과 Vite chunk size warning은 유지됩니다.

## 📬 Reference

