### PR TITLE
[Feat/#82] 맵 선택 모달 제작자 닉네임 표시

### DIFF
--- a/src/components/lobby/MapSelectModal.tsx
+++ b/src/components/lobby/MapSelectModal.tsx
@@ -24,7 +24,10 @@ import {
     MAP_SELECT_MODAL_PAGE_SIZE,
 } from '../../constants/map';
 import { useAuthStore } from '../../store/useAuthStore';
-import { formatMapDescription } from '../../utils/mapFormat';
+import {
+    formatMapDescription,
+    formatMapOwnerNickname,
+} from '../../utils/mapFormat';
 
 import type { MapSummary } from '../../types/map';
 
@@ -441,7 +444,10 @@ export function MapSelectModal({
                                                 </span>
                                                 <span className="mt-1 block truncate text-[11px] font-medium leading-[11px] text-[var(--monomat-text-muted)]">
                                                     {map.category} | 곡{' '}
-                                                    {map.numOfSong}개
+                                                    {map.numOfSong}개 |{' '}
+                                                    {formatMapOwnerNickname(
+                                                        map.ownerNickname,
+                                                    )}
                                                 </span>
                                             </span>
 

--- a/src/mocks/data/maps.ts
+++ b/src/mocks/data/maps.ts
@@ -11,6 +11,7 @@ export const mockPublicMapItems: MapSummary[] = [
         isPublic: true,
         pendingPublic: false,
         ownerId: 101,
+        ownerNickname: '하이퍼비트',
     },
     {
         mapId: 2,
@@ -22,6 +23,7 @@ export const mockPublicMapItems: MapSummary[] = [
         isPublic: true,
         pendingPublic: false,
         ownerId: 102,
+        ownerNickname: '시부야DJ',
     },
     {
         mapId: 3,
@@ -33,6 +35,7 @@ export const mockPublicMapItems: MapSummary[] = [
         isPublic: true,
         pendingPublic: false,
         ownerId: 103,
+        ownerNickname: null,
     },
     {
         mapId: 4,
@@ -44,6 +47,7 @@ export const mockPublicMapItems: MapSummary[] = [
         isPublic: true,
         pendingPublic: false,
         ownerId: 104,
+        ownerNickname: '애니믹스',
     },
     {
         mapId: 5,
@@ -55,6 +59,7 @@ export const mockPublicMapItems: MapSummary[] = [
         isPublic: true,
         pendingPublic: false,
         ownerId: 105,
+        ownerNickname: 'PopArchive',
     },
     {
         mapId: 6,
@@ -66,6 +71,7 @@ export const mockPublicMapItems: MapSummary[] = [
         isPublic: true,
         pendingPublic: false,
         ownerId: 106,
+        ownerNickname: 'OST콜렉터',
     },
 ];
 
@@ -80,6 +86,7 @@ export const mockMyMapItems: MapSummary[] = [
         isPublic: false,
         pendingPublic: false,
         ownerId: 999,
+        ownerNickname: '내계정',
     },
     {
         mapId: 102,
@@ -91,6 +98,7 @@ export const mockMyMapItems: MapSummary[] = [
         isPublic: true,
         pendingPublic: false,
         ownerId: 999,
+        ownerNickname: '내계정',
     },
     {
         mapId: 103,
@@ -102,6 +110,7 @@ export const mockMyMapItems: MapSummary[] = [
         isPublic: false,
         pendingPublic: true,
         ownerId: 999,
+        ownerNickname: '   ',
     },
 ];
 

--- a/src/pages/LobbyCreate.tsx
+++ b/src/pages/LobbyCreate.tsx
@@ -21,6 +21,7 @@ import type { MapSummary } from '../types/map';
 import { getAvatarColor } from '../utils/avatarColor';
 import {
     formatMapDescription,
+    formatMapOwnerNickname,
 } from '../utils/mapFormat';
 
 interface LobbyCreateFormState {
@@ -360,7 +361,10 @@ export function LobbyCreate() {
                                     </h3>
                                     <p className="mt-1 truncate text-sm font-medium leading-[18px] text-[var(--monomat-text-muted)]">
                                         {selectedMap.category} | 곡{' '}
-                                        {selectedMap.numOfSong}개
+                                        {selectedMap.numOfSong}개 |{' '}
+                                        {formatMapOwnerNickname(
+                                            selectedMap.ownerNickname,
+                                        )}
                                     </p>
                                     <p className="mt-1 overflow-hidden whitespace-pre-line break-keep [display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] text-xs font-medium leading-4 text-[var(--monomat-text-muted)] [overflow-wrap:anywhere]">
                                         {formatMapDescription(

--- a/src/schemas/mapSchema.ts
+++ b/src/schemas/mapSchema.ts
@@ -21,6 +21,7 @@ export const mapSummaryResponseSchema = z.object({
     isPublic: z.boolean(),
     pendingPublic: z.boolean(),
     ownerId: z.number().int().positive(),
+    ownerNickname: z.string().nullable(),
 });
 
 export const mapPageResponseSchema = z.object({

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -18,6 +18,7 @@ export interface MapSummary {
     isPublic: boolean;
     pendingPublic: boolean;
     ownerId: number;
+    ownerNickname: string | null;
 }
 
 export interface MapPageResponse {

--- a/src/utils/mapFormat.ts
+++ b/src/utils/mapFormat.ts
@@ -19,3 +19,11 @@ export function formatMapDescription(description: string | null) {
 
     return trimmedDescription || '맵 설명이 없습니다.';
 }
+
+export function formatMapOwnerNickname(
+    ownerNickname: string | null | undefined,
+) {
+    const trimmedNickname = ownerNickname?.trim();
+
+    return trimmedNickname || '알 수 없는 제작자';
+}


### PR DESCRIPTION
## 📣 Related Issue

- #82

## 📝 Summary

- BE develop 기준 맵 목록 응답에 추가된 `ownerNickname`을 FE 타입과 zod schema에 반영했습니다.
- 맵 선택 모달의 공개 맵/내 맵 목록에 제작자 닉네임을 표시했습니다.
- 로비 생성 페이지의 선택된 맵 카드에도 제작자 닉네임을 표시했습니다.
- `ownerNickname`이 null 또는 blank인 경우 `알 수 없는 제작자` fallback을 표시하도록 처리했습니다.
- MSW 맵 mock data에 `ownerNickname` 필드를 추가했습니다.

## 🙏PR point

- `ownerNickname`은 BE 계약상 존재하는 필수 응답 필드로 처리했고, 값 자체만 null을 허용했습니다.
- 화면에는 `ownerId`를 닉네임처럼 표시하지 않고 `ownerNickname`만 사용했습니다.
- 기존 맵 선택, description 확장, 내 맵 탭, 검색, 더보기, 로비 생성 시 `mapId` 전달 흐름은 유지했습니다.
- `npm run lint`, `npm run build` 모두 통과했습니다.
  - lint는 기존 `public/mockServiceWorker.js` unused eslint-disable warning 1개가 있습니다.
  - build는 기존 Vite chunk size warning이 있습니다.

## 📬 Reference

- BE develop `MapSummaryResponse.ownerNickname`