### PR TITLE
[Feat/#89] 맵 관리 및 로비 생성 연동 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { LobbyCreate } from './pages/LobbyCreate';
 import { LobbyRoom } from './pages/LobbyRoom';
 import { MyMaps } from './pages/MyMaps';
 import { MapCreate } from './pages/MapCreate';
+import { MapManage } from './pages/MapManage';
 
 /**
  * [애플리케이션 루트 컴포넌트]
@@ -98,6 +99,17 @@ function AppRoutes() {
                         <AppLayout>
                             <ProtectedRoute>
                                 <MapCreate />
+                            </ProtectedRoute>
+                        </AppLayout>
+                    }
+                />
+
+                <Route
+                    path={MAP_ROUTES.MANAGE_MAP_PATTERN}
+                    element={
+                        <AppLayout>
+                            <ProtectedRoute>
+                                <MapManage />
                             </ProtectedRoute>
                         </AppLayout>
                     }

--- a/src/api/mapApi.ts
+++ b/src/api/mapApi.ts
@@ -1,6 +1,7 @@
 import { API_ENDPOINTS } from '../constants/endpoints';
 import {
     mapDetailResponseSchema,
+    mapItemListResponseSchema,
     mapItemResponseSchema,
     mapPageResponseSchema,
 } from '../schemas/mapSchema';
@@ -14,6 +15,9 @@ import type {
     MapItemResponse,
     MapListQueryParams,
     MapPageResponse,
+    ReorderMapItemsRequest,
+    UpdateMapRequest,
+    UpdateMapItemRequest,
 } from '../types/map';
 
 const JSON_CONTENT_TYPE = 'application/json';
@@ -21,8 +25,17 @@ const DEFAULT_FETCH_PUBLIC_MAP_LIST_ERROR_MESSAGE =
     '맵 목록을 불러오는 데 실패했습니다.';
 const DEFAULT_FETCH_MY_MAP_LIST_ERROR_MESSAGE =
     '내 맵 목록을 불러오는 데 실패했습니다.';
+const DEFAULT_FETCH_MY_MAP_DETAIL_ERROR_MESSAGE =
+    '맵 정보를 불러오는 데 실패했습니다.';
+const DEFAULT_FETCH_MAP_ITEMS_ERROR_MESSAGE =
+    '곡 목록을 불러오는 데 실패했습니다.';
 const DEFAULT_CREATE_MAP_ERROR_MESSAGE = '맵 생성에 실패했습니다.';
 const DEFAULT_CREATE_MAP_ITEM_ERROR_MESSAGE = '곡 등록에 실패했습니다.';
+const DEFAULT_UPDATE_MAP_ERROR_MESSAGE = '맵 수정에 실패했습니다.';
+const DEFAULT_UPDATE_MAP_ITEM_ERROR_MESSAGE = '곡 수정에 실패했습니다.';
+const DEFAULT_DELETE_MAP_ITEM_ERROR_MESSAGE = '곡 삭제에 실패했습니다.';
+const DEFAULT_REORDER_MAP_ITEMS_ERROR_MESSAGE =
+    '곡 순서 변경에 실패했습니다.';
 const DEFAULT_DELETE_MAP_ERROR_MESSAGE =
     '맵 삭제에 실패했습니다.';
 
@@ -105,6 +118,56 @@ export async function getMyMaps(
     );
 }
 
+export async function getMyMapDetail(
+    mapId: number,
+): Promise<MapDetailResponse> {
+    const response = await fetchWithAuth(
+        API_ENDPOINTS.MAP.MY_DETAIL(mapId),
+    );
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            DEFAULT_FETCH_MY_MAP_DETAIL_ERROR_MESSAGE,
+        );
+    }
+
+    const payload = await response.json() as unknown;
+    const parsed = mapDetailResponseSchema.safeParse(payload);
+
+    if (!parsed.success) {
+        console.error('[mapApi] 내 맵 상세 응답 검증 실패:', parsed.error);
+
+        throw new Error('맵 상세 응답 형식이 올바르지 않습니다.');
+    }
+
+    return parsed.data;
+}
+
+export async function getMapItems(
+    mapId: number,
+): Promise<MapItemResponse[]> {
+    const response = await fetchWithAuth(API_ENDPOINTS.MAP.ITEMS(mapId));
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            DEFAULT_FETCH_MAP_ITEMS_ERROR_MESSAGE,
+        );
+    }
+
+    const payload = await response.json() as unknown;
+    const parsed = mapItemListResponseSchema.safeParse(payload);
+
+    if (!parsed.success) {
+        console.error('[mapApi] 곡 목록 응답 검증 실패:', parsed.error);
+
+        throw new Error('곡 목록 응답 형식이 올바르지 않습니다.');
+    }
+
+    return parsed.data;
+}
+
 export async function createMap(
     request: CreateMapRequest,
 ): Promise<MapDetailResponse> {
@@ -127,6 +190,34 @@ export async function createMap(
         console.error('[mapApi] 맵 생성 응답 검증 실패:', parsed.error);
 
         throw new Error('맵 생성 응답 형식이 올바르지 않습니다.');
+    }
+
+    return parsed.data;
+}
+
+export async function updateMap(
+    mapId: number,
+    request: UpdateMapRequest,
+): Promise<MapDetailResponse> {
+    const response = await fetchWithAuth(API_ENDPOINTS.MAP.UPDATE(mapId), {
+        method: 'PUT',
+        headers: {
+            'Content-Type': JSON_CONTENT_TYPE,
+        },
+        body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+        throw await createApiError(response, DEFAULT_UPDATE_MAP_ERROR_MESSAGE);
+    }
+
+    const payload = await response.json() as unknown;
+    const parsed = mapDetailResponseSchema.safeParse(payload);
+
+    if (!parsed.success) {
+        console.error('[mapApi] 맵 수정 응답 검증 실패:', parsed.error);
+
+        throw new Error('맵 수정 응답 형식이 올바르지 않습니다.');
     }
 
     return parsed.data;
@@ -161,6 +252,83 @@ export async function createMapItem(
     }
 
     return parsed.data;
+}
+
+export async function updateMapItem(
+    mapId: number,
+    itemId: number,
+    request: UpdateMapItemRequest,
+): Promise<MapItemResponse> {
+    const response = await fetchWithAuth(
+        API_ENDPOINTS.MAP.ITEM(mapId, itemId),
+        {
+            method: 'PUT',
+            headers: {
+                'Content-Type': JSON_CONTENT_TYPE,
+            },
+            body: JSON.stringify(request),
+        },
+    );
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            DEFAULT_UPDATE_MAP_ITEM_ERROR_MESSAGE,
+        );
+    }
+
+    const payload = await response.json() as unknown;
+    const parsed = mapItemResponseSchema.safeParse(payload);
+
+    if (!parsed.success) {
+        console.error('[mapApi] 곡 수정 응답 검증 실패:', parsed.error);
+
+        throw new Error('곡 수정 응답 형식이 올바르지 않습니다.');
+    }
+
+    return parsed.data;
+}
+
+export async function deleteMapItem(
+    mapId: number,
+    itemId: number,
+): Promise<void> {
+    const response = await fetchWithAuth(
+        API_ENDPOINTS.MAP.ITEM(mapId, itemId),
+        {
+            method: 'DELETE',
+        },
+    );
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            DEFAULT_DELETE_MAP_ITEM_ERROR_MESSAGE,
+        );
+    }
+}
+
+export async function reorderMapItems(
+    mapId: number,
+    request: ReorderMapItemsRequest,
+): Promise<void> {
+    const response = await fetchWithAuth(
+        API_ENDPOINTS.MAP.ITEM_ORDER(mapId),
+        {
+            method: 'PUT',
+            headers: {
+                'Content-Type': JSON_CONTENT_TYPE,
+            },
+            body: JSON.stringify(request),
+        },
+    );
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            DEFAULT_REORDER_MAP_ITEMS_ERROR_MESSAGE,
+        );
+    }
 }
 
 export async function deleteMap(mapId: number): Promise<void> {

--- a/src/components/map/MapCreateSongCard.tsx
+++ b/src/components/map/MapCreateSongCard.tsx
@@ -36,10 +36,7 @@ interface MapCreateSongCardProps {
     disabled: boolean;
     onChange: (
         songId: string,
-        field: Exclude<
-            keyof CreateMapSongFormState,
-            'id' | 'answers' | 'videoDurationSeconds'
-        >,
+        field: 'youtubeUrl' | 'hint' | 'startTime',
         value: string,
     ) => void;
     onAnswerChange: (
@@ -120,6 +117,8 @@ export function MapCreateSongCard({
     const timingError = getMapCreateTimingError(
         song.startTime,
         song.videoDurationSeconds,
+        song.playDurationSeconds ??
+            MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS,
     );
     const playerElementId = `youtube-preview-${song.id}`;
 

--- a/src/components/map/MapItemDetailModal.tsx
+++ b/src/components/map/MapItemDetailModal.tsx
@@ -1,0 +1,149 @@
+import {
+    type MouseEvent,
+    useEffect,
+} from 'react';
+import { ImageOff } from 'lucide-react';
+
+import {
+    MAP_ITEM_DETAIL_MODAL_COPY,
+    MAP_MANAGE_PAGE_COPY,
+} from '../../constants/map';
+import { formatMapStartTime } from '../../utils/mapFormat';
+import {
+    createYouTubeEmbedUrl,
+    extractYouTubeVideoId,
+} from '../../utils/youtube';
+
+import type { MapItemResponse } from '../../types/map';
+
+interface MapItemDetailModalProps {
+    item: MapItemResponse;
+    onClose: () => void;
+}
+
+export function MapItemDetailModal({
+    item,
+    onClose,
+}: MapItemDetailModalProps) {
+    useEffect(() => {
+        const previousOverflow = document.body.style.overflow;
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        document.body.style.overflow = 'hidden';
+
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+            document.body.style.overflow = previousOverflow;
+        };
+    }, [onClose]);
+
+    const title =
+        item.title?.trim() || MAP_MANAGE_PAGE_COPY.SONG_TITLE_FALLBACK;
+    const videoId =
+        item.videoId?.trim() || extractYouTubeVideoId(item.youtubeUrl);
+    const embedUrl = videoId
+        ? createYouTubeEmbedUrl(videoId, item.startTime)
+        : null;
+    const titleId = `map-item-detail-title-${item.id}`;
+    const descriptionId = `map-item-detail-description-${item.id}`;
+
+    const handleContentMouseDown = (event: MouseEvent<HTMLDivElement>) => {
+        event.stopPropagation();
+    };
+
+    return (
+        <div
+            role="presentation"
+            onMouseDown={onClose}
+            className="fixed inset-0 z-[60] flex items-center justify-center bg-black/65 px-4 py-8"
+        >
+            <div
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={titleId}
+                aria-describedby={descriptionId}
+                onMouseDown={handleContentMouseDown}
+                className="flex max-h-[calc(100vh-64px)] w-full max-w-[700px] flex-col overflow-hidden rounded-2xl border border-[var(--monomat-border-card)] bg-white shadow-[0_18px_48px_rgba(15,23,42,0.25)]"
+            >
+                <header className="flex min-h-[70px] shrink-0 items-center border-b border-[var(--monomat-border-card)] px-5">
+                    <div className="min-w-0 flex-1">
+                        <h2
+                            id={titleId}
+                            className="!m-0 truncate !text-base !font-semibold !leading-5 !text-black"
+                        >
+                            {title}
+                        </h2>
+                        <p
+                            id={descriptionId}
+                            className="mt-1 text-sm text-[var(--monomat-text-secondary)]"
+                        >
+                            {MAP_ITEM_DETAIL_MODAL_COPY.PLAY_FROM(
+                                formatMapStartTime(item.startTime),
+                            )}
+                        </p>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        aria-label={
+                            MAP_ITEM_DETAIL_MODAL_COPY.CLOSE_ARIA_LABEL
+                        }
+                        className="ml-4 h-[30px] min-w-[60px] rounded-2xl bg-[var(--monomat-page-bg)] px-3 text-[13px] font-semibold text-[var(--monomat-text-strong)] transition hover:bg-[var(--monomat-border-default)]"
+                    >
+                        {MAP_ITEM_DETAIL_MODAL_COPY.CLOSE}
+                    </button>
+                </header>
+
+                <div className="aspect-video min-h-0 w-full bg-black">
+                    {embedUrl ? (
+                        <iframe
+                            src={embedUrl}
+                            title={MAP_ITEM_DETAIL_MODAL_COPY.IFRAME_TITLE(
+                                title,
+                            )}
+                            className="h-full w-full border-0"
+                            loading="lazy"
+                            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                            referrerPolicy="strict-origin-when-cross-origin"
+                            allowFullScreen
+                        />
+                    ) : item.thumbnailUrl ? (
+                        <img
+                            src={item.thumbnailUrl}
+                            alt=""
+                            className="h-full w-full object-contain"
+                        />
+                    ) : (
+                        <div className="flex h-full min-h-[260px] items-center justify-center text-center text-sm font-medium text-white/75">
+                            <div>
+                                <ImageOff
+                                    className="mx-auto mb-3"
+                                    size={36}
+                                    strokeWidth={1.5}
+                                    aria-hidden="true"
+                                />
+                                {
+                                    MAP_ITEM_DETAIL_MODAL_COPY.PREVIEW_FALLBACK
+                                }
+                            </div>
+                        </div>
+                    )}
+                </div>
+
+                <footer className="max-h-[120px] shrink-0 overflow-y-auto border-t border-[var(--monomat-border-card)] px-5 py-3 text-sm leading-5 text-[var(--monomat-text-secondary)]">
+                    <span className="font-semibold">
+                        {MAP_ITEM_DETAIL_MODAL_COPY.ANSWERS_LABEL} :{' '}
+                    </span>
+                    {item.answers.length > 0
+                        ? item.answers.join(', ')
+                        : MAP_ITEM_DETAIL_MODAL_COPY.EMPTY_ANSWERS}
+                </footer>
+            </div>
+        </div>
+    );
+}

--- a/src/components/map/MapManageSongEditor.tsx
+++ b/src/components/map/MapManageSongEditor.tsx
@@ -1,0 +1,97 @@
+import { MapCreateSongCard } from './MapCreateSongCard';
+import {
+    MAP_CREATE_POLICY,
+    MAP_MANAGE_PAGE_COPY,
+} from '../../constants/map';
+
+import type { ManageMapSongFormState } from '../../types/map';
+
+interface MapManageSongEditorProps {
+    songs: ManageMapSongFormState[];
+    disabled: boolean;
+    onAddSong: () => void;
+    onChange: (
+        songId: string,
+        field: 'youtubeUrl' | 'hint' | 'startTime',
+        value: string,
+    ) => void;
+    onAnswerChange: (
+        songId: string,
+        answerIndex: number,
+        value: string,
+    ) => void;
+    onDurationChange: (
+        songId: string,
+        videoDurationSeconds: number | null,
+    ) => void;
+    onAddAnswer: (songId: string) => void;
+    onDeleteAnswer: (songId: string, answerIndex: number) => void;
+    onDeleteSong: (songId: string) => void;
+    onMoveUp: (songId: string) => void;
+    onMoveDown: (songId: string) => void;
+}
+
+export function MapManageSongEditor({
+    songs,
+    disabled,
+    onAddSong,
+    onChange,
+    onAnswerChange,
+    onDurationChange,
+    onAddAnswer,
+    onDeleteAnswer,
+    onDeleteSong,
+    onMoveUp,
+    onMoveDown,
+}: MapManageSongEditorProps) {
+    return (
+        <section className="mt-[30px] rounded-2xl bg-white p-5 shadow-[0_4px_16px_rgba(0,0,0,0.16)] sm:p-6">
+            <div className="flex items-start justify-between gap-4">
+                <div>
+                    <h2 className="!m-0 !text-lg !font-bold !leading-6 !text-black">
+                        {MAP_MANAGE_PAGE_COPY.SONG_LIST_TITLE}
+                    </h2>
+                    <p className="mt-1 text-sm font-medium leading-5 text-[var(--monomat-text-muted)]">
+                        {MAP_MANAGE_PAGE_COPY.EDIT_SONG_LIST_DESCRIPTION}
+                    </p>
+                </div>
+                <button
+                    type="button"
+                    onClick={onAddSong}
+                    disabled={
+                        disabled ||
+                        songs.length >= MAP_CREATE_POLICY.MAX_SONG_COUNT
+                    }
+                    className="h-[45px] shrink-0 rounded-lg border border-[color:var(--monomat-border-input)] bg-white px-5 text-[15px] font-semibold text-black transition hover:border-[var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-45"
+                >
+                    {MAP_MANAGE_PAGE_COPY.EDIT_ADD_SONG}
+                </button>
+            </div>
+
+            <div className="mt-5 space-y-4">
+                {songs.map((song, index) => (
+                    <MapCreateSongCard
+                        key={song.id}
+                        index={index}
+                        song={song}
+                        canDeleteSong={
+                            songs.length >
+                            MAP_CREATE_POLICY.MIN_SONG_COUNT
+                        }
+                        canMoveUp={index > 0}
+                        canMoveDown={index < songs.length - 1}
+                        disabled={disabled}
+                        onChange={onChange}
+                        onAnswerChange={onAnswerChange}
+                        onDurationChange={onDurationChange}
+                        onAddAnswer={onAddAnswer}
+                        onDeleteAnswer={onDeleteAnswer}
+                        onDeleteSong={onDeleteSong}
+                        onMoveUp={onMoveUp}
+                        onMoveDown={onMoveDown}
+                    />
+                ))}
+            </div>
+        </section>
+    );
+}

--- a/src/components/map/MapManageSongList.tsx
+++ b/src/components/map/MapManageSongList.tsx
@@ -1,0 +1,108 @@
+import { ImageOff } from 'lucide-react';
+
+import { MAP_MANAGE_PAGE_COPY } from '../../constants/map';
+import {
+    formatMapAnswerCount,
+    formatMapStartTime,
+} from '../../utils/mapFormat';
+
+import type { MapItemResponse } from '../../types/map';
+
+interface MapManageSongListProps {
+    items: MapItemResponse[];
+    onItemClick: (item: MapItemResponse) => void;
+}
+
+function getItemTitle(item: MapItemResponse) {
+    return (
+        item.answers[0]?.trim() || MAP_MANAGE_PAGE_COPY.SONG_TITLE_FALLBACK
+    );
+}
+
+function getItemDescription(item: MapItemResponse) {
+    return (
+        item.hint.trim() ||
+        item.artist?.trim() ||
+        MAP_MANAGE_PAGE_COPY.SONG_DESCRIPTION_FALLBACK
+    );
+}
+
+export function MapManageSongList({
+    items,
+    onItemClick,
+}: MapManageSongListProps) {
+    const sortedItems = [...items].sort(
+        (first, second) => first.orderNum - second.orderNum,
+    );
+
+    if (sortedItems.length === 0) {
+        return (
+            <div className="flex min-h-[180px] items-center justify-center rounded-2xl bg-white px-6 text-center text-sm font-medium text-[var(--monomat-text-muted)] shadow-[0_4px_16px_rgba(0,0,0,0.18)]">
+                {MAP_MANAGE_PAGE_COPY.EMPTY_SONG_LIST}
+            </div>
+        );
+    }
+
+    return (
+        <div className="overflow-hidden rounded-2xl bg-white shadow-[0_4px_16px_rgba(0,0,0,0.18)]">
+            {sortedItems.map((item, index) => {
+                const title = getItemTitle(item);
+
+                return (
+                    <button
+                        key={item.id}
+                        type="button"
+                        onClick={() => onItemClick(item)}
+                        aria-label={MAP_MANAGE_PAGE_COPY.SONG_ROW_ARIA_LABEL(
+                            title,
+                        )}
+                        className="group flex min-h-[107px] w-full items-center border-b border-[var(--monomat-border-card)] bg-white px-[15px] text-left transition last:border-b-0 hover:bg-[var(--monomat-page-bg)] focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--monomat-primary)]"
+                    >
+                        <span className="w-[50px] shrink-0 text-center font-mono text-sm font-semibold text-[var(--monomat-text-secondary)]">
+                            {String(index + 1).padStart(2, '0')}
+                        </span>
+
+                        <span className="flex h-20 w-[130px] shrink-0 items-center justify-center overflow-hidden rounded-lg bg-[#D9D9D9] text-[var(--monomat-text-muted)]">
+                            {item.thumbnailUrl ? (
+                                <img
+                                    src={item.thumbnailUrl}
+                                    alt=""
+                                    className="h-full w-full object-cover"
+                                    loading="lazy"
+                                />
+                            ) : (
+                                <span className="text-center text-[11px] font-medium">
+                                    <ImageOff
+                                        className="mx-auto mb-1"
+                                        size={22}
+                                        strokeWidth={1.7}
+                                        aria-hidden="true"
+                                    />
+                                    {
+                                        MAP_MANAGE_PAGE_COPY.THUMBNAIL_FALLBACK
+                                    }
+                                </span>
+                            )}
+                        </span>
+
+                        <span className="ml-[15px] min-w-0 flex-1">
+                            <span className="block truncate text-base font-semibold leading-7 text-black">
+                                {title}
+                            </span>
+                            <span className="mt-1 block truncate text-sm font-medium text-[var(--monomat-text-secondary)]">
+                                {getItemDescription(item)}
+                            </span>
+                        </span>
+
+                        <span className="ml-5 flex shrink-0 items-center gap-4 text-sm font-medium text-[var(--monomat-text-secondary)]">
+                            <span>{formatMapStartTime(item.startTime)}</span>
+                            <span>
+                                {formatMapAnswerCount(item.answers.length)}
+                            </span>
+                        </span>
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/components/map/MapManageSummary.tsx
+++ b/src/components/map/MapManageSummary.tsx
@@ -1,0 +1,396 @@
+import {
+    type ChangeEvent,
+    type FormEvent,
+    type ReactNode,
+    useEffect,
+    useState,
+} from 'react';
+import {
+    Clock,
+    Cloud,
+    Compass,
+    LockKeyhole,
+    Music,
+    Pencil,
+    Trash2,
+} from 'lucide-react';
+
+import {
+    MAP_CATEGORY_OPTIONS,
+    MAP_MANAGE_PAGE_COPY,
+    MAP_PUBLIC_STATUS_META,
+    MAP_UPDATE_POLICY,
+} from '../../constants/map';
+import {
+    formatMapDescription,
+    formatMapPlayCount,
+    formatMapSongCount,
+    formatMapUpdatedAt,
+} from '../../utils/mapFormat';
+
+import type {
+    MapCategory,
+    MapDetailResponse,
+    UpdateMapRequest,
+} from '../../types/map';
+
+interface MapManageSummaryProps {
+    map: MapDetailResponse;
+    isUpdating: boolean;
+    updateErrorMessage: string | null;
+    onCreateLobby: () => void;
+    onDelete: () => void;
+    onSave: (request: UpdateMapRequest) => Promise<void>;
+    onEditingChange: (isEditing: boolean) => void;
+    editContent: ReactNode;
+    isEditDisabled: boolean;
+}
+
+interface MapEditFormState {
+    title: string;
+    description: string;
+    category: MapCategory;
+    isPublic: boolean;
+}
+
+function createEditFormState(map: MapDetailResponse): MapEditFormState {
+    return {
+        title: map.title,
+        description: map.description ?? '',
+        category: map.category,
+        isPublic: map.isPublic || map.pendingPublic,
+    };
+}
+
+function getMapPublicStatusMeta(map: MapDetailResponse) {
+    if (map.isPublic) {
+        return {
+            ...MAP_PUBLIC_STATUS_META.PUBLIC,
+            Icon: Cloud,
+        };
+    }
+
+    if (map.pendingPublic) {
+        return {
+            ...MAP_PUBLIC_STATUS_META.PENDING,
+            Icon: Clock,
+        };
+    }
+
+    return {
+        ...MAP_PUBLIC_STATUS_META.PRIVATE,
+        Icon: LockKeyhole,
+    };
+}
+
+export function MapManageSummary({
+    map,
+    isUpdating,
+    updateErrorMessage,
+    onCreateLobby,
+    onDelete,
+    onSave,
+    onEditingChange,
+    editContent,
+    isEditDisabled,
+}: MapManageSummaryProps) {
+    const [isEditing, setIsEditing] = useState(false);
+    const [formState, setFormState] = useState(() =>
+        createEditFormState(map),
+    );
+    const [validationMessage, setValidationMessage] =
+        useState<string | null>(null);
+
+    useEffect(() => {
+        if (!isEditing) {
+            setFormState(createEditFormState(map));
+        }
+    }, [isEditing, map]);
+
+    const statusMeta = getMapPublicStatusMeta(map);
+    const StatusIcon = statusMeta.Icon;
+
+    const handleEditClick = () => {
+        setFormState(createEditFormState(map));
+        setValidationMessage(null);
+        onEditingChange(true);
+        setIsEditing(true);
+    };
+
+    const handleCancel = () => {
+        if (isUpdating) {
+            return;
+        }
+
+        setFormState(createEditFormState(map));
+        setValidationMessage(null);
+        onEditingChange(false);
+        setIsEditing(false);
+    };
+
+    const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
+        setFormState((current) => ({
+            ...current,
+            title: event.target.value,
+        }));
+        setValidationMessage(null);
+    };
+
+    const handleDescriptionChange = (
+        event: ChangeEvent<HTMLTextAreaElement>,
+    ) => {
+        setFormState((current) => ({
+            ...current,
+            description: event.target.value,
+        }));
+        setValidationMessage(null);
+    };
+
+    const handleCategoryChange = (event: ChangeEvent<HTMLSelectElement>) => {
+        setFormState((current) => ({
+            ...current,
+            category: event.target.value as MapCategory,
+        }));
+    };
+
+    const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        const title = formState.title.trim();
+
+        if (!title) {
+            setValidationMessage('맵 제목을 입력해주세요.');
+            return;
+        }
+
+        if (title.length > MAP_UPDATE_POLICY.TITLE_MAX_LENGTH) {
+            setValidationMessage(
+                `맵 제목은 ${MAP_UPDATE_POLICY.TITLE_MAX_LENGTH}자를 초과할 수 없습니다.`,
+            );
+            return;
+        }
+
+        if (
+            formState.description.length >
+            MAP_UPDATE_POLICY.DESCRIPTION_MAX_LENGTH
+        ) {
+            setValidationMessage(
+                `맵 설명은 ${MAP_UPDATE_POLICY.DESCRIPTION_MAX_LENGTH}자를 초과할 수 없습니다.`,
+            );
+            return;
+        }
+
+        try {
+            await onSave({
+                title,
+                description: formState.description.trim() || null,
+                category: formState.category,
+                isPublic: formState.isPublic,
+            });
+            onEditingChange(false);
+            setIsEditing(false);
+        } catch {
+            // Mutation error is rendered by the parent without discarding edits.
+        }
+    };
+
+    if (isEditing) {
+        return (
+            <form
+                onSubmit={handleSubmit}
+                noValidate
+            >
+                <section className="rounded-2xl bg-white p-[30px] shadow-[0_4px_16px_rgba(0,0,0,0.18)]">
+                    <h1 className="!m-0 !text-xl !font-extrabold !leading-7 !text-black">
+                        {MAP_MANAGE_PAGE_COPY.EDIT}
+                    </h1>
+
+                    <div className="mt-5 grid gap-5 md:grid-cols-2">
+                        <label className="block md:col-span-2">
+                            <span className="mb-2 block text-sm font-semibold text-[var(--monomat-text-secondary)]">
+                                {MAP_MANAGE_PAGE_COPY.TITLE_LABEL}
+                            </span>
+                            <input
+                                type="text"
+                                value={formState.title}
+                                maxLength={MAP_UPDATE_POLICY.TITLE_MAX_LENGTH}
+                                disabled={isUpdating}
+                                onChange={handleTitleChange}
+                                className="h-11 w-full rounded-lg border border-[var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-4 text-sm font-medium text-[var(--monomat-text-strong)] outline-none transition focus:border-[var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                            />
+                        </label>
+
+                        <label className="block md:col-span-2">
+                            <span className="mb-2 block text-sm font-semibold text-[var(--monomat-text-secondary)]">
+                                {MAP_MANAGE_PAGE_COPY.DESCRIPTION_LABEL}
+                            </span>
+                            <textarea
+                                value={formState.description}
+                                maxLength={
+                                    MAP_UPDATE_POLICY.DESCRIPTION_MAX_LENGTH
+                                }
+                                disabled={isUpdating}
+                                onChange={handleDescriptionChange}
+                                rows={3}
+                                className="w-full resize-none rounded-lg border border-[var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-4 py-3 text-sm font-medium leading-5 text-[var(--monomat-text-strong)] outline-none transition focus:border-[var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                            />
+                        </label>
+
+                        <label className="block">
+                            <span className="mb-2 block text-sm font-semibold text-[var(--monomat-text-secondary)]">
+                                {MAP_MANAGE_PAGE_COPY.CATEGORY_LABEL}
+                            </span>
+                            <select
+                                value={formState.category}
+                                disabled={isUpdating}
+                                onChange={handleCategoryChange}
+                                className="h-11 w-full rounded-lg border border-[var(--monomat-border-input)] bg-white px-4 text-sm font-medium text-[var(--monomat-text-strong)] outline-none transition focus:border-[var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                            >
+                                {MAP_CATEGORY_OPTIONS.map((category) => (
+                                    <option key={category} value={category}>
+                                        {category}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+
+                        <fieldset>
+                            <legend className="mb-2 text-sm font-semibold text-[var(--monomat-text-secondary)]">
+                                {MAP_MANAGE_PAGE_COPY.VISIBILITY_LABEL}
+                            </legend>
+                            <div className="grid grid-cols-2 gap-2">
+                                {[true, false].map((isPublic) => (
+                                    <button
+                                        key={String(isPublic)}
+                                        type="button"
+                                        disabled={isUpdating}
+                                        aria-pressed={
+                                            formState.isPublic === isPublic
+                                        }
+                                        onClick={() =>
+                                            setFormState((current) => ({
+                                                ...current,
+                                                isPublic,
+                                            }))
+                                        }
+                                        className={`h-11 rounded-lg border text-sm font-bold transition disabled:cursor-not-allowed disabled:opacity-60 ${
+                                            formState.isPublic === isPublic
+                                                ? 'border-[var(--monomat-primary)] bg-[var(--monomat-primary-light)] text-[var(--monomat-primary)]'
+                                                : 'border-[var(--monomat-border-input)] bg-white text-[var(--monomat-text-muted)] hover:bg-[var(--monomat-page-bg)]'
+                                        }`}
+                                    >
+                                        {isPublic
+                                            ? MAP_MANAGE_PAGE_COPY.PUBLIC
+                                            : MAP_MANAGE_PAGE_COPY.PRIVATE}
+                                    </button>
+                                ))}
+                            </div>
+                        </fieldset>
+                    </div>
+                </section>
+
+                {editContent}
+
+                {(validationMessage || updateErrorMessage) && (
+                    <p
+                        role="alert"
+                        className="mt-4 rounded-lg bg-red-50 px-4 py-3 text-sm font-semibold text-red-600 ring-1 ring-red-100"
+                    >
+                        {validationMessage ?? updateErrorMessage}
+                    </p>
+                )}
+
+                <div className="mt-[30px] flex justify-end gap-3">
+                    <button
+                        type="button"
+                        onClick={handleCancel}
+                        disabled={isUpdating}
+                        className="h-[45px] min-w-[85px] rounded-lg border border-[var(--monomat-border-input)] bg-white px-5 text-[15px] font-bold text-black transition hover:bg-[var(--monomat-page-bg)] disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                        {MAP_MANAGE_PAGE_COPY.CANCEL}
+                    </button>
+                    <button
+                        type="submit"
+                        disabled={isUpdating}
+                        className="h-[45px] min-w-[110px] rounded-lg bg-[var(--monomat-primary)] px-5 text-[15px] font-bold text-white transition hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:bg-[var(--monomat-primary-disabled)]"
+                    >
+                        {isUpdating
+                            ? MAP_MANAGE_PAGE_COPY.SAVING
+                            : MAP_MANAGE_PAGE_COPY.SAVE}
+                    </button>
+                </div>
+            </form>
+        );
+    }
+
+    return (
+        <section className="rounded-2xl bg-white p-[30px] shadow-[0_4px_16px_rgba(0,0,0,0.18)]">
+            <div className="flex min-w-0 items-start gap-[30px]">
+                <span className="flex h-[100px] w-[100px] shrink-0 items-center justify-center rounded-2xl bg-[#C9DBFF] text-[#2B3F6C]">
+                    <Music size={40} strokeWidth={1.8} aria-hidden="true" />
+                </span>
+
+                <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-3">
+                        <span className="inline-flex h-[22px] items-center rounded-full bg-[var(--monomat-primary-light)] px-2.5 text-[11px] font-semibold text-[var(--monomat-primary)]">
+                            {map.category}
+                        </span>
+                        <span className={`inline-flex h-[22px] items-center gap-1 rounded-full border px-2 text-xs font-medium ${statusMeta.badgeClassName}`}>
+                            <StatusIcon
+                                size={13}
+                                strokeWidth={2}
+                                aria-hidden="true"
+                            />
+                            {statusMeta.label}
+                        </span>
+                    </div>
+
+                    <h1 className="!mb-0 !mt-2 break-words !text-xl !font-extrabold !leading-7 !text-black">
+                        {map.title}
+                    </h1>
+                    <p className="mt-1 min-h-10 whitespace-pre-wrap break-keep text-sm font-medium leading-5 text-[var(--monomat-text-secondary)] [overflow-wrap:anywhere]">
+                        {formatMapDescription(map.description)}
+                    </p>
+                    <p className="mt-1 text-sm text-[var(--monomat-text-secondary)]">
+                        {formatMapSongCount(map.numOfSong)} |{' '}
+                        {formatMapPlayCount(map.playCount)}{' '}
+                        {MAP_MANAGE_PAGE_COPY.PLAY_SUFFIX} |{' '}
+                        {MAP_MANAGE_PAGE_COPY.UPDATED_PREFIX}{' '}
+                        {formatMapUpdatedAt(map.updatedAt)}
+                    </p>
+                </div>
+            </div>
+
+            <div className="mt-[19px] flex items-center gap-[14px]">
+                <button
+                    type="button"
+                    onClick={onCreateLobby}
+                    className="flex h-[45px] w-[200px] items-center justify-center gap-2 rounded-lg bg-[var(--monomat-primary)] text-[15px] font-bold text-white transition hover:bg-[var(--monomat-primary-hover)]"
+                >
+                    <Compass size={21} strokeWidth={2} aria-hidden="true" />
+                    {MAP_MANAGE_PAGE_COPY.CREATE_LOBBY}
+                </button>
+                <button
+                    type="button"
+                    onClick={handleEditClick}
+                    disabled={isEditDisabled}
+                    className="flex h-[45px] min-w-20 items-center justify-center gap-1.5 rounded-lg border border-[var(--monomat-border-input)] bg-white px-4 text-[15px] font-bold text-black transition hover:bg-[var(--monomat-page-bg)] disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                    <Pencil size={16} strokeWidth={2} aria-hidden="true" />
+                    {MAP_MANAGE_PAGE_COPY.EDIT}
+                </button>
+                <button
+                    type="button"
+                    onClick={onDelete}
+                    aria-label={MAP_MANAGE_PAGE_COPY.DELETE_ARIA_LABEL(
+                        map.title,
+                    )}
+                    className="ml-auto flex h-[45px] min-w-20 items-center justify-center gap-1.5 rounded-lg border border-[var(--monomat-border-input)] bg-white px-4 text-[15px] font-bold text-black transition hover:border-red-200 hover:bg-red-50 hover:text-red-600"
+                >
+                    <Trash2 size={17} strokeWidth={2} aria-hidden="true" />
+                    {MAP_MANAGE_PAGE_COPY.DELETE}
+                </button>
+            </div>
+        </section>
+    );
+}

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -52,8 +52,15 @@ export const API_ENDPOINTS = {
         LIST: createApiEndpoint('/api/maps'),
         CREATE: createApiEndpoint('/api/maps'),
         MY_LIST: createApiEndpoint('/api/maps/me'),
+        MY_DETAIL: (mapId: number) =>
+            createApiEndpoint(`/api/maps/me/${mapId}`),
         ITEMS: (mapId: number) =>
             createApiEndpoint(`/api/maps/${mapId}/items`),
+        ITEM: (mapId: number, itemId: number) =>
+            createApiEndpoint(`/api/maps/${mapId}/items/${itemId}`),
+        ITEM_ORDER: (mapId: number) =>
+            createApiEndpoint(`/api/maps/${mapId}/items/order`),
+        UPDATE: (mapId: number) => createApiEndpoint(`/api/maps/${mapId}`),
         DELETE: (mapId: number) => createApiEndpoint(`/api/maps/${mapId}`),
     },
 

--- a/src/constants/lobby.ts
+++ b/src/constants/lobby.ts
@@ -60,6 +60,16 @@ export const LOBBY_ROUTES = {
     CREATE_MAP: null as string | null,
 } as const;
 
+export const LOBBY_QUERY_PARAMS = {
+    MAP_ID: 'mapId',
+} as const;
+
+export const LOBBY_CREATE_MAP_PRESELECT_COPY = {
+    LOADING: '선택한 맵 정보를 불러오는 중입니다.',
+    INVALID_MAP_ID: '전달된 맵 번호가 올바르지 않습니다.',
+    FETCH_ERROR: '선택한 내 맵을 불러오지 못했습니다.',
+} as const;
+
 export const LOBBY_STATUS_META = {
     WAITING: {
         label: '대기중',

--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -22,6 +22,8 @@ export const MY_MAP_SEARCH_PAGE_SIZE = 100;
 export const MAP_ROUTES = {
     MY_MAPS: '/maps/me',
     CREATE_MAP: '/maps/new',
+    MANAGE_MAP_PATTERN: '/maps/:mapId/manage',
+    MANAGE_MAP: (mapId: number) => `/maps/${mapId}/manage`,
 } as const;
 
 export const MAP_CREATE_POLICY = {
@@ -38,6 +40,11 @@ export const MAP_CREATE_POLICY = {
     API_FALLBACK_PLAY_DURATION_SECONDS: 30,
     DEFAULT_CATEGORY: 'J-POP',
     DEFAULT_IS_PUBLIC: true,
+} as const;
+
+export const MAP_UPDATE_POLICY = {
+    TITLE_MAX_LENGTH: 50,
+    DESCRIPTION_MAX_LENGTH: 255,
 } as const;
 
 export const MAP_CREATE_PAGE_COPY = {
@@ -183,4 +190,58 @@ export const MAP_PUBLIC_STATUS_META = {
         label: '비공개',
         badgeClassName: 'border-[var(--monomat-border-input)] bg-white text-[var(--monomat-text-muted)]',
     },
+} as const;
+
+export const MAP_MANAGE_PAGE_COPY = {
+    BACK_TO_MAPS: '← 맵 목록으로',
+    SUMMARY_LOADING: '맵 정보를 불러오는 중입니다.',
+    SUMMARY_ERROR_TITLE: '맵 정보를 불러오지 못했습니다.',
+    ITEMS_LOADING: '곡 목록을 불러오는 중입니다.',
+    ITEMS_ERROR_TITLE: '곡 목록을 불러오지 못했습니다.',
+    INVALID_MAP_ID_TITLE: '올바르지 않은 맵 주소입니다.',
+    INVALID_MAP_ID_DESCRIPTION:
+        '맵 번호를 확인하거나 내 맵 목록으로 돌아가주세요.',
+    RETRY: '다시 불러오기',
+    SONG_LIST_TITLE: '곡 목록',
+    EMPTY_SONG_LIST: '등록된 곡이 없습니다.',
+    CREATE_LOBBY: '이 맵으로 로비 만들기',
+    EDIT: '수정',
+    DELETE: '삭제',
+    SAVE: '저장',
+    SAVING: '저장 중...',
+    CANCEL: '취소',
+    TITLE_LABEL: '맵 제목',
+    DESCRIPTION_LABEL: '맵 설명',
+    CATEGORY_LABEL: '카테고리',
+    VISIBILITY_LABEL: '공개 설정',
+    PUBLIC: '공개',
+    PRIVATE: '비공개',
+    UPDATE_ERROR: '맵 정보를 수정하지 못했습니다.',
+    UPDATE_PARTIAL_ERROR:
+        '일부 변경만 저장되었습니다. 최신 정보를 다시 불러온 뒤 확인해주세요.',
+    DESCRIPTION_FALLBACK: '맵 설명이 없습니다.',
+    UPDATED_PREFIX: '업데이트',
+    PLAY_SUFFIX: '플레이',
+    SONG_UNIT: '곡',
+    SONG_TITLE_FALLBACK: '곡 제목 정보 없음',
+    SONG_DESCRIPTION_FALLBACK: '곡 설명이 없습니다.',
+    THUMBNAIL_FALLBACK: '미리보기 없음',
+    SONG_ROW_ARIA_LABEL: (title: string) => `${title} 상세 정보 보기`,
+    DELETE_ARIA_LABEL: (title: string) => `${title} 삭제`,
+    EDIT_SONG_LIST_DESCRIPTION:
+        '곡을 추가하거나 내용을 수정하고, 화살표로 재생 순서를 변경하세요.',
+    EDIT_ADD_SONG: '+ 곡 추가',
+    EDIT_EMPTY_SONG_ERROR: '곡을 1개 이상 등록해주세요.',
+    EDIT_INVALID_SONG_ERROR:
+        '모든 곡의 YouTube URL, 힌트, 시작 시간, 정답 후보를 확인해주세요.',
+} as const;
+
+export const MAP_ITEM_DETAIL_MODAL_COPY = {
+    CLOSE: '닫기',
+    CLOSE_ARIA_LABEL: '곡 상세 모달 닫기',
+    PLAY_FROM: (startTime: string) => `${startTime}부터 재생`,
+    ANSWERS_LABEL: '정답 후보',
+    EMPTY_ANSWERS: '등록된 정답 후보가 없습니다.',
+    PREVIEW_FALLBACK: 'YouTube 미리보기를 표시할 수 없습니다.',
+    IFRAME_TITLE: (title: string) => `${title} YouTube 미리보기`,
 } as const;

--- a/src/pages/LobbyCreate.tsx
+++ b/src/pages/LobbyCreate.tsx
@@ -3,21 +3,29 @@ import {
     type FormEvent,
     type ReactNode,
     type MouseEvent,
+    useEffect,
     useState,
 } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Gamepad2, LockKeyhole, Music, X } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { createLobby } from '../api/lobbyApi';
+import { getMyMapDetail } from '../api/mapApi';
 import { AccountModal } from '../components/common/AccountModal';
 import { MonomatInput } from '../components/common/MonomatInput';
 import { MonomatLogo } from '../components/common/MonomatLogo';
 import { LobbyFooter } from '../components/lobby/LobbyFooter';
 import { MapSelectModal } from '../components/lobby/MapSelectModal';
-import { CREATE_LOBBY_POLICY, LOBBY_ROUTES } from '../constants/lobby';
+import {
+    CREATE_LOBBY_POLICY,
+    LOBBY_CREATE_MAP_PRESELECT_COPY,
+    LOBBY_QUERY_PARAMS,
+    LOBBY_ROUTES,
+} from '../constants/lobby';
 import { useAuthStore } from '../store/useAuthStore';
 import type { CreateLobbyRequest } from '../types/lobby';
-import type { MapSummary } from '../types/map';
+import type { MapDetailResponse, MapSummary } from '../types/map';
 import { getAvatarColor } from '../utils/avatarColor';
 import {
     formatMapDescription,
@@ -95,6 +103,22 @@ function createRequestFromFormState(
         mapId: selectedMap?.mapId ?? null,
         questionCount: formState.questionCount,
         timeLimitSeconds: formState.timeLimitSeconds,
+    };
+}
+
+function mapDetailToSummary(map: MapDetailResponse): MapSummary {
+    return {
+        mapId: map.id,
+        title: map.title,
+        description: map.description,
+        category: map.category,
+        numOfSong: map.numOfSong,
+        totalPlayTime: map.totalPlayTime,
+        playCount: map.playCount,
+        isPublic: map.isPublic,
+        pendingPublic: map.pendingPublic,
+        ownerId: map.ownerId,
+        ownerNickname: map.ownerNickname,
     };
 }
 
@@ -226,12 +250,44 @@ function VisibilityOption({
 
 export function LobbyCreate() {
     const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
     const [formState, setFormState] =
         useState<LobbyCreateFormState>(DEFAULT_FORM_STATE);
     const [selectedMap, setSelectedMap] = useState<MapSummary | null>(null);
     const [isMapSelectModalOpen, setIsMapSelectModalOpen] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const mapIdParam = searchParams.get(LOBBY_QUERY_PARAMS.MAP_ID);
+    const parsedMapId = Number(mapIdParam);
+    const hasPreselectedMapId = mapIdParam !== null;
+    const isValidPreselectedMapId =
+        hasPreselectedMapId &&
+        Number.isInteger(parsedMapId) &&
+        parsedMapId > 0;
+    const preselectedMapId = isValidPreselectedMapId ? parsedMapId : 0;
+
+    const preselectedMapQuery = useQuery<MapDetailResponse>({
+        queryKey: ['myMapDetail', preselectedMapId],
+        queryFn: () => getMyMapDetail(preselectedMapId),
+        enabled: isValidPreselectedMapId,
+    });
+
+    useEffect(() => {
+        if (preselectedMapQuery.data) {
+            setSelectedMap(mapDetailToSummary(preselectedMapQuery.data));
+        }
+    }, [preselectedMapQuery.data]);
+
+    const preselectedMapErrorMessage = !hasPreselectedMapId
+        ? null
+        : !isValidPreselectedMapId
+            ? LOBBY_CREATE_MAP_PRESELECT_COPY.INVALID_MAP_ID
+            : preselectedMapQuery.isError
+                ? getErrorMessage(
+                    preselectedMapQuery.error,
+                    LOBBY_CREATE_MAP_PRESELECT_COPY.FETCH_ERROR,
+                )
+                : null;
 
     const updateFormState = <TKey extends keyof LobbyCreateFormState>(
         key: TKey,
@@ -342,14 +398,21 @@ export function LobbyCreate() {
                             <button
                                 type="button"
                                 onClick={handleMapSelectClick}
-                                disabled={isSubmitting}
+                                disabled={
+                                    isSubmitting ||
+                                    preselectedMapQuery.isLoading
+                                }
                                 className="h-10 w-20 shrink-0 rounded-lg border border-[var(--monomat-border-input)] bg-white text-[15px] font-bold text-black transition hover:bg-[var(--monomat-page-bg)] disabled:cursor-not-allowed disabled:opacity-60"
                             >
                                 {selectedMap ? '맵 변경' : '맵 선택'}
                             </button>
                         </div>
 
-                        {selectedMap ? (
+                        {preselectedMapQuery.isLoading ? (
+                            <div className="mt-[18px] flex h-[120px] items-center justify-center rounded-lg border border-[var(--monomat-border-default)] bg-[var(--monomat-page-bg)] text-sm font-medium text-[var(--monomat-text-muted)]">
+                                {LOBBY_CREATE_MAP_PRESELECT_COPY.LOADING}
+                            </div>
+                        ) : selectedMap ? (
                             <div className="mt-[18px] flex h-[120px] items-center rounded-lg border border-[var(--monomat-border-default)] bg-[var(--monomat-page-bg)] px-[25px]">
                                 <span className="flex h-[50px] w-[50px] shrink-0 items-center justify-center rounded-lg bg-[var(--monomat-primary-light)] text-[#2B3F6C]">
                                     <Music size={24} strokeWidth={1.7} />
@@ -508,6 +571,15 @@ export function LobbyCreate() {
                             className="mt-4 rounded-lg bg-red-50 px-4 py-3 text-sm font-semibold text-red-600 ring-1 ring-red-100"
                         >
                             {errorMessage}
+                        </div>
+                    )}
+
+                    {preselectedMapErrorMessage && (
+                        <div
+                            role="alert"
+                            className="mt-4 rounded-lg bg-amber-50 px-4 py-3 text-sm font-semibold text-amber-700 ring-1 ring-amber-100"
+                        >
+                            {preselectedMapErrorMessage}
                         </div>
                     )}
 

--- a/src/pages/MapCreate.tsx
+++ b/src/pages/MapCreate.tsx
@@ -18,15 +18,13 @@ import {
     MAP_ROUTES,
 } from '../constants/map';
 import { generateUUID } from '../utils/uuid';
-import { normalizeAnswerList } from '../utils/answerNormalizer';
 import {
-    getMapCreateTiming,
-    getMapCreateTimingError,
-} from '../utils/mapCreateTiming';
+    createMapItemRequestFromSong,
+    isValidMapSongForm,
+} from '../utils/mapSongForm';
 
 import type {
     CreateMapFormState,
-    CreateMapItemRequest,
     CreateMapSongFormState,
 } from '../types/map';
 
@@ -51,53 +49,6 @@ function createInitialFormState(): CreateMapFormState {
         category: MAP_CREATE_POLICY.DEFAULT_CATEGORY,
         isPublic: MAP_CREATE_POLICY.DEFAULT_IS_PUBLIC,
         songs: [createEmptySong()],
-    };
-}
-
-function isValidSong(song: CreateMapSongFormState) {
-    const startTime = Number(song.startTime);
-    const normalizedAnswers = normalizeAnswerList(song.answers);
-    const timingError = getMapCreateTimingError(
-        song.startTime,
-        song.videoDurationSeconds,
-    );
-
-    return (
-        song.youtubeUrl.trim().length > 0 &&
-        song.youtubeUrl.trim().length <=
-            MAP_CREATE_POLICY.YOUTUBE_URL_MAX_LENGTH &&
-        song.hint.trim().length > 0 &&
-        song.hint.trim().length <= MAP_CREATE_POLICY.HINT_MAX_LENGTH &&
-        song.startTime.trim().length > 0 &&
-        Number.isInteger(startTime) &&
-        startTime >= MAP_CREATE_POLICY.MIN_START_TIME_SECONDS &&
-        timingError == null &&
-        normalizedAnswers.length >= MAP_CREATE_POLICY.MIN_ANSWER_COUNT &&
-        normalizedAnswers.length <= MAP_CREATE_POLICY.MAX_ANSWER_COUNT &&
-        normalizedAnswers.every(
-            (answer) =>
-                answer.length <= MAP_CREATE_POLICY.ANSWER_MAX_LENGTH,
-        )
-    );
-}
-
-function createMapItemRequest(
-    song: CreateMapSongFormState,
-    index: number,
-): CreateMapItemRequest {
-    const timing = getMapCreateTiming(Number(song.startTime));
-
-    return {
-        orderNum: index + 1,
-        youtubeUrl: song.youtubeUrl.trim(),
-        startTime: timing.startTime,
-        // 현재 BE 계약상 endTime은 필수다. 로비 전역 재생 시간 계약이
-        // 도입되기 전까지 고정 길이를 더해 호환 가능한 값으로 전송한다.
-        endTime: timing.endTime,
-        answers: song.answers
-            .map((answer) => answer.trim())
-            .filter(Boolean),
-        hint: song.hint.trim(),
     };
 }
 
@@ -147,7 +98,8 @@ export function MapCreate() {
         formState.title.trim().length > 0 &&
         formState.title.trim().length <=
             MAP_CREATE_POLICY.TITLE_MAX_LENGTH;
-    const registeredSongCount = formState.songs.filter(isValidSong).length;
+    const registeredSongCount =
+        formState.songs.filter(isValidMapSongForm).length;
     const hasValidSongs =
         formState.songs.length >= MAP_CREATE_POLICY.MIN_SONG_COUNT &&
         registeredSongCount === formState.songs.length;
@@ -175,10 +127,7 @@ export function MapCreate() {
 
     const updateSong = (
         songId: string,
-        field: Exclude<
-            keyof CreateMapSongFormState,
-            'id' | 'answers' | 'videoDurationSeconds'
-        >,
+        field: 'youtubeUrl' | 'hint' | 'startTime',
         value: string,
     ) => {
         setFormState((current) => ({
@@ -365,7 +314,7 @@ export function MapCreate() {
                 for (const [index, song] of formState.songs.entries()) {
                     await createMapItem(
                         createdMap.id,
-                        createMapItemRequest(song, index),
+                        createMapItemRequestFromSong(song, index + 1),
                     );
                 }
             } catch (itemError) {

--- a/src/pages/MapManage.tsx
+++ b/src/pages/MapManage.tsx
@@ -1,0 +1,707 @@
+import { useState } from 'react';
+import {
+    useMutation,
+    useQuery,
+    useQueryClient,
+} from '@tanstack/react-query';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import {
+    createMapItem,
+    deleteMapItem,
+    deleteMap,
+    getMapItems,
+    getMyMapDetail,
+    reorderMapItems,
+    updateMap,
+    updateMapItem,
+} from '../api/mapApi';
+import { NavigationBar } from '../components/common/NavigationBar';
+import { LobbyFooter } from '../components/lobby/LobbyFooter';
+import { MapDeleteConfirmModal } from '../components/map/MapDeleteConfirmModal';
+import { MapItemDetailModal } from '../components/map/MapItemDetailModal';
+import { MapManageSongList } from '../components/map/MapManageSongList';
+import { MapManageSongEditor } from '../components/map/MapManageSongEditor';
+import { MapManageSummary } from '../components/map/MapManageSummary';
+import {
+    MAP_CREATE_POLICY,
+    MAP_DELETE_CONFIRM_MODAL_COPY,
+    MAP_MANAGE_PAGE_COPY,
+    MAP_ROUTES,
+} from '../constants/map';
+import {
+    LOBBY_QUERY_PARAMS,
+    LOBBY_ROUTES,
+} from '../constants/lobby';
+
+import type {
+    CreateMapItemRequest,
+    MapDetailResponse,
+    MapItemResponse,
+    ManageMapSongFormState,
+    UpdateMapRequest,
+} from '../types/map';
+import { generateUUID } from '../utils/uuid';
+import {
+    createMapItemRequestFromSong,
+    isValidMapSongForm,
+} from '../utils/mapSongForm';
+
+function getErrorMessage(error: unknown, fallbackMessage: string) {
+    if (error instanceof Error && error.message) {
+        return error.message;
+    }
+
+    return fallbackMessage;
+}
+
+interface SaveMapManageChanges {
+    mapRequest: UpdateMapRequest;
+    songs: ManageMapSongFormState[];
+}
+
+function createManageSongForm(
+    item: MapItemResponse,
+): ManageMapSongFormState {
+    return {
+        id: `map-item-${item.id}`,
+        itemId: item.id,
+        youtubeUrl: item.youtubeUrl,
+        hint: item.hint,
+        startTime: String(item.startTime),
+        videoDurationSeconds: null,
+        answers: [...item.answers],
+        hintTime: item.hintTime,
+        playDurationSeconds: Math.max(1, item.endTime - item.startTime),
+    };
+}
+
+function createEmptyManageSong(): ManageMapSongFormState {
+    return {
+        id: generateUUID(),
+        itemId: null,
+        youtubeUrl: '',
+        hint: '',
+        startTime: '',
+        videoDurationSeconds: null,
+        answers: [''],
+        hintTime: null,
+        playDurationSeconds:
+            MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS,
+    };
+}
+
+function hasMapItemChanges(
+    item: MapItemResponse,
+    request: CreateMapItemRequest,
+) {
+    return (
+        item.youtubeUrl !== request.youtubeUrl ||
+        item.startTime !== request.startTime ||
+        item.endTime !== request.endTime ||
+        item.hint !== request.hint ||
+        item.hintTime !== (request.hintTime ?? item.hintTime) ||
+        item.answers.length !== request.answers.length ||
+        item.answers.some(
+            (answer, index) => answer !== request.answers[index],
+        )
+    );
+}
+
+async function synchronizeMapItems(
+    mapId: number,
+    originalItems: MapItemResponse[],
+    songs: ManageMapSongFormState[],
+    onApplied: () => void,
+) {
+    const retainedItemIds = new Set(
+        songs.flatMap((song) => song.itemId == null ? [] : [song.itemId]),
+    );
+    const deletedItems = originalItems.filter(
+        (item) => !retainedItemIds.has(item.id),
+    );
+
+    for (const item of deletedItems) {
+        await deleteMapItem(mapId, item.id);
+        onApplied();
+    }
+
+    const existingSongs = songs.filter(
+        (song): song is ManageMapSongFormState & { itemId: number } =>
+            song.itemId != null,
+    );
+    const existingItemIds = existingSongs.map((song) => song.itemId);
+    const originalItemsById = new Map(
+        originalItems.map((item) => [item.id, item]),
+    );
+
+    if (existingItemIds.length > 0) {
+        await reorderMapItems(mapId, { itemIds: existingItemIds });
+        onApplied();
+    }
+
+    for (const [index, song] of existingSongs.entries()) {
+        const originalItem = originalItemsById.get(song.itemId);
+        const request = createMapItemRequestFromSong(song, index + 1);
+
+        if (
+            originalItem &&
+            !hasMapItemChanges(originalItem, request)
+        ) {
+            continue;
+        }
+
+        await updateMapItem(
+            mapId,
+            song.itemId,
+            request,
+        );
+        onApplied();
+    }
+
+    const createdItemIds = new Map<string, number>();
+    const newSongs = songs.filter((song) => song.itemId == null);
+
+    for (const [index, song] of newSongs.entries()) {
+        const createdItem = await createMapItem(
+            mapId,
+            createMapItemRequestFromSong(
+                song,
+                existingSongs.length + index + 1,
+            ),
+        );
+        createdItemIds.set(song.id, createdItem.id);
+        onApplied();
+    }
+
+    const finalItemIds = songs.map((song) => {
+        const itemId = song.itemId ?? createdItemIds.get(song.id);
+
+        if (itemId == null) {
+            throw new Error('저장된 곡 ID를 확인할 수 없습니다.');
+        }
+
+        return itemId;
+    });
+
+    await reorderMapItems(mapId, { itemIds: finalItemIds });
+    onApplied();
+}
+
+function MapManageLoadingCard({ message }: { message: string }) {
+    return (
+        <div className="flex min-h-[180px] items-center justify-center rounded-2xl bg-white px-6 text-sm font-medium text-[var(--monomat-text-muted)] shadow-[0_4px_16px_rgba(0,0,0,0.18)]">
+            <span className="animate-pulse">{message}</span>
+        </div>
+    );
+}
+
+function MapManageErrorCard({
+    title,
+    error,
+    onRetry,
+}: {
+    title: string;
+    error: unknown;
+    onRetry: () => void;
+}) {
+    return (
+        <div className="flex min-h-[180px] flex-col items-center justify-center rounded-2xl bg-white px-6 text-center shadow-[0_4px_16px_rgba(0,0,0,0.18)]">
+            <p className="text-base font-bold text-[var(--monomat-text-strong)]">
+                {title}
+            </p>
+            <p className="mt-2 max-w-[520px] text-sm text-[var(--monomat-text-muted)]">
+                {getErrorMessage(error, title)}
+            </p>
+            <button
+                type="button"
+                onClick={onRetry}
+                className="mt-5 h-9 rounded-lg bg-[var(--monomat-primary)] px-5 text-sm font-bold text-white transition hover:bg-[var(--monomat-primary-hover)]"
+            >
+                {MAP_MANAGE_PAGE_COPY.RETRY}
+            </button>
+        </div>
+    );
+}
+
+export function MapManage() {
+    const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    const { mapId: mapIdParam } = useParams();
+    const parsedMapId = Number(mapIdParam);
+    const isValidMapId =
+        Number.isInteger(parsedMapId) && parsedMapId > 0;
+    const mapId = isValidMapId ? parsedMapId : 0;
+
+    const [selectedItem, setSelectedItem] =
+        useState<MapItemResponse | null>(null);
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+    const [deleteErrorMessage, setDeleteErrorMessage] =
+        useState<string | null>(null);
+    const [isEditing, setIsEditing] = useState(false);
+    const [editSongs, setEditSongs] =
+        useState<ManageMapSongFormState[]>([]);
+    const [songEditErrorMessage, setSongEditErrorMessage] =
+        useState<string | null>(null);
+
+    const mapDetailQuery = useQuery<MapDetailResponse>({
+        queryKey: ['myMapDetail', mapId],
+        queryFn: () => getMyMapDetail(mapId),
+        enabled: isValidMapId,
+    });
+    const mapItemsQuery = useQuery<MapItemResponse[]>({
+        queryKey: ['mapItems', mapId],
+        queryFn: () => getMapItems(mapId),
+        enabled: isValidMapId,
+    });
+
+    const updateMapMutation = useMutation({
+        mutationFn: async ({
+            mapRequest,
+            songs,
+        }: SaveMapManageChanges) => {
+            let hasAppliedChange = false;
+
+            try {
+                await synchronizeMapItems(
+                    mapId,
+                    mapItemsQuery.data ?? [],
+                    songs,
+                    () => {
+                        hasAppliedChange = true;
+                    },
+                );
+                const updatedMap = await updateMap(mapId, mapRequest);
+                hasAppliedChange = true;
+
+                return updatedMap;
+            } catch (error) {
+                const message = getErrorMessage(
+                    error,
+                    MAP_MANAGE_PAGE_COPY.UPDATE_ERROR,
+                );
+
+                if (hasAppliedChange) {
+                    throw new Error(
+                        `${MAP_MANAGE_PAGE_COPY.UPDATE_PARTIAL_ERROR} ${message}`,
+                    );
+                }
+
+                throw error;
+            }
+        },
+        onSuccess: async (updatedMap) => {
+            queryClient.setQueryData(
+                ['myMapDetail', mapId],
+                updatedMap,
+            );
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: ['myMapDetail', mapId],
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: ['myMaps'],
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: ['mapItems', mapId],
+                }),
+            ]);
+        },
+        onError: async () => {
+            await Promise.all([
+                queryClient.invalidateQueries({
+                    queryKey: ['myMapDetail', mapId],
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: ['myMaps'],
+                }),
+                queryClient.invalidateQueries({
+                    queryKey: ['mapItems', mapId],
+                }),
+            ]);
+        },
+    });
+
+    const deleteMapMutation = useMutation({
+        mutationFn: () => deleteMap(mapId),
+        onMutate: () => {
+            setDeleteErrorMessage(null);
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({
+                queryKey: ['myMaps'],
+            });
+            queryClient.removeQueries({
+                queryKey: ['myMapDetail', mapId],
+            });
+            queryClient.removeQueries({
+                queryKey: ['mapItems', mapId],
+            });
+            navigate(MAP_ROUTES.MY_MAPS, { replace: true });
+        },
+        onError: (error) => {
+            setDeleteErrorMessage(
+                getErrorMessage(
+                    error,
+                    MAP_DELETE_CONFIRM_MODAL_COPY.ERROR_FALLBACK,
+                ),
+            );
+        },
+    });
+
+    const handleCreateLobby = () => {
+        const searchParams = new URLSearchParams({
+            [LOBBY_QUERY_PARAMS.MAP_ID]: String(mapId),
+        });
+
+        navigate(`${LOBBY_ROUTES.CREATE_LOBBY}?${searchParams.toString()}`);
+    };
+
+    const handleSave = async (request: UpdateMapRequest) => {
+        setSongEditErrorMessage(null);
+
+        if (editSongs.length < MAP_CREATE_POLICY.MIN_SONG_COUNT) {
+            setSongEditErrorMessage(
+                MAP_MANAGE_PAGE_COPY.EDIT_EMPTY_SONG_ERROR,
+            );
+            throw new Error(MAP_MANAGE_PAGE_COPY.EDIT_EMPTY_SONG_ERROR);
+        }
+
+        if (!editSongs.every(isValidMapSongForm)) {
+            setSongEditErrorMessage(
+                MAP_MANAGE_PAGE_COPY.EDIT_INVALID_SONG_ERROR,
+            );
+            throw new Error(MAP_MANAGE_PAGE_COPY.EDIT_INVALID_SONG_ERROR);
+        }
+
+        await updateMapMutation.mutateAsync({
+            mapRequest: request,
+            songs: editSongs,
+        });
+    };
+
+    const handleEditingChange = (nextIsEditing: boolean) => {
+        updateMapMutation.reset();
+        setSongEditErrorMessage(null);
+        setIsEditing(nextIsEditing);
+
+        if (nextIsEditing) {
+            const items = [...(mapItemsQuery.data ?? [])].sort(
+                (first, second) => first.orderNum - second.orderNum,
+            );
+            setEditSongs(items.map(createManageSongForm));
+        } else {
+            setEditSongs([]);
+        }
+    };
+
+    const updateEditSong = (
+        songId: string,
+        field: 'youtubeUrl' | 'hint' | 'startTime',
+        value: string,
+    ) => {
+        setEditSongs((current) =>
+            current.map((song) =>
+                song.id === songId
+                    ? {
+                        ...song,
+                        [field]: value,
+                        ...(field === 'youtubeUrl'
+                            ? { videoDurationSeconds: null }
+                            : {}),
+                    }
+                    : song,
+            ),
+        );
+        setSongEditErrorMessage(null);
+    };
+
+    const updateEditSongDuration = (
+        songId: string,
+        videoDurationSeconds: number | null,
+    ) => {
+        setEditSongs((current) =>
+            current.map((song) =>
+                song.id === songId
+                    ? { ...song, videoDurationSeconds }
+                    : song,
+            ),
+        );
+    };
+
+    const updateEditAnswer = (
+        songId: string,
+        answerIndex: number,
+        value: string,
+    ) => {
+        setEditSongs((current) =>
+            current.map((song) =>
+                song.id === songId
+                    ? {
+                        ...song,
+                        answers: song.answers.map((answer, index) =>
+                            index === answerIndex ? value : answer,
+                        ),
+                    }
+                    : song,
+            ),
+        );
+        setSongEditErrorMessage(null);
+    };
+
+    const addEditSong = () => {
+        setEditSongs((current) =>
+            current.length >= MAP_CREATE_POLICY.MAX_SONG_COUNT
+                ? current
+                : [...current, createEmptyManageSong()],
+        );
+        setSongEditErrorMessage(null);
+    };
+
+    const deleteEditSong = (songId: string) => {
+        setEditSongs((current) =>
+            current.length <= MAP_CREATE_POLICY.MIN_SONG_COUNT
+                ? current
+                : current.filter((song) => song.id !== songId),
+        );
+        setSongEditErrorMessage(null);
+    };
+
+    const moveEditSong = (songId: string, direction: -1 | 1) => {
+        setEditSongs((current) => {
+            const currentIndex = current.findIndex(
+                (song) => song.id === songId,
+            );
+            const targetIndex = currentIndex + direction;
+
+            if (
+                currentIndex < 0 ||
+                targetIndex < 0 ||
+                targetIndex >= current.length
+            ) {
+                return current;
+            }
+
+            const nextSongs = [...current];
+            [nextSongs[currentIndex], nextSongs[targetIndex]] = [
+                nextSongs[targetIndex],
+                nextSongs[currentIndex],
+            ];
+
+            return nextSongs;
+        });
+        setSongEditErrorMessage(null);
+    };
+
+    const addEditAnswer = (songId: string) => {
+        setEditSongs((current) =>
+            current.map((song) =>
+                song.id === songId &&
+                song.answers.length < MAP_CREATE_POLICY.MAX_ANSWER_COUNT
+                    ? { ...song, answers: [...song.answers, ''] }
+                    : song,
+            ),
+        );
+        setSongEditErrorMessage(null);
+    };
+
+    const deleteEditAnswer = (
+        songId: string,
+        answerIndex: number,
+    ) => {
+        setEditSongs((current) =>
+            current.map((song) =>
+                song.id === songId &&
+                song.answers.length >
+                    MAP_CREATE_POLICY.MIN_ANSWER_COUNT
+                    ? {
+                        ...song,
+                        answers: song.answers.filter(
+                            (_, index) => index !== answerIndex,
+                        ),
+                    }
+                    : song,
+            ),
+        );
+        setSongEditErrorMessage(null);
+    };
+
+    const handleDeleteClick = () => {
+        if (deleteMapMutation.isPending) {
+            return;
+        }
+
+        setDeleteErrorMessage(null);
+        setIsDeleteModalOpen(true);
+    };
+
+    const handleDeleteModalClose = () => {
+        if (deleteMapMutation.isPending) {
+            return;
+        }
+
+        setDeleteErrorMessage(null);
+        setIsDeleteModalOpen(false);
+    };
+
+    if (!isValidMapId) {
+        return (
+            <div className="flex min-h-screen flex-col bg-[var(--monomat-page-bg)] text-left">
+                <NavigationBar />
+                <main className="mx-auto flex w-full max-w-[950px] flex-1 items-center px-6 py-10">
+                    <div className="w-full rounded-2xl bg-white px-8 py-12 text-center shadow-[0_4px_16px_rgba(0,0,0,0.18)]">
+                        <h1 className="!m-0 !text-2xl !font-extrabold !text-[var(--monomat-text-strong)]">
+                            {MAP_MANAGE_PAGE_COPY.INVALID_MAP_ID_TITLE}
+                        </h1>
+                        <p className="mt-3 text-sm text-[var(--monomat-text-muted)]">
+                            {
+                                MAP_MANAGE_PAGE_COPY.INVALID_MAP_ID_DESCRIPTION
+                            }
+                        </p>
+                        <button
+                            type="button"
+                            onClick={() => navigate(MAP_ROUTES.MY_MAPS)}
+                            className="mt-6 h-10 rounded-lg bg-[var(--monomat-primary)] px-5 text-sm font-bold text-white transition hover:bg-[var(--monomat-primary-hover)]"
+                        >
+                            {MAP_MANAGE_PAGE_COPY.BACK_TO_MAPS}
+                        </button>
+                    </div>
+                </main>
+                <LobbyFooter />
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex min-h-screen flex-col bg-[var(--monomat-page-bg)] text-left text-[var(--monomat-text-strong)]">
+            <NavigationBar />
+
+            <main className="mx-auto w-full max-w-[1440px] flex-1 px-4 pb-16 pt-[30px] sm:px-6 lg:px-8 xl:px-10">
+                <div className="mx-auto w-full max-w-[950px]">
+                    <button
+                        type="button"
+                        onClick={() => navigate(MAP_ROUTES.MY_MAPS)}
+                        className="h-[30px] text-base font-semibold text-[var(--monomat-text-muted)] transition hover:text-[var(--monomat-text-strong)]"
+                    >
+                        {MAP_MANAGE_PAGE_COPY.BACK_TO_MAPS}
+                    </button>
+
+                    <div className="mt-[15px]">
+                        {mapDetailQuery.isLoading ? (
+                            <MapManageLoadingCard
+                                message={
+                                    MAP_MANAGE_PAGE_COPY.SUMMARY_LOADING
+                                }
+                            />
+                        ) : mapDetailQuery.isError ? (
+                            <MapManageErrorCard
+                                title={
+                                    MAP_MANAGE_PAGE_COPY.SUMMARY_ERROR_TITLE
+                                }
+                                error={mapDetailQuery.error}
+                                onRetry={() => void mapDetailQuery.refetch()}
+                            />
+                        ) : mapDetailQuery.data ? (
+                            <MapManageSummary
+                                map={mapDetailQuery.data}
+                                isUpdating={updateMapMutation.isPending}
+                                updateErrorMessage={
+                                    songEditErrorMessage ??
+                                    (updateMapMutation.isError
+                                        ? getErrorMessage(
+                                            updateMapMutation.error,
+                                            MAP_MANAGE_PAGE_COPY.UPDATE_ERROR,
+                                        )
+                                        : null)
+                                }
+                                onCreateLobby={handleCreateLobby}
+                                onDelete={handleDeleteClick}
+                                onSave={handleSave}
+                                onEditingChange={handleEditingChange}
+                                isEditDisabled={
+                                    mapItemsQuery.isLoading ||
+                                    mapItemsQuery.isError
+                                }
+                                editContent={
+                                    <MapManageSongEditor
+                                        songs={editSongs}
+                                        disabled={
+                                            updateMapMutation.isPending
+                                        }
+                                        onAddSong={addEditSong}
+                                        onChange={updateEditSong}
+                                        onAnswerChange={updateEditAnswer}
+                                        onDurationChange={
+                                            updateEditSongDuration
+                                        }
+                                        onAddAnswer={addEditAnswer}
+                                        onDeleteAnswer={deleteEditAnswer}
+                                        onDeleteSong={deleteEditSong}
+                                        onMoveUp={(songId) =>
+                                            moveEditSong(songId, -1)
+                                        }
+                                        onMoveDown={(songId) =>
+                                            moveEditSong(songId, 1)
+                                        }
+                                    />
+                                }
+                            />
+                        ) : null}
+                    </div>
+
+                    {!isEditing && (
+                        <>
+                            <h2 className="!mb-0 !mt-[27px] !text-lg !font-bold !leading-[21px] !text-black">
+                                {MAP_MANAGE_PAGE_COPY.SONG_LIST_TITLE}
+                            </h2>
+
+                            <div className="mt-[11px]">
+                                {mapItemsQuery.isLoading ? (
+                                    <MapManageLoadingCard
+                                        message={
+                                            MAP_MANAGE_PAGE_COPY.ITEMS_LOADING
+                                        }
+                                    />
+                                ) : mapItemsQuery.isError ? (
+                                    <MapManageErrorCard
+                                        title={
+                                            MAP_MANAGE_PAGE_COPY.ITEMS_ERROR_TITLE
+                                        }
+                                        error={mapItemsQuery.error}
+                                        onRetry={() =>
+                                            void mapItemsQuery.refetch()
+                                        }
+                                    />
+                                ) : (
+                                    <MapManageSongList
+                                        items={mapItemsQuery.data ?? []}
+                                        onItemClick={setSelectedItem}
+                                    />
+                                )}
+                            </div>
+                        </>
+                    )}
+                </div>
+            </main>
+
+            <LobbyFooter />
+
+            {selectedItem && (
+                <MapItemDetailModal
+                    item={selectedItem}
+                    onClose={() => setSelectedItem(null)}
+                />
+            )}
+
+            {isDeleteModalOpen && mapDetailQuery.data && (
+                <MapDeleteConfirmModal
+                    mapTitle={mapDetailQuery.data.title}
+                    isDeleting={deleteMapMutation.isPending}
+                    errorMessage={deleteErrorMessage}
+                    onCancel={handleDeleteModalClose}
+                    onConfirm={() => deleteMapMutation.mutate()}
+                />
+            )}
+        </div>
+    );
+}

--- a/src/pages/MyMaps.tsx
+++ b/src/pages/MyMaps.tsx
@@ -139,9 +139,11 @@ function MyMapIcon() {
 
 function MyMapRow({
     map,
+    onEditClick,
     onDeleteClick,
 }: {
     map: MapSummary;
+    onEditClick: (map: MapSummary) => void;
     onDeleteClick: (map: MapSummary) => void;
 }) {
     const [isDescriptionOpen, setIsDescriptionOpen] = useState(false);
@@ -211,6 +213,7 @@ function MyMapRow({
                 <div className="flex items-center gap-[10px]">
                     <button
                         type="button"
+                        onClick={() => onEditClick(map)}
                         className="flex h-[30px] w-[30px] items-center justify-center rounded-lg border border-[color:var(--monomat-border-input)] bg-white text-[#2B3F6C] transition hover:bg-[var(--monomat-page-bg)]"
                         aria-label={MY_MAPS_PAGE_COPY.EDIT_ARIA_LABEL}
                         title={MY_MAPS_PAGE_COPY.EDIT_ARIA_LABEL}
@@ -463,6 +466,10 @@ export function MyMaps() {
         setDeleteErrorMessage(null);
     };
 
+    const handleEditClick = (map: MapSummary) => {
+        navigate(MAP_ROUTES.MANAGE_MAP(map.mapId));
+    };
+
     const handleCloseDeleteModal = () => {
         if (deleteMapMutation.isPending) {
             return;
@@ -565,6 +572,7 @@ export function MyMaps() {
                                     <MyMapRow
                                         key={map.mapId}
                                         map={map}
+                                        onEditClick={handleEditClick}
                                         onDeleteClick={handleDeleteClick}
                                     />
                                 ))}

--- a/src/schemas/mapSchema.ts
+++ b/src/schemas/mapSchema.ts
@@ -55,7 +55,7 @@ export const mapItemResponseSchema = z.object({
     mapId: z.number().int().positive(),
     orderNum: z.number().int().positive(),
     youtubeUrl: z.string().min(1),
-    videoId: z.string().min(1),
+    videoId: z.string().min(1).nullable(),
     startTime: z.number().int().min(0),
     endTime: z.number().int().positive(),
     title: z.string().nullable(),
@@ -67,3 +67,5 @@ export const mapItemResponseSchema = z.object({
     createdAt: z.string().min(1),
     updatedAt: z.string().min(1),
 });
+
+export const mapItemListResponseSchema = z.array(mapItemResponseSchema);

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -46,6 +46,13 @@ export interface CreateMapRequest {
     isPublic: boolean;
 }
 
+export interface UpdateMapRequest {
+    title: string;
+    description: string | null;
+    category: MapCategory;
+    isPublic: boolean;
+}
+
 export interface CreateMapItemRequest {
     orderNum: number;
     youtubeUrl: string;
@@ -54,6 +61,12 @@ export interface CreateMapItemRequest {
     answers: string[];
     hint: string;
     hintTime?: number | null;
+}
+
+export type UpdateMapItemRequest = CreateMapItemRequest;
+
+export interface ReorderMapItemsRequest {
+    itemIds: number[];
 }
 
 export interface MapDetailResponse {
@@ -77,7 +90,7 @@ export interface MapItemResponse {
     mapId: number;
     orderNum: number;
     youtubeUrl: string;
-    videoId: string;
+    videoId: string | null;
     startTime: number;
     endTime: number;
     title: string | null;
@@ -97,6 +110,12 @@ export interface CreateMapSongFormState {
     startTime: string;
     videoDurationSeconds: number | null;
     answers: string[];
+    hintTime?: number | null;
+    playDurationSeconds?: number | null;
+}
+
+export interface ManageMapSongFormState extends CreateMapSongFormState {
+    itemId: number | null;
 }
 
 export interface CreateMapFormState {

--- a/src/utils/mapCreateTiming.ts
+++ b/src/utils/mapCreateTiming.ts
@@ -5,18 +5,27 @@ export interface MapCreateTiming {
     endTime: number;
 }
 
-export function getMapCreateTiming(startTime: number): MapCreateTiming {
+export function getMapCreateTiming(
+    startTime: number,
+    playDurationSeconds: number =
+        MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS,
+): MapCreateTiming {
+    const normalizedPlayDuration =
+        Number.isInteger(playDurationSeconds) && playDurationSeconds > 0
+            ? playDurationSeconds
+            : MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS;
+
     return {
         startTime,
-        endTime:
-            startTime +
-            MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS,
+        endTime: startTime + normalizedPlayDuration,
     };
 }
 
 export function getMapCreateTimingError(
     rawStartTime: string,
     videoDurationSeconds: number | null,
+    playDurationSeconds: number =
+        MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS,
 ) {
     // 사용자 입력 단계의 UX 검증이며 최종 무결성은 BE 검증을 따른다.
     if (!rawStartTime.trim()) {
@@ -32,7 +41,7 @@ export function getMapCreateTimingError(
         return '시작 시간은 0 이상의 정수로 입력해주세요.';
     }
 
-    const timing = getMapCreateTiming(startTime);
+    const timing = getMapCreateTiming(startTime, playDurationSeconds);
 
     if (timing.endTime <= timing.startTime) {
         return '종료 시간은 시작 시간보다 커야 합니다.';
@@ -55,11 +64,11 @@ export function getMapCreateTimingError(
             MAP_CREATE_POLICY.MIN_START_TIME_SECONDS,
             Math.floor(
                 videoDurationSeconds -
-                    MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS,
+                    playDurationSeconds,
             ),
         );
 
-        return `현재 ${MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS}초 재생 구간이 영상 길이를 넘습니다. 시작 시간을 ${latestStartTime}초 이하로 입력해주세요.`;
+        return `현재 ${playDurationSeconds}초 재생 구간이 영상 길이를 넘습니다. 시작 시간을 ${latestStartTime}초 이하로 입력해주세요.`;
     }
 
     return null;

--- a/src/utils/mapFormat.ts
+++ b/src/utils/mapFormat.ts
@@ -37,3 +37,71 @@ export function formatMapOwnerNickname(
 
     return trimmedNickname || '알 수 없는 제작자';
 }
+
+export function formatMapSongCount(songCount: number) {
+    const safeSongCount = Math.max(0, Math.floor(songCount));
+
+    return `${safeSongCount.toLocaleString('ko-KR')}곡`;
+}
+
+export function formatMapStartTime(startTime: number) {
+    const safeSeconds = Math.max(0, Math.floor(startTime));
+    const minutes = Math.floor(safeSeconds / 60);
+    const seconds = safeSeconds % 60;
+
+    return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
+export function formatMapAnswerCount(answerCount: number) {
+    const safeAnswerCount = Math.max(0, Math.floor(answerCount));
+
+    return `+${safeAnswerCount} 정답`;
+}
+
+export function formatMapUpdatedAt(updatedAt: string) {
+    const timestamp = new Date(updatedAt).getTime();
+
+    if (!Number.isFinite(timestamp)) {
+        return '-';
+    }
+
+    const elapsedSeconds = Math.round((timestamp - Date.now()) / 1_000);
+    const absoluteSeconds = Math.abs(elapsedSeconds);
+    const relativeTimeFormatter = new Intl.RelativeTimeFormat('ko-KR', {
+        numeric: 'auto',
+    });
+
+    if (absoluteSeconds < 60) {
+        return relativeTimeFormatter.format(elapsedSeconds, 'second');
+    }
+
+    const elapsedMinutes = Math.round(elapsedSeconds / 60);
+    if (Math.abs(elapsedMinutes) < 60) {
+        return relativeTimeFormatter.format(elapsedMinutes, 'minute');
+    }
+
+    const elapsedHours = Math.round(elapsedMinutes / 60);
+    if (Math.abs(elapsedHours) < 24) {
+        return relativeTimeFormatter.format(elapsedHours, 'hour');
+    }
+
+    const elapsedDays = Math.round(elapsedHours / 24);
+    if (Math.abs(elapsedDays) < 7) {
+        return relativeTimeFormatter.format(elapsedDays, 'day');
+    }
+
+    const elapsedWeeks = Math.round(elapsedDays / 7);
+    if (Math.abs(elapsedWeeks) < 5) {
+        return relativeTimeFormatter.format(elapsedWeeks, 'week');
+    }
+
+    const elapsedMonths = Math.round(elapsedDays / 30);
+    if (Math.abs(elapsedMonths) < 12) {
+        return relativeTimeFormatter.format(elapsedMonths, 'month');
+    }
+
+    return relativeTimeFormatter.format(
+        Math.round(elapsedDays / 365),
+        'year',
+    );
+}

--- a/src/utils/mapSongForm.ts
+++ b/src/utils/mapSongForm.ts
@@ -1,0 +1,63 @@
+import { MAP_CREATE_POLICY } from '../constants/map';
+import { normalizeAnswerList } from './answerNormalizer';
+import {
+    getMapCreateTiming,
+    getMapCreateTimingError,
+} from './mapCreateTiming';
+
+import type {
+    CreateMapItemRequest,
+    CreateMapSongFormState,
+} from '../types/map';
+
+export function isValidMapSongForm(song: CreateMapSongFormState) {
+    const startTime = Number(song.startTime);
+    const normalizedAnswers = normalizeAnswerList(song.answers);
+    const timingError = getMapCreateTimingError(
+        song.startTime,
+        song.videoDurationSeconds,
+        song.playDurationSeconds ??
+            MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS,
+    );
+
+    return (
+        song.youtubeUrl.trim().length > 0 &&
+        song.youtubeUrl.trim().length <=
+            MAP_CREATE_POLICY.YOUTUBE_URL_MAX_LENGTH &&
+        song.hint.trim().length > 0 &&
+        song.hint.trim().length <= MAP_CREATE_POLICY.HINT_MAX_LENGTH &&
+        song.startTime.trim().length > 0 &&
+        Number.isInteger(startTime) &&
+        startTime >= MAP_CREATE_POLICY.MIN_START_TIME_SECONDS &&
+        timingError == null &&
+        normalizedAnswers.length >= MAP_CREATE_POLICY.MIN_ANSWER_COUNT &&
+        normalizedAnswers.length <= MAP_CREATE_POLICY.MAX_ANSWER_COUNT &&
+        normalizedAnswers.every(
+            (answer) =>
+                answer.length <= MAP_CREATE_POLICY.ANSWER_MAX_LENGTH,
+        )
+    );
+}
+
+export function createMapItemRequestFromSong(
+    song: CreateMapSongFormState,
+    orderNum: number,
+): CreateMapItemRequest {
+    const timing = getMapCreateTiming(
+        Number(song.startTime),
+        song.playDurationSeconds ??
+            MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS,
+    );
+
+    return {
+        orderNum,
+        youtubeUrl: song.youtubeUrl.trim(),
+        startTime: timing.startTime,
+        endTime: timing.endTime,
+        answers: song.answers
+            .map((answer) => answer.trim())
+            .filter(Boolean),
+        hint: song.hint.trim(),
+        hintTime: song.hintTime ?? undefined,
+    };
+}


### PR DESCRIPTION
## 📣 Related Issue

- #89

## 📝 Summary

- 내 맵 관리 상세 페이지를 구현했습니다.
- 맵 제목, 설명, 카테고리, 공개 여부 수정 기능을 추가했습니다.
- 곡 입력, 추가, 삭제, 정답 수정 및 순서 재정렬 기능을 구현했습니다.
- 곡 상세 정보 확인 모달을 추가했습니다.
- 곡 목록 제목에 첫 번째 정답 후보가 표시되도록 적용했습니다.
- 선택한 맵으로 로비 생성 페이지에 진입하는 기능을 추가했습니다.
- `mapId` query param이 있으면 내 맵 단건 조회 API로 맵을 사전 선택합니다.
- 수정 및 삭제 후 관련 React Query 캐시를 갱신하도록 처리했습니다.

## 🙏PR point

- 비공개 맵도 선택할 수 있도록 맵 관리와 로비 사전 선택에서 `GET /api/maps/me/{mapId}`를 사용합니다.
- 곡 수정 시 삭제, 기존 곡 재정렬, 수정 및 추가, 전체 재정렬 순서로 API를 호출합니다.
- 곡의 기존 재생 시간과 힌트 노출 시점은 수정 과정에서도 유지됩니다.
- 일부 API만 성공한 경우 서버 상태와 화면 상태가 달라질 수 있어 경고 메시지를 표시하고 데이터를 다시 조회합니다.
- 기존 로비 생성 API 계약은 변경하지 않았습니다.
- `npm run lint`, `npm run build`를 통과했습니다.

## 📬 Reference

- BE `develop` 브랜치의 맵 수정 및 맵 아이템 API 계약

