### PR TITLE
[Feat/#67] 맵 카테고리 옵션 확장

### DIFF
--- a/src/constants/lobby.ts
+++ b/src/constants/lobby.ts
@@ -26,6 +26,8 @@ export const LOBBY_CATEGORY_FILTERS = [
     'K-POP',
     'J-POP',
     'POP',
+    'OST',
+    '애니',
 ] as const;
 
 export const LOBBY_ALL_CATEGORY_FILTER = LOBBY_CATEGORY_FILTERS[0];

--- a/src/mocks/data/lobbies.ts
+++ b/src/mocks/data/lobbies.ts
@@ -44,6 +44,32 @@ export const mockLobbyItems: LobbyListItem[] = [
         status: 'PLAYING',
         createdAtEpochMillis: 1_714_000_200_000,
     },
+    {
+        code: 'OST321',
+        hostId: 'host-4',
+        title: '드라마 OST 이어듣기',
+        mapId: 4,
+        mapTitle: 'OST 명곡 모음',
+        mapCategory: 'OST',
+        maxPlayers: 7,
+        currentPlayers: 2,
+        isPrivate: false,
+        status: 'WAITING',
+        createdAtEpochMillis: 1_714_000_300_000,
+    },
+    {
+        code: 'ANI654',
+        hostId: 'host-5',
+        title: '애니 오프닝 퀴즈',
+        mapId: 5,
+        mapTitle: '애니송 베스트',
+        mapCategory: '애니',
+        maxPlayers: 6,
+        currentPlayers: 3,
+        isPrivate: false,
+        status: 'WAITING',
+        createdAtEpochMillis: 1_714_000_400_000,
+    },
 ];
 
 export const mockLobbyPageResponse: LobbyPageResponse<LobbyListItem> = {

--- a/src/mocks/handlers/lobby.ts
+++ b/src/mocks/handlers/lobby.ts
@@ -13,7 +13,7 @@ import type {
     LobbySortQuery,
 } from '../../types/lobby';
 
-const LOBBY_CATEGORIES = ['K-POP', 'J-POP', 'POP'] as const;
+const LOBBY_CATEGORIES = ['K-POP', 'J-POP', 'POP', 'OST', '애니'] as const;
 const LOBBY_SORT_QUERIES = [
     'latest',
     'most_players',

--- a/src/schemas/lobbySchema.ts
+++ b/src/schemas/lobbySchema.ts
@@ -1,6 +1,12 @@
 import { z } from 'zod';
 
-export const lobbyCategorySchema = z.enum(['K-POP', 'J-POP', 'POP']);
+export const lobbyCategorySchema = z.enum([
+    'K-POP',
+    'J-POP',
+    'POP',
+    'OST',
+    '애니',
+]);
 
 export const lobbyStatusSchema = z.string().min(1);
 

--- a/src/types/lobby.ts
+++ b/src/types/lobby.ts
@@ -1,6 +1,6 @@
 // 게임 로비 (대기방)와 관련된 타입을 정의한다.
 
-export type LobbyCategory = 'K-POP' | 'J-POP' | 'POP';
+export type LobbyCategory = 'K-POP' | 'J-POP' | 'POP' | 'OST' | '애니';
 
 export type LobbyStatus = 'WAITING' | 'PLAYING' | (string & {});
 


### PR DESCRIPTION
## 📣 Related Issue

- #67

## 📝 Summary

- BE HTTP JSON 표시값 기준으로 로비 카테고리 타입을 `K-POP`, `J-POP`, `POP`, `OST`, `애니`로 확장했습니다.
- `lobbyCategorySchema`에 `OST`, `애니`를 추가해 신규 카테고리 응답 검증이 실패하지 않도록 수정했습니다.
- 로비 목록 카테고리 필터에 `OST`, `애니` 옵션을 추가했습니다.
- MSW mock category 검증과 로컬 확인용 mock 로비 데이터를 신규 카테고리에 맞춰 확장했습니다.

## 🙏PR point

- FE 타입/schema/filter 값에는 BE 내부 enum 값인 `KPOP`, `JPOP`, `ANIME`, `anime`을 추가하지 않고, HTTP JSON 표시값만 사용했습니다.
- `전체` 선택 시 기존처럼 `mapCategory` query를 제거하는 흐름은 유지했습니다.
- 검색, 정렬, 페이지네이션, 카드 레이아웃은 변경하지 않았습니다.
- `npm run lint` 통과: 기존 `public/mockServiceWorker.js` unused eslint-disable warning 1건 있음
- `npm run build` 통과: Vite chunk size warning 있음

## 📬 Reference

- BE develop `MapCategory` 계약