### PR TITLE
[Feat/#73] 프로필 아바타 색상 자동 지정

### DIFF
--- a/src/components/common/AccountModal.tsx
+++ b/src/components/common/AccountModal.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../api/userApi';
 import { GUEST_NICKNAME_POLICY } from '../../constants/auth';
 import { useAuthStore } from '../../store/useAuthStore';
+import { getAvatarColor } from '../../utils/avatarColor';
 import { validateGuestNickname } from '../../utils/validateNickname';
 import { MonomatInput } from './MonomatInput';
 
@@ -108,11 +109,16 @@ function AccountModalContent({
     const navigate = useNavigate();
 
     const nickname = useAuthStore((state) => state.nickname);
+    const userId = useAuthStore((state) => state.userId);
+    const userIdentifier = useAuthStore((state) => state.userIdentifier);
     const updateNickname = useAuthStore((state) => state.updateNickname);
     const clearSession = useAuthStore((state) => state.clearSession);
 
     const displayNickname = nickname?.trim() || 'Guest';
     const avatarText = displayNickname.charAt(0).toUpperCase() || 'G';
+    const avatarColorSeed =
+        userIdentifier ?? userId?.toString() ?? nickname ?? 'monomat-user';
+    const avatarColor = getAvatarColor(avatarColorSeed);
 
     const [nicknameInput, setNicknameInput] = useState(displayNickname);
     const [currentPassword, setCurrentPassword] = useState('');
@@ -321,7 +327,10 @@ function AccountModalContent({
 
                 <div className="flex flex-1 flex-col justify-center">
                     <section className="mb-[23px] flex h-[77px] items-center rounded-lg bg-[var(--monomat-page-bg)] px-[25px]">
-                        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[#7359D9] text-xl font-extrabold leading-none text-white">
+                        <div
+                            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-xl font-extrabold leading-none text-white"
+                            style={{ backgroundColor: avatarColor }}
+                        >
                             {avatarText}
                         </div>
 
@@ -414,7 +423,10 @@ function AccountModalContent({
 
             <div className="flex flex-1 flex-col justify-center pb-[4px] pt-[24px]">
                 <section className="mb-[18px] flex h-[77px] items-center rounded-lg bg-[var(--monomat-page-bg)] px-[25px]">
-                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[var(--monomat-primary)] text-xl font-extrabold leading-none text-white">
+                    <div
+                        className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-xl font-extrabold leading-none text-white"
+                        style={{ backgroundColor: avatarColor }}
+                    >
                         {avatarText}
                     </div>
 

--- a/src/components/common/NavigationBar.tsx
+++ b/src/components/common/NavigationBar.tsx
@@ -9,6 +9,7 @@ import {
     LOBBY_ROUTES,
 } from '../../constants/lobby';
 import { useAuthStore } from '../../store/useAuthStore';
+import { getAvatarColor } from '../../utils/avatarColor';
 import { AccountModal } from './AccountModal';
 import { MonomatLogo } from './MonomatLogo';
 import type { CreateLobbyResponse } from '../../types/lobby';
@@ -17,6 +18,8 @@ export function NavigationBar() {
     const navigate = useNavigate();
 
     const nickname = useAuthStore((state) => state.nickname);
+    const userId = useAuthStore((state) => state.userId);
+    const userIdentifier = useAuthStore((state) => state.userIdentifier);
     const userType = useAuthStore((state) => state.userType);
 
     const [isInviteCodeModalOpen, setIsInviteCodeModalOpen] = useState(false);
@@ -25,9 +28,9 @@ export function NavigationBar() {
 
     const displayNickname = nickname ?? 'Guest';
     const avatarText = displayNickname.charAt(0).toUpperCase();
-    const avatarClassName = userType === 'GUEST'
-        ? 'bg-[#7359D9]'
-        : 'bg-[var(--monomat-primary)]';
+    const avatarColorSeed =
+        userIdentifier ?? userId?.toString() ?? nickname ?? 'monomat-user';
+    const avatarColor = getAvatarColor(avatarColorSeed);
 
     const accountType = userType === 'REGISTERED' ? 'member' : 'guest';
     const canCreateMap = userType === 'REGISTERED';
@@ -115,7 +118,8 @@ export function NavigationBar() {
                         <button
                             type="button"
                             onClick={() => setIsAccountModalOpen(true)}
-                            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-xl font-extrabold leading-none text-white ${avatarClassName}`}
+                            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-xl font-extrabold leading-none text-white"
+                            style={{ backgroundColor: avatarColor }}
                             aria-label={LOBBY_NAVIGATION_LABELS.ACCOUNT_ARIA_LABEL}
                         >
                             {avatarText}

--- a/src/utils/avatarColor.ts
+++ b/src/utils/avatarColor.ts
@@ -1,0 +1,31 @@
+const AVATAR_COLOR_PALETTE = [
+    '#7359D9',
+    '#3873E6',
+    '#16A34A',
+    '#F97316',
+    '#DC2626',
+    '#9333EA',
+    '#0891B2',
+    '#BE185D',
+    '#4F46E5',
+    '#0F766E',
+] as const;
+
+const DEFAULT_AVATAR_COLOR_SEED = 'monomat-user';
+
+function createHashSeed(value: string): number {
+    let hash = 0;
+
+    for (let index = 0; index < value.length; index += 1) {
+        hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+    }
+
+    return hash;
+}
+
+export function getAvatarColor(seed: string | null | undefined): string {
+    const normalizedSeed = seed?.trim() || DEFAULT_AVATAR_COLOR_SEED;
+    const hash = createHashSeed(normalizedSeed);
+
+    return AVATAR_COLOR_PALETTE[hash % AVATAR_COLOR_PALETTE.length];
+}


### PR DESCRIPTION
## 📣 Related Issue

- #73

## 📝 Summary

- seed 기반 deterministic 아바타 색상 유틸을 추가했습니다.
- `userIdentifier ?? userId?.toString() ?? nickname ?? 'monomat-user'` 우선순위로 아바타 색상 seed를 구성했습니다.
- 상단바 프로필 버튼, 게스트 계정 모달, 정식 회원 계정 모달에 사용자별 아바타 배경색을 적용했습니다.
- 기존 userType 기반 고정 아바타 배경색을 제거하고 `style={{ backgroundColor: avatarColor }}` 방식으로 적용했습니다.
- 기존 닉네임 첫 글자 fallback과 닉네임 변경/비밀번호 변경/회원가입 유도 흐름은 유지했습니다.

## 🙏PR point

- `useAuthStore.ts`는 수정하지 않았고, 기존 store 값을 읽어 색상 seed만 구성했습니다.
- `Math.random()`은 사용하지 않아 같은 사용자는 새로고침 후에도 같은 색상이 유지됩니다.
- `npm run lint`는 통과했으며, 기존 `public/mockServiceWorker.js`의 unused eslint-disable warning 1개만 출력됩니다.
- `npm run build`는 통과했으며, Vite chunk size warning은 기존 번들 크기 관련 경고입니다.

## 📬 Reference

