### PR TITLE
[Feat/#87] 맵 생성 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { Lobbies } from './pages/Lobbies';
 import { LobbyCreate } from './pages/LobbyCreate';
 import { LobbyRoom } from './pages/LobbyRoom';
 import { MyMaps } from './pages/MyMaps';
+import { MapCreate } from './pages/MapCreate';
 
 /**
  * [애플리케이션 루트 컴포넌트]
@@ -86,6 +87,17 @@ function AppRoutes() {
                         <AppLayout>
                             <ProtectedRoute>
                                 <MyMaps />
+                            </ProtectedRoute>
+                        </AppLayout>
+                    }
+                />
+
+                <Route
+                    path={MAP_ROUTES.CREATE_MAP}
+                    element={
+                        <AppLayout>
+                            <ProtectedRoute>
+                                <MapCreate />
                             </ProtectedRoute>
                         </AppLayout>
                     }

--- a/src/api/mapApi.ts
+++ b/src/api/mapApi.ts
@@ -1,14 +1,28 @@
 import { API_ENDPOINTS } from '../constants/endpoints';
-import { mapPageResponseSchema } from '../schemas/mapSchema';
+import {
+    mapDetailResponseSchema,
+    mapItemResponseSchema,
+    mapPageResponseSchema,
+} from '../schemas/mapSchema';
 import { createApiError } from './apiError';
 import { fetchWithAuth } from './apiClient';
 
-import type { MapListQueryParams, MapPageResponse } from '../types/map';
+import type {
+    CreateMapItemRequest,
+    CreateMapRequest,
+    MapDetailResponse,
+    MapItemResponse,
+    MapListQueryParams,
+    MapPageResponse,
+} from '../types/map';
 
+const JSON_CONTENT_TYPE = 'application/json';
 const DEFAULT_FETCH_PUBLIC_MAP_LIST_ERROR_MESSAGE =
     '맵 목록을 불러오는 데 실패했습니다.';
 const DEFAULT_FETCH_MY_MAP_LIST_ERROR_MESSAGE =
     '내 맵 목록을 불러오는 데 실패했습니다.';
+const DEFAULT_CREATE_MAP_ERROR_MESSAGE = '맵 생성에 실패했습니다.';
+const DEFAULT_CREATE_MAP_ITEM_ERROR_MESSAGE = '곡 등록에 실패했습니다.';
 const DEFAULT_DELETE_MAP_ERROR_MESSAGE =
     '맵 삭제에 실패했습니다.';
 
@@ -89,6 +103,64 @@ export async function getMyMaps(
         createMapListUrl(API_ENDPOINTS.MAP.MY_LIST, params),
         DEFAULT_FETCH_MY_MAP_LIST_ERROR_MESSAGE,
     );
+}
+
+export async function createMap(
+    request: CreateMapRequest,
+): Promise<MapDetailResponse> {
+    const response = await fetchWithAuth(API_ENDPOINTS.MAP.CREATE, {
+        method: 'POST',
+        headers: {
+            'Content-Type': JSON_CONTENT_TYPE,
+        },
+        body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+        throw await createApiError(response, DEFAULT_CREATE_MAP_ERROR_MESSAGE);
+    }
+
+    const payload = await response.json() as unknown;
+    const parsed = mapDetailResponseSchema.safeParse(payload);
+
+    if (!parsed.success) {
+        console.error('[mapApi] 맵 생성 응답 검증 실패:', parsed.error);
+
+        throw new Error('맵 생성 응답 형식이 올바르지 않습니다.');
+    }
+
+    return parsed.data;
+}
+
+export async function createMapItem(
+    mapId: number,
+    request: CreateMapItemRequest,
+): Promise<MapItemResponse> {
+    const response = await fetchWithAuth(API_ENDPOINTS.MAP.ITEMS(mapId), {
+        method: 'POST',
+        headers: {
+            'Content-Type': JSON_CONTENT_TYPE,
+        },
+        body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            DEFAULT_CREATE_MAP_ITEM_ERROR_MESSAGE,
+        );
+    }
+
+    const payload = await response.json() as unknown;
+    const parsed = mapItemResponseSchema.safeParse(payload);
+
+    if (!parsed.success) {
+        console.error('[mapApi] 곡 생성 응답 검증 실패:', parsed.error);
+
+        throw new Error('곡 생성 응답 형식이 올바르지 않습니다.');
+    }
+
+    return parsed.data;
 }
 
 export async function deleteMap(mapId: number): Promise<void> {

--- a/src/components/map/MapCreateGuide.tsx
+++ b/src/components/map/MapCreateGuide.tsx
@@ -1,0 +1,67 @@
+import {
+    Clock3,
+    Link2,
+    ListChecks,
+    Music2,
+    Sparkles,
+} from 'lucide-react';
+
+import {
+    MAP_CREATE_GUIDE_STEPS,
+    MAP_CREATE_PAGE_COPY,
+} from '../../constants/map';
+
+const guideIcons = [Music2, Link2, ListChecks, Clock3] as const;
+
+export function MapCreateGuide() {
+    return (
+        <section className="rounded-lg border border-[var(--monomat-primary)] bg-[rgba(56,115,229,0.1)] px-4 py-4 shadow-[0_4px_16px_rgba(0,0,0,0.14)] sm:px-6">
+            <div className="flex items-center gap-2 text-base font-semibold text-[var(--monomat-text-primary)]">
+                <Sparkles
+                    size={21}
+                    className="text-[var(--monomat-primary)]"
+                    aria-hidden="true"
+                />
+                <h2 className="!m-0 !text-base !font-semibold !leading-6 !text-[var(--monomat-text-primary)]">
+                    {MAP_CREATE_PAGE_COPY.GUIDE_TITLE}
+                </h2>
+            </div>
+
+            <ol className="mt-3 grid grid-cols-2 gap-3 lg:grid-cols-4">
+                {MAP_CREATE_GUIDE_STEPS.map((step, index) => {
+                    const Icon = guideIcons[index];
+
+                    return (
+                        <li
+                            key={step.title}
+                            className="min-h-[110px] rounded-lg border border-[color:var(--monomat-border-input)] bg-white p-3"
+                        >
+                            <div className="flex items-center gap-2">
+                                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--monomat-primary)] text-sm font-semibold text-white">
+                                    {index + 1}
+                                </span>
+                                <Icon
+                                    size={21}
+                                    className="shrink-0 text-[var(--monomat-primary)]"
+                                    aria-hidden="true"
+                                />
+                                <h3 className="text-base font-bold leading-6 text-black">
+                                    {step.title}
+                                </h3>
+                            </div>
+                            <div className="flex min-h-[52px] items-center">
+                                <p className="text-xs font-medium leading-[17px] text-[var(--monomat-text-secondary)]">
+                                    {step.description}
+                                </p>
+                            </div>
+                        </li>
+                    );
+                })}
+            </ol>
+
+            <p className="mt-2 text-[13px] leading-5 text-[var(--monomat-text-secondary)]">
+                {MAP_CREATE_PAGE_COPY.GUIDE_TIP}
+            </p>
+        </section>
+    );
+}

--- a/src/components/map/MapCreateSongCard.tsx
+++ b/src/components/map/MapCreateSongCard.tsx
@@ -1,0 +1,527 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+    ChevronDown,
+    ChevronUp,
+    Music2,
+    Play,
+    Trash2,
+} from 'lucide-react';
+
+import { MonomatInput } from '../common/MonomatInput';
+import {
+    MAP_CREATE_POLICY,
+    MAP_CREATE_SONG_COPY,
+} from '../../constants/map';
+import {
+    createYouTubeEmbedUrl,
+    createYouTubeThumbnailUrl,
+    extractYouTubeVideoId,
+    loadYouTubeIframeApi,
+} from '../../utils/youtube';
+import {
+    normalizeAnswer,
+    normalizeAnswerList,
+} from '../../utils/answerNormalizer';
+import { getMapCreateTimingError } from '../../utils/mapCreateTiming';
+
+import type { CreateMapSongFormState } from '../../types/map';
+import type { YouTubeIframePlayer } from '../../utils/youtube';
+
+interface MapCreateSongCardProps {
+    index: number;
+    song: CreateMapSongFormState;
+    canDeleteSong: boolean;
+    canMoveUp: boolean;
+    canMoveDown: boolean;
+    disabled: boolean;
+    onChange: (
+        songId: string,
+        field: Exclude<
+            keyof CreateMapSongFormState,
+            'id' | 'answers' | 'videoDurationSeconds'
+        >,
+        value: string,
+    ) => void;
+    onAnswerChange: (
+        songId: string,
+        answerIndex: number,
+        value: string,
+    ) => void;
+    onDurationChange: (
+        songId: string,
+        videoDurationSeconds: number | null,
+    ) => void;
+    onAddAnswer: (songId: string) => void;
+    onDeleteAnswer: (songId: string, answerIndex: number) => void;
+    onDeleteSong: (songId: string) => void;
+    onMoveUp: (songId: string) => void;
+    onMoveDown: (songId: string) => void;
+}
+
+const inputClassName =
+    'h-[45px] w-full rounded-lg border border-[color:var(--monomat-border-input)] bg-[#FBFCFE] px-[14px] text-[15px] text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-text-muted)] focus:border-[var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60';
+
+function SongFieldLabel({ children }: { children: string }) {
+    return (
+        <span className="mb-1 block text-sm font-medium leading-5 text-[var(--monomat-text-muted)]">
+            {children}
+        </span>
+    );
+}
+
+export function MapCreateSongCard({
+    index,
+    song,
+    canDeleteSong,
+    canMoveUp,
+    canMoveDown,
+    disabled,
+    onChange,
+    onAnswerChange,
+    onDurationChange,
+    onAddAnswer,
+    onDeleteAnswer,
+    onDeleteSong,
+    onMoveUp,
+    onMoveDown,
+}: MapCreateSongCardProps) {
+    const [playingVideoId, setPlayingVideoId] = useState<string | null>(null);
+    const onDurationChangeRef = useRef(onDurationChange);
+    const songNumber = String(index + 1).padStart(2, '0');
+    const songTitle =
+        song.answers[0]?.trim() || MAP_CREATE_SONG_COPY.TITLE;
+    const canAddAnswer =
+        song.answers.length < MAP_CREATE_POLICY.MAX_ANSWER_COUNT;
+    const normalizedAnswers = normalizeAnswerList(song.answers);
+    const normalizedAnswerCount = song.answers
+        .map((answer) => normalizeAnswer(answer))
+        .filter(Boolean)
+        .length;
+    const hasDuplicateAnswers =
+        normalizedAnswerCount > normalizedAnswers.length;
+    const videoId = extractYouTubeVideoId(song.youtubeUrl);
+    const parsedStartTime = Number(song.startTime);
+    const previewStartTime =
+        song.startTime.trim() &&
+        Number.isInteger(parsedStartTime) &&
+        parsedStartTime >= MAP_CREATE_POLICY.MIN_START_TIME_SECONDS
+            ? parsedStartTime
+            : MAP_CREATE_POLICY.MIN_START_TIME_SECONDS;
+    const thumbnailUrl = videoId
+        ? createYouTubeThumbnailUrl(videoId)
+        : null;
+    const embedUrl = videoId
+        ? createYouTubeEmbedUrl(
+              videoId,
+              previewStartTime,
+              window.location.origin,
+          )
+        : null;
+    const timingError = getMapCreateTimingError(
+        song.startTime,
+        song.videoDurationSeconds,
+    );
+    const playerElementId = `youtube-preview-${song.id}`;
+
+    useEffect(() => {
+        onDurationChangeRef.current = onDurationChange;
+    }, [onDurationChange]);
+
+    useEffect(() => {
+        setPlayingVideoId(null);
+    }, [song.startTime, song.youtubeUrl]);
+
+    useEffect(() => {
+        if (
+            !videoId ||
+            playingVideoId !== videoId ||
+            !embedUrl
+        ) {
+            return;
+        }
+
+        let isDisposed = false;
+        let player: YouTubeIframePlayer | null = null;
+        let durationTimer: ReturnType<typeof setTimeout> | null = null;
+
+        const reportDuration = (attempt = 0) => {
+            if (isDisposed || !player) {
+                return;
+            }
+
+            const duration = player.getDuration();
+
+            if (Number.isFinite(duration) && duration > 0) {
+                onDurationChangeRef.current(
+                    song.id,
+                    Math.floor(duration),
+                );
+                return;
+            }
+
+            if (attempt < 20) {
+                durationTimer = setTimeout(
+                    () => reportDuration(attempt + 1),
+                    500,
+                );
+            }
+        };
+
+        void loadYouTubeIframeApi()
+            .then((youtubeApi) => {
+                if (isDisposed) {
+                    return;
+                }
+
+                player = new youtubeApi.Player(playerElementId, {
+                    events: {
+                        onReady: () => reportDuration(),
+                        onError: () =>
+                            onDurationChangeRef.current(song.id, null),
+                    },
+                });
+            })
+            .catch(() => {
+                if (!isDisposed) {
+                    onDurationChangeRef.current(song.id, null);
+                }
+            });
+
+        return () => {
+            isDisposed = true;
+
+            if (durationTimer) {
+                clearTimeout(durationTimer);
+            }
+        };
+    }, [embedUrl, playerElementId, playingVideoId, song.id, videoId]);
+
+    return (
+        <article className="overflow-hidden rounded-2xl border border-[color:var(--monomat-border-input)] bg-[#FBFCFE]">
+            <header className="flex h-[60px] items-center border-b border-[color:var(--monomat-border-input)] bg-[#F7F8FA] px-5">
+                <span className="w-9 shrink-0 text-center font-mono text-sm font-bold text-[var(--monomat-text-secondary)]">
+                    {songNumber}
+                </span>
+                <Music2
+                    size={22}
+                    className="ml-1 shrink-0 text-[var(--monomat-primary)]"
+                    aria-hidden="true"
+                />
+                <h3
+                    className="ml-3 min-w-0 truncate text-base font-bold text-[var(--monomat-text-secondary)]"
+                    title={songTitle}
+                >
+                    {songTitle}
+                </h3>
+                <div className="ml-auto flex items-center gap-1">
+                    <button
+                        type="button"
+                        onClick={() => onMoveUp(song.id)}
+                        disabled={disabled || !canMoveUp}
+                        className="flex h-8 w-8 items-center justify-center rounded-lg text-[var(--monomat-text-secondary)] transition hover:bg-white hover:text-black disabled:cursor-not-allowed disabled:opacity-30"
+                        aria-label={MAP_CREATE_SONG_COPY.MOVE_SONG_UP_ARIA_LABEL(
+                            index,
+                        )}
+                    >
+                        <ChevronUp
+                            size={19}
+                            strokeWidth={2}
+                            aria-hidden="true"
+                        />
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => onMoveDown(song.id)}
+                        disabled={disabled || !canMoveDown}
+                        className="flex h-8 w-8 items-center justify-center rounded-lg text-[var(--monomat-text-secondary)] transition hover:bg-white hover:text-black disabled:cursor-not-allowed disabled:opacity-30"
+                        aria-label={MAP_CREATE_SONG_COPY.MOVE_SONG_DOWN_ARIA_LABEL(
+                            index,
+                        )}
+                    >
+                        <ChevronDown
+                            size={19}
+                            strokeWidth={2}
+                            aria-hidden="true"
+                        />
+                    </button>
+                </div>
+                <button
+                    type="button"
+                    onClick={() => onDeleteSong(song.id)}
+                    disabled={disabled || !canDeleteSong}
+                    className="ml-1 flex h-9 w-9 items-center justify-center rounded-lg text-[var(--monomat-text-secondary)] transition hover:bg-white hover:text-[var(--monomat-danger)] disabled:cursor-not-allowed disabled:opacity-35"
+                    aria-label={MAP_CREATE_SONG_COPY.DELETE_SONG_ARIA_LABEL(
+                        index,
+                    )}
+                >
+                    <Trash2 size={20} strokeWidth={1.8} aria-hidden="true" />
+                </button>
+            </header>
+
+            <div className="grid gap-5 p-4 lg:grid-cols-[240px_minmax(0,1fr)] lg:p-6">
+                <div>
+                    {videoId && thumbnailUrl && embedUrl ? (
+                        playingVideoId === videoId ? (
+                            <iframe
+                                id={playerElementId}
+                                src={embedUrl}
+                                title={MAP_CREATE_SONG_COPY.YOUTUBE_PREVIEW_IFRAME_TITLE(
+                                    index,
+                                )}
+                                className="aspect-video w-full rounded-lg border-0 bg-black"
+                                loading="lazy"
+                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                                referrerPolicy="strict-origin-when-cross-origin"
+                                allowFullScreen
+                            />
+                        ) : (
+                            <button
+                                type="button"
+                                onClick={() => setPlayingVideoId(videoId)}
+                                disabled={disabled}
+                                className="group relative block aspect-video w-full overflow-hidden rounded-lg bg-black disabled:cursor-not-allowed"
+                                aria-label={MAP_CREATE_SONG_COPY.YOUTUBE_PREVIEW_PLAY_ARIA_LABEL(
+                                    index,
+                                )}
+                            >
+                                <img
+                                    src={thumbnailUrl}
+                                    alt=""
+                                    className="h-full w-full object-contain"
+                                />
+                                <span className="absolute inset-0 flex items-center justify-center bg-black/20 transition group-hover:bg-black/30">
+                                    <span className="flex h-12 w-12 items-center justify-center rounded-full bg-black/70 text-white">
+                                        <Play
+                                            size={25}
+                                            fill="currentColor"
+                                            aria-hidden="true"
+                                        />
+                                    </span>
+                                </span>
+                            </button>
+                        )
+                    ) : (
+                        <div
+                            className="flex aspect-video w-full items-center justify-center rounded-lg bg-[#F1F2F5] text-[var(--monomat-text-muted)]"
+                            aria-label={MAP_CREATE_SONG_COPY.YOUTUBE_PREVIEW}
+                        >
+                            <div className="text-center">
+                                <Play
+                                    size={34}
+                                    strokeWidth={1.6}
+                                    className="mx-auto"
+                                    aria-hidden="true"
+                                />
+                                <span className="mt-2 block text-xs">
+                                    {
+                                        MAP_CREATE_SONG_COPY.YOUTUBE_PREVIEW_PLACEHOLDER
+                                    }
+                                </span>
+                            </div>
+                        </div>
+                    )}
+                </div>
+
+                <div className="min-w-0">
+                    <label className="block">
+                        <SongFieldLabel>
+                            {MAP_CREATE_SONG_COPY.YOUTUBE_URL_LABEL}
+                        </SongFieldLabel>
+                        <MonomatInput
+                            type="url"
+                            value={song.youtubeUrl}
+                            maxLength={
+                                MAP_CREATE_POLICY.YOUTUBE_URL_MAX_LENGTH
+                            }
+                            placeholder={
+                                MAP_CREATE_SONG_COPY.YOUTUBE_URL_PLACEHOLDER
+                            }
+                            disabled={disabled}
+                            onChange={(event) =>
+                                onChange(
+                                    song.id,
+                                    'youtubeUrl',
+                                    event.target.value,
+                                )
+                            }
+                            className={inputClassName}
+                        />
+                    </label>
+
+                    <label className="mt-4 block">
+                        <div className="flex items-center justify-between">
+                            <SongFieldLabel>
+                                {MAP_CREATE_SONG_COPY.HINT_LABEL}
+                            </SongFieldLabel>
+                            <span className="mb-1 text-xs text-[var(--monomat-text-muted)]">
+                                {song.hint.length}/
+                                {MAP_CREATE_POLICY.HINT_MAX_LENGTH}
+                            </span>
+                        </div>
+                        <MonomatInput
+                            value={song.hint}
+                            maxLength={MAP_CREATE_POLICY.HINT_MAX_LENGTH}
+                            placeholder={MAP_CREATE_SONG_COPY.HINT_PLACEHOLDER}
+                            disabled={disabled}
+                            onChange={(event) =>
+                                onChange(song.id, 'hint', event.target.value)
+                            }
+                            className={inputClassName}
+                        />
+                    </label>
+
+                    <div className="mt-4">
+                        <label className="block min-w-0">
+                            <SongFieldLabel>
+                                {MAP_CREATE_SONG_COPY.START_TIME_LABEL}
+                            </SongFieldLabel>
+                            <MonomatInput
+                                type="number"
+                                min={
+                                    MAP_CREATE_POLICY.MIN_START_TIME_SECONDS
+                                }
+                                step={1}
+                                value={song.startTime}
+                                placeholder={
+                                    MAP_CREATE_SONG_COPY.START_TIME_PLACEHOLDER
+                                }
+                                disabled={disabled}
+                                onChange={(event) =>
+                                    onChange(
+                                        song.id,
+                                        'startTime',
+                                        event.target.value,
+                                    )
+                                }
+                                aria-invalid={timingError != null}
+                                aria-describedby={
+                                    timingError
+                                        ? `${song.id}-timing-error`
+                                        : undefined
+                                }
+                                className={`${inputClassName} ${
+                                    timingError
+                                        ? 'border-[var(--monomat-danger)] focus:border-[var(--monomat-danger)]'
+                                        : ''
+                                }`}
+                            />
+                        </label>
+                        {timingError && (
+                            <p
+                                id={`${song.id}-timing-error`}
+                                className="mt-1 text-xs font-medium leading-5 text-[var(--monomat-danger)]"
+                            >
+                                {timingError}
+                            </p>
+                        )}
+                        {song.videoDurationSeconds != null &&
+                            !timingError && (
+                                <p className="mt-1 text-xs leading-5 text-[var(--monomat-text-muted)]">
+                                    영상 길이{' '}
+                                    {song.videoDurationSeconds}초 확인됨
+                                </p>
+                            )}
+                    </div>
+
+                    <div className="mt-4 flex items-center justify-between">
+                        <span className="text-sm font-medium text-[var(--monomat-text-muted)]">
+                            정답 후보
+                        </span>
+                        <button
+                            type="button"
+                            onClick={() => onAddAnswer(song.id)}
+                            disabled={disabled || !canAddAnswer}
+                            className="text-sm font-medium text-[var(--monomat-primary)] transition hover:text-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:opacity-45"
+                        >
+                            {MAP_CREATE_SONG_COPY.ADD_ANSWER}
+                        </button>
+                    </div>
+
+                    <div className="mt-2 space-y-3">
+                        {song.answers.map((answer, answerIndex) => (
+                            <div
+                                key={answerIndex}
+                                className="block min-w-0"
+                            >
+                                <SongFieldLabel>
+                                    {MAP_CREATE_SONG_COPY.ANSWER_LABEL(
+                                        answerIndex,
+                                    )}
+                                </SongFieldLabel>
+                                <div className="flex gap-2">
+                                    <MonomatInput
+                                        aria-label={MAP_CREATE_SONG_COPY.ANSWER_LABEL(
+                                            answerIndex,
+                                        )}
+                                        value={answer}
+                                        maxLength={
+                                            MAP_CREATE_POLICY.ANSWER_MAX_LENGTH
+                                        }
+                                        placeholder={
+                                            MAP_CREATE_SONG_COPY.ANSWER_PLACEHOLDER
+                                        }
+                                        disabled={disabled}
+                                        onChange={(event) =>
+                                            onAnswerChange(
+                                                song.id,
+                                                answerIndex,
+                                                event.target.value,
+                                            )
+                                        }
+                                        onBlur={(event) =>
+                                            onAnswerChange(
+                                                song.id,
+                                                answerIndex,
+                                                normalizeAnswer(
+                                                    event.currentTarget.value,
+                                                ),
+                                            )
+                                        }
+                                        className={inputClassName}
+                                    />
+                                    <button
+                                        type="button"
+                                        onClick={() =>
+                                            onDeleteAnswer(
+                                                song.id,
+                                                answerIndex,
+                                            )
+                                        }
+                                        disabled={
+                                            disabled ||
+                                            song.answers.length <=
+                                                MAP_CREATE_POLICY.MIN_ANSWER_COUNT
+                                        }
+                                        className="flex h-[45px] w-[45px] shrink-0 items-center justify-center rounded-lg border border-[color:var(--monomat-border-input)] bg-[#FBFCFE] text-[var(--monomat-text-secondary)] transition hover:text-[var(--monomat-danger)] disabled:cursor-not-allowed disabled:opacity-35"
+                                        aria-label={MAP_CREATE_SONG_COPY.DELETE_ANSWER_ARIA_LABEL(
+                                            answerIndex,
+                                        )}
+                                    >
+                                        <Trash2
+                                            size={20}
+                                            strokeWidth={1.8}
+                                            aria-hidden="true"
+                                        />
+                                    </button>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+
+                    <p className="mt-2 text-[13px] leading-5 text-[var(--monomat-text-muted)]">
+                        {MAP_CREATE_SONG_COPY.ANSWER_DESCRIPTION}
+                    </p>
+                    {hasDuplicateAnswers && (
+                        <p className="mt-1 text-xs leading-5 text-[var(--monomat-text-muted)]">
+                            {
+                                MAP_CREATE_SONG_COPY.NORMALIZED_ANSWER_DUPLICATE
+                            }{' '}
+                            중복 제거 후 {normalizedAnswers.length}개가
+                            저장됩니다.
+                        </p>
+                    )}
+                </div>
+            </div>
+        </article>
+    );
+}

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -50,7 +50,10 @@ export const API_ENDPOINTS = {
 
     MAP: {
         LIST: createApiEndpoint('/api/maps'),
+        CREATE: createApiEndpoint('/api/maps'),
         MY_LIST: createApiEndpoint('/api/maps/me'),
+        ITEMS: (mapId: number) =>
+            createApiEndpoint(`/api/maps/${mapId}/items`),
         DELETE: (mapId: number) => createApiEndpoint(`/api/maps/${mapId}`),
     },
 

--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -2,6 +2,9 @@ import { LOBBY_CATEGORY_FILTERS } from './lobby';
 
 export const MAP_CATEGORY_FILTERS = LOBBY_CATEGORY_FILTERS;
 export const MAP_ALL_CATEGORY_FILTER = MAP_CATEGORY_FILTERS[0];
+export const MAP_CATEGORY_OPTIONS = MAP_CATEGORY_FILTERS.filter(
+    (category) => category !== MAP_ALL_CATEGORY_FILTER,
+);
 
 export const MAP_SORT_LABELS = {
     NEWEST: '최신순',
@@ -21,12 +24,113 @@ export const MAP_ROUTES = {
     CREATE_MAP: '/maps/new',
 } as const;
 
+export const MAP_CREATE_POLICY = {
+    TITLE_MAX_LENGTH: 50,
+    DESCRIPTION_MAX_LENGTH: 120,
+    YOUTUBE_URL_MAX_LENGTH: 500,
+    HINT_MAX_LENGTH: 50,
+    ANSWER_MAX_LENGTH: 255,
+    MIN_ANSWER_COUNT: 1,
+    MAX_ANSWER_COUNT: 5,
+    MIN_SONG_COUNT: 1,
+    MAX_SONG_COUNT: 200,
+    MIN_START_TIME_SECONDS: 0,
+    API_FALLBACK_PLAY_DURATION_SECONDS: 30,
+    DEFAULT_CATEGORY: 'J-POP',
+    DEFAULT_IS_PUBLIC: true,
+} as const;
+
+export const MAP_CREATE_PAGE_COPY = {
+    BACK_TO_MAPS: '← 맵 목록으로',
+    TITLE: '새 맵 만들기',
+    DESCRIPTION: (songCount: number) =>
+        `YouTube URL을 추가하고 정답을 등록하세요. 곡 ${songCount}개 등록됨.`,
+    STATUS_TITLE: '제목',
+    STATUS_SONG: '곡 1+',
+    STATUS_RECOMMENDED_SONG: '곡 5+ 권장',
+    GUIDE_TITLE: '맵 만들기 4단계',
+    GUIDE_TIP:
+        '팁 : 정답은 띄어쓰기/대소문자 무시, 다양한 표기를 등록할수록 정답 인정 폭이 넓어집니다.',
+    MAP_INFO_TITLE: '맵 정보',
+    MAP_TITLE_LABEL: '맵 이름',
+    MAP_TITLE_PLACEHOLDER: '예 : J-POP 퀴즈 대결',
+    DESCRIPTION_LABEL: '설명 (선택)',
+    DESCRIPTION_PLACEHOLDER:
+        '어떤 분위기/난이도/주제의 맵인지 짧게 적어주세요',
+    CATEGORY_LABEL: '카테고리',
+    VISIBILITY_LABEL: '공개 설정',
+    PUBLIC: '공개',
+    PRIVATE: '비공개',
+    SONG_LIST_TITLE: '문제 목록',
+    SONG_LIST_DESCRIPTION:
+        'YouTube URL과 정답 (여러 개 가능)을 입력하고, 시작 시간을 초 단위로 지정합니다.',
+    ADD_SONG: '+ 곡 추가',
+    CANCEL: '취소',
+    SUBMIT: '맵 만들기',
+    SUBMITTING: '맵 만드는 중...',
+    CREATE_ERROR: '맵 생성에 실패했습니다. 잠시 후 다시 시도해주세요.',
+    PARTIAL_CREATE_ERROR:
+        '맵은 생성되었지만 일부 곡 등록에 실패했습니다. 내 맵 관리에서 생성된 맵을 확인해주세요.',
+} as const;
+
+export const MAP_CREATE_SONG_COPY = {
+    TITLE: '새 곡',
+    YOUTUBE_PREVIEW: 'YouTube 미리보기',
+    YOUTUBE_PREVIEW_PLACEHOLDER: '미리보기 준비 중',
+    YOUTUBE_PREVIEW_PLAY_ARIA_LABEL: (index: number) =>
+        `${index + 1}번 곡 YouTube 미리보기 재생`,
+    YOUTUBE_PREVIEW_IFRAME_TITLE: (index: number) =>
+        `${index + 1}번 곡 YouTube 미리보기`,
+    YOUTUBE_URL_LABEL: 'YouTube URL',
+    YOUTUBE_URL_PLACEHOLDER: 'https://www.youtube.com/watch?v=',
+    HINT_LABEL: '힌트',
+    HINT_PLACEHOLDER: '초성이나 문장으로 힌트를 작성해주세요',
+    START_TIME_LABEL: '시작 시간 (초)',
+    START_TIME_PLACEHOLDER: '0',
+    ANSWER_LABEL: (index: number) => `정답 후보 (${index + 1})`,
+    ANSWER_PLACEHOLDER: '예 : 짝사랑',
+    ANSWER_DESCRIPTION:
+        '여러 표기를 등록하면 그중 하나만 맞춰도 정답 처리됩니다.',
+    NORMALIZED_ANSWER_DUPLICATE:
+        '앞선 후보와 같아 중복으로 저장되지 않습니다.',
+    ADD_ANSWER: '+ 후보 추가',
+    MOVE_SONG_UP_ARIA_LABEL: (index: number) =>
+        `${index + 1}번 곡 위로 이동`,
+    MOVE_SONG_DOWN_ARIA_LABEL: (index: number) =>
+        `${index + 1}번 곡 아래로 이동`,
+    DELETE_SONG_ARIA_LABEL: (index: number) => `${index + 1}번 곡 삭제`,
+    DELETE_ANSWER_ARIA_LABEL: (index: number) =>
+        `${index + 1}번 정답 후보 삭제`,
+} as const;
+
+export const MAP_CREATE_GUIDE_STEPS = [
+    {
+        title: '기본 정보',
+        description:
+            '맵 제목과 카테고리를 정하고, 공개 여부를 선택합니다.',
+    },
+    {
+        title: 'YouTube URL',
+        description:
+            '곡마다 영상 URL을 입력합니다. 등록 시 서버에서 유효성을 확인합니다.',
+    },
+    {
+        title: '정답 등록',
+        description:
+            '별칭, 영문, 한글, 약칭 등 정답 후보를 여러 개 등록할 수 있습니다.',
+    },
+    {
+        title: '재생 시간',
+        description:
+            '하이라이트 부분의 시작 시간을 초 단위로 지정합니다.',
+    },
+] as const;
+
 export const MY_MAPS_PAGE_COPY = {
     BACK_TO_LOBBIES: '← 로비 목록으로',
     TITLE: '맵 관리',
     DESCRIPTION: '직접 만든 맵을 관리하고, 새 맵을 생성하세요',
     CREATE_MAP: '+ 새 맵 만들기',
-    CREATE_MAP_PENDING: '맵 생성 기능은 추후 제공 예정입니다.',
     SEARCH_PLACEHOLDER: '맵 제목이나 카테고리로 검색하세요',
     MAP_TITLE: '맵 제목',
     CATEGORY: '카테고리',
@@ -61,7 +165,7 @@ export const MY_MAPS_ERROR_COPY = {
 
 export const MY_MAPS_EMPTY_STATE_COPY = {
     TITLE: '아직 만든 맵이 없습니다.',
-    DESCRIPTION: '새 맵 만들기는 후속 기능으로 제공될 예정입니다.',
+    DESCRIPTION: '새 맵 만들기 버튼으로 첫 맵을 만들어보세요.',
     SEARCH_TITLE: '검색 결과가 없습니다.',
     SEARCH_DESCRIPTION: '다른 맵 제목이나 카테고리로 검색해보세요.',
 } as const;

--- a/src/pages/MapCreate.tsx
+++ b/src/pages/MapCreate.tsx
@@ -1,0 +1,682 @@
+import {
+    type FormEvent,
+    useState,
+} from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+import { createMap, createMapItem } from '../api/mapApi';
+import { MonomatInput } from '../components/common/MonomatInput';
+import { NavigationBar } from '../components/common/NavigationBar';
+import { LobbyFooter } from '../components/lobby/LobbyFooter';
+import { MapCreateGuide } from '../components/map/MapCreateGuide';
+import { MapCreateSongCard } from '../components/map/MapCreateSongCard';
+import {
+    MAP_CATEGORY_OPTIONS,
+    MAP_CREATE_PAGE_COPY,
+    MAP_CREATE_POLICY,
+    MAP_ROUTES,
+} from '../constants/map';
+import { generateUUID } from '../utils/uuid';
+import { normalizeAnswerList } from '../utils/answerNormalizer';
+import {
+    getMapCreateTiming,
+    getMapCreateTimingError,
+} from '../utils/mapCreateTiming';
+
+import type {
+    CreateMapFormState,
+    CreateMapItemRequest,
+    CreateMapSongFormState,
+} from '../types/map';
+
+const inputClassName =
+    'h-11 w-full rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-[14px] text-sm text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-text-muted)] focus:border-[var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60';
+
+function createEmptySong(): CreateMapSongFormState {
+    return {
+        id: generateUUID(),
+        youtubeUrl: '',
+        hint: '',
+        startTime: '',
+        videoDurationSeconds: null,
+        answers: [''],
+    };
+}
+
+function createInitialFormState(): CreateMapFormState {
+    return {
+        title: '',
+        description: '',
+        category: MAP_CREATE_POLICY.DEFAULT_CATEGORY,
+        isPublic: MAP_CREATE_POLICY.DEFAULT_IS_PUBLIC,
+        songs: [createEmptySong()],
+    };
+}
+
+function isValidSong(song: CreateMapSongFormState) {
+    const startTime = Number(song.startTime);
+    const normalizedAnswers = normalizeAnswerList(song.answers);
+    const timingError = getMapCreateTimingError(
+        song.startTime,
+        song.videoDurationSeconds,
+    );
+
+    return (
+        song.youtubeUrl.trim().length > 0 &&
+        song.youtubeUrl.trim().length <=
+            MAP_CREATE_POLICY.YOUTUBE_URL_MAX_LENGTH &&
+        song.hint.trim().length > 0 &&
+        song.hint.trim().length <= MAP_CREATE_POLICY.HINT_MAX_LENGTH &&
+        song.startTime.trim().length > 0 &&
+        Number.isInteger(startTime) &&
+        startTime >= MAP_CREATE_POLICY.MIN_START_TIME_SECONDS &&
+        timingError == null &&
+        normalizedAnswers.length >= MAP_CREATE_POLICY.MIN_ANSWER_COUNT &&
+        normalizedAnswers.length <= MAP_CREATE_POLICY.MAX_ANSWER_COUNT &&
+        normalizedAnswers.every(
+            (answer) =>
+                answer.length <= MAP_CREATE_POLICY.ANSWER_MAX_LENGTH,
+        )
+    );
+}
+
+function createMapItemRequest(
+    song: CreateMapSongFormState,
+    index: number,
+): CreateMapItemRequest {
+    const timing = getMapCreateTiming(Number(song.startTime));
+
+    return {
+        orderNum: index + 1,
+        youtubeUrl: song.youtubeUrl.trim(),
+        startTime: timing.startTime,
+        // 현재 BE 계약상 endTime은 필수다. 로비 전역 재생 시간 계약이
+        // 도입되기 전까지 고정 길이를 더해 호환 가능한 값으로 전송한다.
+        endTime: timing.endTime,
+        answers: song.answers
+            .map((answer) => answer.trim())
+            .filter(Boolean),
+        hint: song.hint.trim(),
+    };
+}
+
+function getErrorMessage(error: unknown) {
+    if (error instanceof Error && error.message) {
+        return error.message;
+    }
+
+    return MAP_CREATE_PAGE_COPY.CREATE_ERROR;
+}
+
+function StatusBadge({
+    label,
+    isComplete,
+}: {
+    label: string;
+    isComplete: boolean;
+}) {
+    return (
+        <span
+            className={`inline-flex h-[30px] items-center gap-1.5 rounded-full border px-3 text-xs font-semibold ${
+                isComplete
+                    ? 'border-[#9BDBBD] bg-[#D9F0E5] text-[#33A659]'
+                    : 'border-[#E4E5E9] bg-[#F1F2F5] text-[var(--monomat-text-secondary)]'
+            }`}
+        >
+            <span
+                className={`h-2 w-2 rounded-full ${
+                    isComplete ? 'bg-[#33A659]' : 'bg-[#B7B9C1]'
+                }`}
+                aria-hidden="true"
+            />
+            {label}
+        </span>
+    );
+}
+
+export function MapCreate() {
+    const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    const [formState, setFormState] = useState(createInitialFormState);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [hasPartialFailure, setHasPartialFailure] = useState(false);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+    const hasValidTitle =
+        formState.title.trim().length > 0 &&
+        formState.title.trim().length <=
+            MAP_CREATE_POLICY.TITLE_MAX_LENGTH;
+    const registeredSongCount = formState.songs.filter(isValidSong).length;
+    const hasValidSongs =
+        formState.songs.length >= MAP_CREATE_POLICY.MIN_SONG_COUNT &&
+        registeredSongCount === formState.songs.length;
+    const isFormValid =
+        hasValidTitle &&
+        formState.description.length <=
+            MAP_CREATE_POLICY.DESCRIPTION_MAX_LENGTH &&
+        MAP_CATEGORY_OPTIONS.includes(formState.category) &&
+        hasValidSongs;
+    const isFormLocked = isSubmitting || hasPartialFailure;
+
+    const updateFormState = <TKey extends keyof Omit<
+        CreateMapFormState,
+        'songs'
+    >>(
+        key: TKey,
+        value: CreateMapFormState[TKey],
+    ) => {
+        setFormState((current) => ({
+            ...current,
+            [key]: value,
+        }));
+        setErrorMessage(null);
+    };
+
+    const updateSong = (
+        songId: string,
+        field: Exclude<
+            keyof CreateMapSongFormState,
+            'id' | 'answers' | 'videoDurationSeconds'
+        >,
+        value: string,
+    ) => {
+        setFormState((current) => ({
+            ...current,
+            songs: current.songs.map((song) =>
+                song.id === songId
+                    ? {
+                          ...song,
+                          [field]: value,
+                          ...(field === 'youtubeUrl'
+                              ? { videoDurationSeconds: null }
+                              : {}),
+                      }
+                    : song,
+            ),
+        }));
+        setErrorMessage(null);
+    };
+
+    const updateSongDuration = (
+        songId: string,
+        videoDurationSeconds: number | null,
+    ) => {
+        setFormState((current) => ({
+            ...current,
+            songs: current.songs.map((song) =>
+                song.id === songId
+                    ? { ...song, videoDurationSeconds }
+                    : song,
+            ),
+        }));
+    };
+
+    const updateAnswer = (
+        songId: string,
+        answerIndex: number,
+        value: string,
+    ) => {
+        setFormState((current) => ({
+            ...current,
+            songs: current.songs.map((song) => {
+                if (song.id !== songId) {
+                    return song;
+                }
+
+                return {
+                    ...song,
+                    answers: song.answers.map((answer, index) =>
+                        index === answerIndex ? value : answer,
+                    ),
+                };
+            }),
+        }));
+        setErrorMessage(null);
+    };
+
+    const addSong = () => {
+        setFormState((current) => {
+            if (
+                current.songs.length >= MAP_CREATE_POLICY.MAX_SONG_COUNT
+            ) {
+                return current;
+            }
+
+            return {
+                ...current,
+                songs: [...current.songs, createEmptySong()],
+            };
+        });
+        setErrorMessage(null);
+    };
+
+    const deleteSong = (songId: string) => {
+        setFormState((current) => {
+            if (
+                current.songs.length <= MAP_CREATE_POLICY.MIN_SONG_COUNT
+            ) {
+                return current;
+            }
+
+            return {
+                ...current,
+                songs: current.songs.filter((song) => song.id !== songId),
+            };
+        });
+        setErrorMessage(null);
+    };
+
+    const moveSong = (
+        songId: string,
+        direction: -1 | 1,
+    ) => {
+        setFormState((current) => {
+            const currentIndex = current.songs.findIndex(
+                (song) => song.id === songId,
+            );
+            const targetIndex = currentIndex + direction;
+
+            if (
+                currentIndex < 0 ||
+                targetIndex < 0 ||
+                targetIndex >= current.songs.length
+            ) {
+                return current;
+            }
+
+            const songs = [...current.songs];
+            [songs[currentIndex], songs[targetIndex]] = [
+                songs[targetIndex],
+                songs[currentIndex],
+            ];
+
+            return {
+                ...current,
+                songs,
+            };
+        });
+        setErrorMessage(null);
+    };
+
+    const addAnswer = (songId: string) => {
+        setFormState((current) => ({
+            ...current,
+            songs: current.songs.map((song) => {
+                if (
+                    song.id !== songId ||
+                    song.answers.length >=
+                        MAP_CREATE_POLICY.MAX_ANSWER_COUNT
+                ) {
+                    return song;
+                }
+
+                return {
+                    ...song,
+                    answers: [...song.answers, ''],
+                };
+            }),
+        }));
+        setErrorMessage(null);
+    };
+
+    const deleteAnswer = (songId: string, answerIndex: number) => {
+        setFormState((current) => ({
+            ...current,
+            songs: current.songs.map((song) => {
+                if (
+                    song.id !== songId ||
+                    song.answers.length <=
+                        MAP_CREATE_POLICY.MIN_ANSWER_COUNT
+                ) {
+                    return song;
+                }
+
+                return {
+                    ...song,
+                    answers: song.answers.filter(
+                        (_, index) => index !== answerIndex,
+                    ),
+                };
+            }),
+        }));
+        setErrorMessage(null);
+    };
+
+    const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        if (!isFormValid || isFormLocked) {
+            return;
+        }
+
+        setIsSubmitting(true);
+        setErrorMessage(null);
+
+        try {
+            const createdMap = await createMap({
+                title: formState.title.trim(),
+                description: formState.description.trim() || null,
+                category: formState.category,
+                isPublic: formState.isPublic,
+            });
+
+            try {
+                for (const [index, song] of formState.songs.entries()) {
+                    await createMapItem(
+                        createdMap.id,
+                        createMapItemRequest(song, index),
+                    );
+                }
+            } catch (itemError) {
+                console.error('[MapCreate] 일부 곡 생성 실패:', itemError);
+                setHasPartialFailure(true);
+                setErrorMessage(MAP_CREATE_PAGE_COPY.PARTIAL_CREATE_ERROR);
+                await queryClient.invalidateQueries({
+                    queryKey: ['myMaps'],
+                });
+                return;
+            }
+
+            await queryClient.invalidateQueries({
+                queryKey: ['myMaps'],
+            });
+            navigate(MAP_ROUTES.MY_MAPS);
+        } catch (error) {
+            setErrorMessage(getErrorMessage(error));
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    return (
+        <div className="flex min-h-screen flex-col bg-[var(--monomat-page-bg)] text-left">
+            <NavigationBar />
+
+            <main className="mx-auto w-full max-w-[1440px] flex-1 px-4 pb-8 pt-6 sm:px-6 lg:px-8 xl:px-10 xl:pt-[30px]">
+                <form
+                    noValidate
+                    onSubmit={(event) => void handleSubmit(event)}
+                    className="mx-auto w-full max-w-[1030px]"
+                >
+                    <button
+                        type="button"
+                        onClick={() => navigate(MAP_ROUTES.MY_MAPS)}
+                        disabled={isSubmitting}
+                        className="text-sm font-semibold leading-5 text-[var(--monomat-text-muted)] transition hover:text-[var(--monomat-text-strong)] disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        {MAP_CREATE_PAGE_COPY.BACK_TO_MAPS}
+                    </button>
+
+                    <div className="mt-3 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+                        <div>
+                            <h1 className="!m-0 !text-[36px] !font-extrabold !leading-[43px] !text-[var(--monomat-text-strong)]">
+                                {MAP_CREATE_PAGE_COPY.TITLE}
+                            </h1>
+                            <p className="mt-2 text-sm font-medium leading-5 text-[var(--monomat-text-muted)]">
+                                {MAP_CREATE_PAGE_COPY.DESCRIPTION(
+                                    registeredSongCount,
+                                )}
+                            </p>
+                        </div>
+                        <div className="flex flex-wrap gap-2 lg:justify-end">
+                            <StatusBadge
+                                label={MAP_CREATE_PAGE_COPY.STATUS_TITLE}
+                                isComplete={hasValidTitle}
+                            />
+                            <StatusBadge
+                                label={MAP_CREATE_PAGE_COPY.STATUS_SONG}
+                                isComplete={registeredSongCount >= 1}
+                            />
+                            <StatusBadge
+                                label={
+                                    MAP_CREATE_PAGE_COPY.STATUS_RECOMMENDED_SONG
+                                }
+                                isComplete={registeredSongCount >= 5}
+                            />
+                        </div>
+                    </div>
+
+                    <div className="mt-[30px]">
+                        <MapCreateGuide />
+                    </div>
+
+                    <section className="mt-[30px] rounded-2xl bg-white p-5 shadow-[0_4px_16px_rgba(0,0,0,0.16)] sm:p-6">
+                        <h2 className="!m-0 !text-lg !font-bold !leading-6 !text-black">
+                            {MAP_CREATE_PAGE_COPY.MAP_INFO_TITLE}
+                        </h2>
+
+                        <label className="mt-4 block">
+                            <div className="mb-1 flex items-center justify-between text-sm text-[var(--monomat-text-muted)]">
+                                <span>
+                                    {MAP_CREATE_PAGE_COPY.MAP_TITLE_LABEL}
+                                </span>
+                                <span>
+                                    {formState.title.length}/
+                                    {MAP_CREATE_POLICY.TITLE_MAX_LENGTH}
+                                </span>
+                            </div>
+                            <MonomatInput
+                                value={formState.title}
+                                maxLength={
+                                    MAP_CREATE_POLICY.TITLE_MAX_LENGTH
+                                }
+                                placeholder={
+                                    MAP_CREATE_PAGE_COPY.MAP_TITLE_PLACEHOLDER
+                                }
+                                disabled={isFormLocked}
+                                onChange={(event) =>
+                                    updateFormState(
+                                        'title',
+                                        event.target.value,
+                                    )
+                                }
+                                className={inputClassName}
+                            />
+                        </label>
+
+                        <label className="mt-4 block">
+                            <div className="mb-1 flex items-center justify-between text-sm text-[var(--monomat-text-muted)]">
+                                <span>
+                                    {MAP_CREATE_PAGE_COPY.DESCRIPTION_LABEL}
+                                </span>
+                                <span>
+                                    {formState.description.length}/
+                                    {
+                                        MAP_CREATE_POLICY.DESCRIPTION_MAX_LENGTH
+                                    }
+                                </span>
+                            </div>
+                            <textarea
+                                value={formState.description}
+                                maxLength={
+                                    MAP_CREATE_POLICY.DESCRIPTION_MAX_LENGTH
+                                }
+                                placeholder={
+                                    MAP_CREATE_PAGE_COPY.DESCRIPTION_PLACEHOLDER
+                                }
+                                disabled={isFormLocked}
+                                onChange={(event) =>
+                                    updateFormState(
+                                        'description',
+                                        event.target.value,
+                                    )
+                                }
+                                className="h-[95px] w-full resize-none rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-[14px] py-3 text-sm leading-5 text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-text-muted)] focus:border-[var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                            />
+                        </label>
+
+                        <div className="mt-4 grid gap-4 lg:grid-cols-[370px_minmax(0,1fr)] lg:gap-6">
+                            <label className="block">
+                                <span className="mb-1 block text-sm text-[var(--monomat-text-muted)]">
+                                    {MAP_CREATE_PAGE_COPY.CATEGORY_LABEL}
+                                </span>
+                                <select
+                                    value={formState.category}
+                                    disabled={isFormLocked}
+                                    onChange={(event) =>
+                                        updateFormState(
+                                            'category',
+                                            event.target
+                                                .value as CreateMapFormState['category'],
+                                        )
+                                    }
+                                    className="h-[45px] w-full rounded-lg border border-[color:var(--monomat-border-input)] bg-[#FBFCFE] px-4 text-center text-base font-semibold text-black outline-none focus:border-[var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                                >
+                                    {MAP_CATEGORY_OPTIONS.map((category) => (
+                                        <option
+                                            key={category}
+                                            value={category}
+                                        >
+                                            {category}
+                                        </option>
+                                    ))}
+                                </select>
+                            </label>
+
+                            <fieldset>
+                                <legend className="mb-1 text-sm text-[var(--monomat-text-muted)]">
+                                    {MAP_CREATE_PAGE_COPY.VISIBILITY_LABEL}
+                                </legend>
+                                <div className="grid grid-cols-2 gap-3">
+                                    {[true, false].map((isPublic) => {
+                                        const isSelected =
+                                            formState.isPublic === isPublic;
+
+                                        return (
+                                            <button
+                                                key={String(isPublic)}
+                                                type="button"
+                                                disabled={isFormLocked}
+                                                aria-pressed={isSelected}
+                                                onClick={() =>
+                                                    updateFormState(
+                                                        'isPublic',
+                                                        isPublic,
+                                                    )
+                                                }
+                                                className={`h-[45px] rounded-lg border text-base font-semibold text-black transition disabled:cursor-not-allowed disabled:opacity-60 ${
+                                                    isSelected
+                                                        ? 'border-[var(--monomat-primary)] bg-[var(--monomat-primary-light)]'
+                                                        : 'border-[color:var(--monomat-border-input)] bg-white hover:border-[var(--monomat-primary)]'
+                                                }`}
+                                            >
+                                                {isPublic
+                                                    ? MAP_CREATE_PAGE_COPY.PUBLIC
+                                                    : MAP_CREATE_PAGE_COPY.PRIVATE}
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                            </fieldset>
+                        </div>
+                    </section>
+
+                    <section className="mt-[30px] rounded-2xl bg-white p-5 shadow-[0_4px_16px_rgba(0,0,0,0.16)] sm:p-6">
+                        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                            <div>
+                                <h2 className="!m-0 !text-lg !font-bold !leading-6 !text-black">
+                                    {MAP_CREATE_PAGE_COPY.SONG_LIST_TITLE}
+                                </h2>
+                                <p className="mt-1 text-sm font-medium leading-5 text-[var(--monomat-text-muted)]">
+                                    {
+                                        MAP_CREATE_PAGE_COPY.SONG_LIST_DESCRIPTION
+                                    }
+                                </p>
+                            </div>
+                            <button
+                                type="button"
+                                onClick={addSong}
+                                disabled={
+                                    isFormLocked ||
+                                    formState.songs.length >=
+                                        MAP_CREATE_POLICY.MAX_SONG_COUNT
+                                }
+                                className="h-[45px] shrink-0 rounded-lg border border-[color:var(--monomat-border-input)] bg-white px-5 text-[15px] font-semibold text-black transition hover:border-[var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-45"
+                            >
+                                {MAP_CREATE_PAGE_COPY.ADD_SONG}
+                            </button>
+                        </div>
+
+                        <div className="mt-5 space-y-4">
+                            {formState.songs.map((song, index) => (
+                                <MapCreateSongCard
+                                    key={song.id}
+                                    index={index}
+                                    song={song}
+                                    canDeleteSong={
+                                        formState.songs.length >
+                                        MAP_CREATE_POLICY.MIN_SONG_COUNT
+                                    }
+                                    canMoveUp={index > 0}
+                                    canMoveDown={
+                                        index < formState.songs.length - 1
+                                    }
+                                    disabled={isFormLocked}
+                                    onChange={updateSong}
+                                    onAnswerChange={updateAnswer}
+                                    onDurationChange={updateSongDuration}
+                                    onAddAnswer={addAnswer}
+                                    onDeleteAnswer={deleteAnswer}
+                                    onDeleteSong={deleteSong}
+                                    onMoveUp={(songId) =>
+                                        moveSong(songId, -1)
+                                    }
+                                    onMoveDown={(songId) =>
+                                        moveSong(songId, 1)
+                                    }
+                                />
+                            ))}
+                        </div>
+                    </section>
+
+                    {errorMessage && (
+                        <div
+                            role="alert"
+                            className="mt-5 rounded-lg border border-[var(--monomat-danger)] bg-[var(--monomat-danger-light)] px-4 py-3 text-sm font-medium leading-5 text-[var(--monomat-danger)]"
+                        >
+                            <p>{errorMessage}</p>
+                            {hasPartialFailure && (
+                                <button
+                                    type="button"
+                                    onClick={() =>
+                                        navigate(MAP_ROUTES.MY_MAPS)
+                                    }
+                                    className="mt-2 font-bold underline underline-offset-2"
+                                >
+                                    내 맵 관리로 이동
+                                </button>
+                            )}
+                        </div>
+                    )}
+
+                    <div className="mt-[30px] flex justify-end gap-3">
+                        <button
+                            type="button"
+                            onClick={() => navigate(MAP_ROUTES.MY_MAPS)}
+                            disabled={isSubmitting}
+                            className="h-[45px] min-w-[85px] rounded-lg border border-[color:var(--monomat-border-input)] bg-white px-5 text-[15px] font-bold text-black transition hover:bg-[var(--monomat-page-bg)] disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                            {MAP_CREATE_PAGE_COPY.CANCEL}
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={
+                                !isFormValid ||
+                                isSubmitting ||
+                                hasPartialFailure
+                            }
+                            className="h-[45px] min-w-[110px] rounded-lg bg-[var(--monomat-primary)] px-5 text-[15px] font-bold text-white transition hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:bg-[var(--monomat-primary-disabled)]"
+                        >
+                            {isSubmitting
+                                ? MAP_CREATE_PAGE_COPY.SUBMITTING
+                                : MAP_CREATE_PAGE_COPY.SUBMIT}
+                        </button>
+                    </div>
+                </form>
+            </main>
+
+            <LobbyFooter />
+        </div>
+    );
+}

--- a/src/pages/MyMaps.tsx
+++ b/src/pages/MyMaps.tsx
@@ -451,7 +451,7 @@ export function MyMaps() {
     };
 
     const handleCreateMapClick = () => {
-        window.alert(MY_MAPS_PAGE_COPY.CREATE_MAP_PENDING);
+        navigate(MAP_ROUTES.CREATE_MAP);
     };
 
     const handleDeleteClick = (map: MapSummary) => {

--- a/src/schemas/mapSchema.ts
+++ b/src/schemas/mapSchema.ts
@@ -33,3 +33,37 @@ export const mapPageResponseSchema = z.object({
     totalPages: z.number().int().min(0),
     hasNext: z.boolean(),
 });
+
+export const mapDetailResponseSchema = z.object({
+    id: z.number().int().positive(),
+    ownerId: z.number().int().positive(),
+    ownerNickname: z.string().nullable(),
+    title: z.string().min(1),
+    description: z.string().nullable(),
+    category: mapCategorySchema,
+    numOfSong: z.number().int().min(0),
+    totalPlayTime: z.number().int().min(0),
+    isPublic: z.boolean(),
+    pendingPublic: z.boolean(),
+    playCount: z.number().int().min(0),
+    createdAt: z.string().min(1),
+    updatedAt: z.string().min(1),
+});
+
+export const mapItemResponseSchema = z.object({
+    id: z.number().int().positive(),
+    mapId: z.number().int().positive(),
+    orderNum: z.number().int().positive(),
+    youtubeUrl: z.string().min(1),
+    videoId: z.string().min(1),
+    startTime: z.number().int().min(0),
+    endTime: z.number().int().positive(),
+    title: z.string().nullable(),
+    artist: z.string().nullable(),
+    thumbnailUrl: z.string().nullable(),
+    answers: z.array(z.string().min(1)).min(1).max(5),
+    hint: z.string().min(1),
+    hintTime: z.number().int().min(1).max(100),
+    createdAt: z.string().min(1),
+    updatedAt: z.string().min(1),
+});

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -38,3 +38,71 @@ export interface MapListQueryParams {
     category?: MapCategory;
     sort?: MapSortOption;
 }
+
+export interface CreateMapRequest {
+    title: string;
+    description: string | null;
+    category: MapCategory;
+    isPublic: boolean;
+}
+
+export interface CreateMapItemRequest {
+    orderNum: number;
+    youtubeUrl: string;
+    startTime: number;
+    endTime: number;
+    answers: string[];
+    hint: string;
+    hintTime?: number | null;
+}
+
+export interface MapDetailResponse {
+    id: number;
+    ownerId: number;
+    ownerNickname: string | null;
+    title: string;
+    description: string | null;
+    category: MapCategory;
+    numOfSong: number;
+    totalPlayTime: number;
+    isPublic: boolean;
+    pendingPublic: boolean;
+    playCount: number;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface MapItemResponse {
+    id: number;
+    mapId: number;
+    orderNum: number;
+    youtubeUrl: string;
+    videoId: string;
+    startTime: number;
+    endTime: number;
+    title: string | null;
+    artist: string | null;
+    thumbnailUrl: string | null;
+    answers: string[];
+    hint: string;
+    hintTime: number;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface CreateMapSongFormState {
+    id: string;
+    youtubeUrl: string;
+    hint: string;
+    startTime: string;
+    videoDurationSeconds: number | null;
+    answers: string[];
+}
+
+export interface CreateMapFormState {
+    title: string;
+    description: string;
+    category: MapCategory;
+    isPublic: boolean;
+    songs: CreateMapSongFormState[];
+}

--- a/src/utils/answerNormalizer.ts
+++ b/src/utils/answerNormalizer.ts
@@ -1,0 +1,46 @@
+const ANSWER_METADATA_PATTERN =
+    /\[[^\]]*\]|\([^)]*\)|(official\s+video|official\s+audio|official\s+mv|official\s+music\s+video|official|mv|audio)/giu;
+const ANSWER_REMOVED_CHARACTER_PATTERN = /[\p{White_Space}\u00A0\u3000,，]/gu;
+
+export function cleanAnswerMetadata(raw: string | null | undefined) {
+    if (raw == null) {
+        return '';
+    }
+
+    return raw.replace(ANSWER_METADATA_PATTERN, '').trim();
+}
+
+export function normalizeAnswer(raw: string | null | undefined) {
+    if (raw == null) {
+        return '';
+    }
+
+    const compactAnswer = cleanAnswerMetadata(raw)
+        .normalize('NFC')
+        .replace(ANSWER_REMOVED_CHARACTER_PATTERN, '');
+
+    // BE의 Character.toLowerCase(codePoint)처럼 문자별 단순 소문자화를 적용한다.
+    return Array.from(compactAnswer, (character) =>
+        character === '\u0130' ? 'i' : character.toLowerCase(),
+    ).join('');
+}
+
+export function normalizeAnswerList(
+    raw: ReadonlyArray<string | null | undefined> | null | undefined,
+) {
+    if (!raw) {
+        return [];
+    }
+
+    const normalizedAnswers = new Set<string>();
+
+    raw.forEach((answer) => {
+        const normalizedAnswer = normalizeAnswer(answer);
+
+        if (normalizedAnswer) {
+            normalizedAnswers.add(normalizedAnswer);
+        }
+    });
+
+    return [...normalizedAnswers];
+}

--- a/src/utils/mapCreateTiming.ts
+++ b/src/utils/mapCreateTiming.ts
@@ -1,0 +1,66 @@
+import { MAP_CREATE_POLICY } from '../constants/map';
+
+export interface MapCreateTiming {
+    startTime: number;
+    endTime: number;
+}
+
+export function getMapCreateTiming(startTime: number): MapCreateTiming {
+    return {
+        startTime,
+        endTime:
+            startTime +
+            MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS,
+    };
+}
+
+export function getMapCreateTimingError(
+    rawStartTime: string,
+    videoDurationSeconds: number | null,
+) {
+    // 사용자 입력 단계의 UX 검증이며 최종 무결성은 BE 검증을 따른다.
+    if (!rawStartTime.trim()) {
+        return null;
+    }
+
+    const startTime = Number(rawStartTime);
+
+    if (
+        !Number.isInteger(startTime) ||
+        startTime < MAP_CREATE_POLICY.MIN_START_TIME_SECONDS
+    ) {
+        return '시작 시간은 0 이상의 정수로 입력해주세요.';
+    }
+
+    const timing = getMapCreateTiming(startTime);
+
+    if (timing.endTime <= timing.startTime) {
+        return '종료 시간은 시작 시간보다 커야 합니다.';
+    }
+
+    if (
+        videoDurationSeconds == null ||
+        !Number.isFinite(videoDurationSeconds) ||
+        videoDurationSeconds <= 0
+    ) {
+        return null;
+    }
+
+    if (timing.startTime >= videoDurationSeconds) {
+        return `시작 시간은 영상 길이 ${Math.floor(videoDurationSeconds)}초보다 작아야 합니다.`;
+    }
+
+    if (timing.endTime > videoDurationSeconds) {
+        const latestStartTime = Math.max(
+            MAP_CREATE_POLICY.MIN_START_TIME_SECONDS,
+            Math.floor(
+                videoDurationSeconds -
+                    MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS,
+            ),
+        );
+
+        return `현재 ${MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS}초 재생 구간이 영상 길이를 넘습니다. 시작 시간을 ${latestStartTime}초 이하로 입력해주세요.`;
+    }
+
+    return null;
+}

--- a/src/utils/youtube.ts
+++ b/src/utils/youtube.ts
@@ -1,0 +1,156 @@
+const YOUTUBE_VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+const YOUTUBE_HOSTS = new Set([
+    'youtube.com',
+    'www.youtube.com',
+    'm.youtube.com',
+]);
+const YOUTUBE_IFRAME_API_SCRIPT_ID = 'youtube-iframe-api';
+
+export interface YouTubeIframePlayer {
+    getDuration: () => number;
+}
+
+interface YouTubeIframePlayerEvent {
+    target: YouTubeIframePlayer;
+}
+
+interface YouTubeIframePlayerOptions {
+    events?: {
+        onReady?: (event: YouTubeIframePlayerEvent) => void;
+        onError?: () => void;
+    };
+}
+
+interface YouTubeIframeApi {
+    Player: new (
+        elementId: string,
+        options: YouTubeIframePlayerOptions,
+    ) => YouTubeIframePlayer;
+}
+
+declare global {
+    interface Window {
+        YT?: YouTubeIframeApi;
+        onYouTubeIframeAPIReady?: () => void;
+    }
+}
+
+let youtubeIframeApiPromise: Promise<YouTubeIframeApi> | null = null;
+
+function getVideoIdFromYoutubePath(pathname: string) {
+    const segments = pathname.split('/').filter(Boolean);
+
+    if (
+        segments.length >= 2 &&
+        (segments[0] === 'shorts' || segments[0] === 'embed')
+    ) {
+        return segments[1];
+    }
+
+    return null;
+}
+
+export function extractYouTubeVideoId(rawUrl: string): string | null {
+    const trimmedUrl = rawUrl.trim();
+
+    if (!trimmedUrl) {
+        return null;
+    }
+
+    try {
+        const url = new URL(trimmedUrl);
+        const hostname = url.hostname.toLowerCase();
+        let videoId: string | null = null;
+
+        if (hostname === 'youtu.be') {
+            videoId = url.pathname.split('/').filter(Boolean)[0] ?? null;
+        } else if (YOUTUBE_HOSTS.has(hostname)) {
+            videoId = url.pathname === '/watch'
+                ? url.searchParams.get('v')
+                : getVideoIdFromYoutubePath(url.pathname);
+        }
+
+        return videoId && YOUTUBE_VIDEO_ID_PATTERN.test(videoId)
+            ? videoId
+            : null;
+    } catch {
+        return null;
+    }
+}
+
+export function createYouTubeThumbnailUrl(videoId: string) {
+    return `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+}
+
+export function createYouTubeEmbedUrl(
+    videoId: string,
+    startTimeSeconds = 0,
+    origin?: string,
+) {
+    const normalizedStartTime =
+        Number.isInteger(startTimeSeconds) && startTimeSeconds >= 0
+            ? startTimeSeconds
+            : 0;
+    const searchParams = new URLSearchParams({
+        autoplay: '1',
+        start: String(normalizedStartTime),
+    });
+
+    if (origin) {
+        searchParams.set('enablejsapi', '1');
+        searchParams.set('origin', origin);
+    }
+
+    return `https://www.youtube.com/embed/${videoId}?${searchParams}`;
+}
+
+export function loadYouTubeIframeApi() {
+    if (window.YT?.Player) {
+        return Promise.resolve(window.YT);
+    }
+
+    if (youtubeIframeApiPromise) {
+        return youtubeIframeApiPromise;
+    }
+
+    youtubeIframeApiPromise = new Promise<YouTubeIframeApi>(
+        (resolve, reject) => {
+            const previousReadyHandler =
+                window.onYouTubeIframeAPIReady;
+
+            window.onYouTubeIframeAPIReady = () => {
+                previousReadyHandler?.();
+
+                if (window.YT?.Player) {
+                    resolve(window.YT);
+                    return;
+                }
+
+                reject(new Error('YouTube IFrame API를 불러오지 못했습니다.'));
+            };
+
+            const existingScript = document.getElementById(
+                YOUTUBE_IFRAME_API_SCRIPT_ID,
+            );
+
+            if (existingScript) {
+                return;
+            }
+
+            const script = document.createElement('script');
+            script.id = YOUTUBE_IFRAME_API_SCRIPT_ID;
+            script.src = 'https://www.youtube.com/iframe_api';
+            script.async = true;
+            script.onerror = () => {
+                script.remove();
+                youtubeIframeApiPromise = null;
+                reject(
+                    new Error('YouTube IFrame API를 불러오지 못했습니다.'),
+                );
+            };
+            document.head.appendChild(script);
+        },
+    );
+
+    return youtubeIframeApiPromise;
+}


### PR DESCRIPTION
## 📣 Related Issue

- #87

## 📝 Summary

- 맵 제목, 설명, 카테고리, 공개 여부를 입력하는 맵 생성 페이지를 구현했습니다.
- YouTube URL, 정답 후보, 힌트, 시작 시간을 입력하는 곡 등록 UI를 구현했습니다.
- YouTube URL에서 videoId를 추출해 16:9 썸네일 및 iframe 미리보기를 제공합니다.
- 입력한 시작 시간부터 미리보기를 재생하고, 영상 길이를 확인할 수 있는 경우 재생 구간을 검증합니다.
- BE `AnswerNormalizer` 정책에 맞춘 정답 정규화 및 중복 안내를 구현했습니다.
- 첫 번째 정답 후보를 곡 카드 제목에 표시합니다.
- 곡 순서를 로컬에서 변경하고 현재 순서대로 `orderNum`을 전송합니다.
- 맵 생성 후 `createdMap.id`로 곡을 순차 등록하고 `/maps/me`로 이동합니다.
- 일부 곡 등록 실패 시 부분 생성 가능성을 안내합니다.

## 🙏PR point

- 현재 BE 요청 계약상 `endTime`이 필수이므로 `startTime + 30초`로 전송합니다.
- YouTube 미리보기와 영상 길이 검증은 UI 편의 기능이며 최종 유효성은 BE 응답을 따릅니다.
- YouTube Data API, API Key, oEmbed API는 사용하지 않았습니다.
- 곡 생성 API는 일괄 생성 및 롤백을 지원하지 않아 일부 곡만 생성될 수 있습니다.
- `npm run lint`, `npm run build`를 통과했습니다.
- lint의 MSW 미사용 directive 경고와 Vite 번들 크기 경고는 기존 경고입니다.

## 📬 Reference

- [YouTube IFrame Player API](https://developers.google.com/youtube/iframe_api_reference)