### PR TITLE
[Feat/#85] 맵 삭제 확인 모달 구현

### DIFF
--- a/src/api/mapApi.ts
+++ b/src/api/mapApi.ts
@@ -9,6 +9,8 @@ const DEFAULT_FETCH_PUBLIC_MAP_LIST_ERROR_MESSAGE =
     '맵 목록을 불러오는 데 실패했습니다.';
 const DEFAULT_FETCH_MY_MAP_LIST_ERROR_MESSAGE =
     '내 맵 목록을 불러오는 데 실패했습니다.';
+const DEFAULT_DELETE_MAP_ERROR_MESSAGE =
+    '맵 삭제에 실패했습니다.';
 
 function appendNonEmptyParam(
     searchParams: URLSearchParams,
@@ -87,4 +89,14 @@ export async function getMyMaps(
         createMapListUrl(API_ENDPOINTS.MAP.MY_LIST, params),
         DEFAULT_FETCH_MY_MAP_LIST_ERROR_MESSAGE,
     );
+}
+
+export async function deleteMap(mapId: number): Promise<void> {
+    const response = await fetchWithAuth(API_ENDPOINTS.MAP.DELETE(mapId), {
+        method: 'DELETE',
+    });
+
+    if (!response.ok) {
+        throw await createApiError(response, DEFAULT_DELETE_MAP_ERROR_MESSAGE);
+    }
 }

--- a/src/components/map/MapDeleteConfirmModal.tsx
+++ b/src/components/map/MapDeleteConfirmModal.tsx
@@ -1,0 +1,129 @@
+import {
+    type MouseEvent,
+    useEffect,
+} from 'react';
+import { X } from 'lucide-react';
+
+import { MAP_DELETE_CONFIRM_MODAL_COPY } from '../../constants/map';
+
+interface MapDeleteConfirmModalProps {
+    mapTitle: string;
+    isDeleting: boolean;
+    errorMessage: string | null;
+    onCancel: () => void;
+    onConfirm: () => void;
+}
+
+export function MapDeleteConfirmModal({
+    mapTitle,
+    isDeleting,
+    errorMessage,
+    onCancel,
+    onConfirm,
+}: MapDeleteConfirmModalProps) {
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape' && !isDeleting) {
+                onCancel();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        document.body.style.overflow = 'hidden';
+
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+            document.body.style.overflow = '';
+        };
+    }, [isDeleting, onCancel]);
+
+    const handleOverlayMouseDown = () => {
+        if (!isDeleting) {
+            onCancel();
+        }
+    };
+
+    const handleContentMouseDown = (event: MouseEvent<HTMLDivElement>) => {
+        event.stopPropagation();
+    };
+
+    return (
+        <div
+            role="presentation"
+            onMouseDown={handleOverlayMouseDown}
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 px-4 py-8"
+        >
+            <div
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="map-delete-confirm-modal-title"
+                aria-describedby="map-delete-confirm-modal-description"
+                onMouseDown={handleContentMouseDown}
+                className="relative w-full max-w-[445px] overflow-hidden rounded-lg bg-white px-7 pb-[18px] pt-8 text-center shadow-[0_18px_48px_rgba(15,23,42,0.22)]"
+            >
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    disabled={isDeleting}
+                    className="absolute right-3 top-3 flex h-8 w-8 items-center justify-center rounded-lg text-[var(--monomat-text-muted)] transition hover:bg-[var(--monomat-page-bg)] hover:text-black disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-label={MAP_DELETE_CONFIRM_MODAL_COPY.CLOSE_ARIA_LABEL}
+                >
+                    <X size={20} strokeWidth={1.8} aria-hidden="true" />
+                </button>
+
+                <h2
+                    id="map-delete-confirm-modal-title"
+                    className="!m-0 !text-sm !font-semibold !leading-[21px] !text-black"
+                >
+                    {MAP_DELETE_CONFIRM_MODAL_COPY.TITLE}
+                </h2>
+
+                <p
+                    id="map-delete-confirm-modal-description"
+                    className="mx-auto mt-2 max-w-[360px] break-keep text-sm font-medium leading-5 text-[var(--monomat-text-muted)]"
+                >
+                    {MAP_DELETE_CONFIRM_MODAL_COPY.DESCRIPTION}
+                </p>
+
+                <div className="mt-4 rounded-lg bg-[var(--monomat-page-bg)] px-4 py-3 text-left">
+                    <span className="block text-[11px] font-bold leading-none text-[var(--monomat-text-muted)]">
+                        {MAP_DELETE_CONFIRM_MODAL_COPY.TARGET_LABEL}
+                    </span>
+                    <span className="mt-1 block break-keep text-sm font-bold leading-5 text-[var(--monomat-text-strong)] [overflow-wrap:anywhere]">
+                        {mapTitle}
+                    </span>
+                </div>
+
+                {errorMessage && (
+                    <p
+                        role="alert"
+                        className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm font-semibold leading-5 text-red-600 ring-1 ring-red-100"
+                    >
+                        {errorMessage}
+                    </p>
+                )}
+
+                <div className="mt-[18px] flex justify-end gap-2">
+                    <button
+                        type="button"
+                        onClick={onCancel}
+                        disabled={isDeleting}
+                        className="h-[33px] min-w-[62px] rounded-[25px] bg-[var(--monomat-primary)] px-4 text-sm font-bold leading-none text-white transition hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:bg-[var(--monomat-primary-disabled)]"
+                    >
+                        {MAP_DELETE_CONFIRM_MODAL_COPY.CANCEL}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onConfirm}
+                        disabled={isDeleting}
+                        className="h-[33px] min-w-[62px] rounded-2xl border border-[#CCCCD1] bg-white px-4 text-sm font-bold leading-none text-[#808085] transition hover:border-red-200 hover:bg-red-50 hover:text-red-600 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-[#CCCCD1] disabled:hover:bg-white disabled:hover:text-[#808085]"
+                    >
+                        {isDeleting
+                            ? MAP_DELETE_CONFIRM_MODAL_COPY.DELETING
+                            : MAP_DELETE_CONFIRM_MODAL_COPY.CONFIRM}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -51,6 +51,7 @@ export const API_ENDPOINTS = {
     MAP: {
         LIST: createApiEndpoint('/api/maps'),
         MY_LIST: createApiEndpoint('/api/maps/me'),
+        DELETE: (mapId: number) => createApiEndpoint(`/api/maps/${mapId}`),
     },
 
     USER: {

--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -36,8 +36,20 @@ export const MY_MAPS_PAGE_COPY = {
     ACTION: '동작',
     EDIT_ARIA_LABEL: '맵 수정',
     DELETE_ARIA_LABEL: '맵 삭제',
+    DELETE_BUTTON_ARIA_LABEL: (title: string) => `${title} 삭제`,
     DESCRIPTION_TOGGLE_ARIA_LABEL: (title: string) => `${title} 설명 보기`,
     SONG_UNIT: '곡',
+} as const;
+
+export const MAP_DELETE_CONFIRM_MODAL_COPY = {
+    TITLE: '이 맵을 삭제할까요?',
+    DESCRIPTION: '삭제하면 포함된 모든 곡이 함께 삭제되며 복구하기 어렵습니다.',
+    TARGET_LABEL: '삭제 대상',
+    CANCEL: '취소',
+    CONFIRM: '삭제',
+    DELETING: '삭제 중...',
+    CLOSE_ARIA_LABEL: '삭제 확인 모달 닫기',
+    ERROR_FALLBACK: '맵 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.',
 } as const;
 
 export const MY_MAPS_ERROR_COPY = {

--- a/src/pages/MyMaps.tsx
+++ b/src/pages/MyMaps.tsx
@@ -3,6 +3,10 @@ import {
     useState,
 } from 'react';
 import {
+    useMutation,
+    useQueryClient,
+} from '@tanstack/react-query';
+import {
     ChevronDown,
     ChevronLeft,
     ChevronRight,
@@ -18,10 +22,13 @@ import {
 import { useNavigate } from 'react-router-dom';
 
 import { ApiError } from '../api/apiError';
+import { deleteMap } from '../api/mapApi';
 import { NavigationBar } from '../components/common/NavigationBar';
 import { LobbyFooter } from '../components/lobby/LobbyFooter';
+import { MapDeleteConfirmModal } from '../components/map/MapDeleteConfirmModal';
 import {
     DEFAULT_MAP_LIST_PAGE,
+    MAP_DELETE_CONFIRM_MODAL_COPY,
     MAP_PUBLIC_STATUS_META,
     MAP_ROUTES,
     MY_MAP_LIST_PAGE_SIZE,
@@ -74,6 +81,14 @@ function getErrorDescription(error: unknown) {
     return MY_MAPS_ERROR_COPY.DESCRIPTION;
 }
 
+function getDeleteErrorMessage(error: unknown) {
+    if (error instanceof Error && error.message) {
+        return error.message;
+    }
+
+    return MAP_DELETE_CONFIRM_MODAL_COPY.ERROR_FALLBACK;
+}
+
 function matchesMyMapSearch(map: MapSummary, keyword: string) {
     const normalizedKeyword = keyword.trim().toLowerCase();
 
@@ -122,7 +137,13 @@ function MyMapIcon() {
     );
 }
 
-function MyMapRow({ map }: { map: MapSummary }) {
+function MyMapRow({
+    map,
+    onDeleteClick,
+}: {
+    map: MapSummary;
+    onDeleteClick: (map: MapSummary) => void;
+}) {
     const [isDescriptionOpen, setIsDescriptionOpen] = useState(false);
     const description = formatMapDescription(map.description);
     const songCount = numberFormatter.format(map.numOfSong);
@@ -198,8 +219,11 @@ function MyMapRow({ map }: { map: MapSummary }) {
                     </button>
                     <button
                         type="button"
+                        onClick={() => onDeleteClick(map)}
                         className="flex h-[30px] w-[30px] items-center justify-center rounded-lg border border-[color:var(--monomat-border-input)] bg-white text-[#2B3F6C] transition hover:bg-[var(--monomat-page-bg)]"
-                        aria-label={MY_MAPS_PAGE_COPY.DELETE_ARIA_LABEL}
+                        aria-label={MY_MAPS_PAGE_COPY.DELETE_BUTTON_ARIA_LABEL(
+                            map.title,
+                        )}
                         title={MY_MAPS_PAGE_COPY.DELETE_ARIA_LABEL}
                     >
                         <Trash2 size={17} strokeWidth={2} aria-hidden="true" />
@@ -375,8 +399,13 @@ function MyMapsPagination({
 
 export function MyMaps() {
     const navigate = useNavigate();
+    const queryClient = useQueryClient();
     const [currentPage, setCurrentPage] = useState(DEFAULT_MAP_LIST_PAGE);
     const [searchKeyword, setSearchKeyword] = useState('');
+    const [deleteTargetMap, setDeleteTargetMap] =
+        useState<MapSummary | null>(null);
+    const [deleteErrorMessage, setDeleteErrorMessage] =
+        useState<string | null>(null);
     const trimmedSearchKeyword = searchKeyword.trim();
     const isSearching = trimmedSearchKeyword.length > 0;
 
@@ -400,6 +429,22 @@ export function MyMaps() {
     const totalPages = activeQuery.data?.totalPages ?? 0;
     const hasNext = activeQuery.data?.hasNext ?? false;
 
+    const deleteMapMutation = useMutation({
+        mutationFn: (mapId: number) => deleteMap(mapId),
+        onMutate: () => {
+            setDeleteErrorMessage(null);
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({
+                queryKey: ['myMaps'],
+            });
+            setDeleteTargetMap(null);
+        },
+        onError: (mutationError) => {
+            setDeleteErrorMessage(getDeleteErrorMessage(mutationError));
+        },
+    });
+
     const handleSearchKeywordChange = (event: ChangeEvent<HTMLInputElement>) => {
         setSearchKeyword(event.target.value);
         setCurrentPage(DEFAULT_MAP_LIST_PAGE);
@@ -407,6 +452,32 @@ export function MyMaps() {
 
     const handleCreateMapClick = () => {
         window.alert(MY_MAPS_PAGE_COPY.CREATE_MAP_PENDING);
+    };
+
+    const handleDeleteClick = (map: MapSummary) => {
+        if (deleteMapMutation.isPending) {
+            return;
+        }
+
+        setDeleteTargetMap(map);
+        setDeleteErrorMessage(null);
+    };
+
+    const handleCloseDeleteModal = () => {
+        if (deleteMapMutation.isPending) {
+            return;
+        }
+
+        setDeleteTargetMap(null);
+        setDeleteErrorMessage(null);
+    };
+
+    const handleConfirmDelete = () => {
+        if (!deleteTargetMap || deleteMapMutation.isPending) {
+            return;
+        }
+
+        deleteMapMutation.mutate(deleteTargetMap.mapId);
     };
 
     return (
@@ -491,7 +562,11 @@ export function MyMaps() {
                             maps.length > 0 && (
                             <>
                                 {maps.map((map) => (
-                                    <MyMapRow key={map.mapId} map={map} />
+                                    <MyMapRow
+                                        key={map.mapId}
+                                        map={map}
+                                        onDeleteClick={handleDeleteClick}
+                                    />
                                 ))}
                             </>
                         )}
@@ -512,6 +587,16 @@ export function MyMaps() {
             </main>
 
             <LobbyFooter />
+
+            {deleteTargetMap && (
+                <MapDeleteConfirmModal
+                    mapTitle={deleteTargetMap.title}
+                    isDeleting={deleteMapMutation.isPending}
+                    errorMessage={deleteErrorMessage}
+                    onCancel={handleCloseDeleteModal}
+                    onConfirm={handleConfirmDelete}
+                />
+            )}
         </div>
     );
 }


### PR DESCRIPTION
## 📣 Related Issue

- #85

## 📝 Summary

- 맵 관리 페이지에서 삭제 버튼 클릭 시 즉시 삭제하지 않고 확인 모달을 표시하도록 변경했습니다.
- 삭제 대상 맵 상태를 `MyMaps` 상위에서 관리하고, `MyMapRow`에는 삭제 콜백만 전달하도록 수정했습니다.
- `DELETE /api/maps/{mapId}` 호출 API와 `API_ENDPOINTS.MAP.DELETE(mapId)` endpoint를 추가했습니다.
- 삭제 성공 후 `queryClient.invalidateQueries({ queryKey: ['myMaps'] })`로 내 맵 목록 전체를 갱신하도록 처리했습니다.
- 삭제 요청 중 중복 요청을 방지하고, 실패 시 모달 내부에 에러 메시지를 표시하도록 구현했습니다.

## 🙏PR point

- 삭제 API는 BE develop 기준 204 No Content 응답이므로 `response.json()`을 호출하지 않습니다.
- MSW 삭제 핸들러는 이번 이슈 범위에서 제외했습니다.
- Figma의 확인 모달 레이아웃을 참고하되, 이슈 요구사항에 맞춰 삭제 대상 맵 제목, 닫기 버튼, 에러 표시 영역을 추가했습니다.
- `npm run lint`는 통과했으며, 기존 `public/mockServiceWorker.js`의 unused eslint-disable warning 1건만 출력됩니다.
- `npm run build`는 통과했으며, 기존 Vite chunk size warning만 출력됩니다.

## 📬 Reference

- BE API: `DELETE /api/maps/{mapId}`