### PR TITLE
[Fix/#91] 맵 곡 표시명을 대표 정답으로 통일

### DIFF
--- a/src/components/map/MapCreateSongCard.tsx
+++ b/src/components/map/MapCreateSongCard.tsx
@@ -23,6 +23,7 @@ import {
     normalizeAnswerList,
 } from '../../utils/answerNormalizer';
 import { getMapCreateTimingError } from '../../utils/mapCreateTiming';
+import { getMapItemDisplayTitle } from '../../utils/mapFormat';
 
 import type { CreateMapSongFormState } from '../../types/map';
 import type { YouTubeIframePlayer } from '../../utils/youtube';
@@ -85,8 +86,10 @@ export function MapCreateSongCard({
     const [playingVideoId, setPlayingVideoId] = useState<string | null>(null);
     const onDurationChangeRef = useRef(onDurationChange);
     const songNumber = String(index + 1).padStart(2, '0');
-    const songTitle =
-        song.answers[0]?.trim() || MAP_CREATE_SONG_COPY.TITLE;
+    const songTitle = getMapItemDisplayTitle(
+        song.answers,
+        MAP_CREATE_SONG_COPY.TITLE,
+    );
     const canAddAnswer =
         song.answers.length < MAP_CREATE_POLICY.MAX_ANSWER_COUNT;
     const normalizedAnswers = normalizeAnswerList(song.answers);

--- a/src/components/map/MapItemDetailModal.tsx
+++ b/src/components/map/MapItemDetailModal.tsx
@@ -8,7 +8,10 @@ import {
     MAP_ITEM_DETAIL_MODAL_COPY,
     MAP_MANAGE_PAGE_COPY,
 } from '../../constants/map';
-import { formatMapStartTime } from '../../utils/mapFormat';
+import {
+    formatMapStartTime,
+    getMapItemDisplayTitle,
+} from '../../utils/mapFormat';
 import {
     createYouTubeEmbedUrl,
     extractYouTubeVideoId,
@@ -42,8 +45,10 @@ export function MapItemDetailModal({
         };
     }, [onClose]);
 
-    const title =
-        item.title?.trim() || MAP_MANAGE_PAGE_COPY.SONG_TITLE_FALLBACK;
+    const title = getMapItemDisplayTitle(
+        item.answers,
+        MAP_MANAGE_PAGE_COPY.SONG_TITLE_FALLBACK,
+    );
     const videoId =
         item.videoId?.trim() || extractYouTubeVideoId(item.youtubeUrl);
     const embedUrl = videoId

--- a/src/components/map/MapManageSongList.tsx
+++ b/src/components/map/MapManageSongList.tsx
@@ -4,6 +4,7 @@ import { MAP_MANAGE_PAGE_COPY } from '../../constants/map';
 import {
     formatMapAnswerCount,
     formatMapStartTime,
+    getMapItemDisplayTitle,
 } from '../../utils/mapFormat';
 
 import type { MapItemResponse } from '../../types/map';
@@ -11,12 +12,6 @@ import type { MapItemResponse } from '../../types/map';
 interface MapManageSongListProps {
     items: MapItemResponse[];
     onItemClick: (item: MapItemResponse) => void;
-}
-
-function getItemTitle(item: MapItemResponse) {
-    return (
-        item.answers[0]?.trim() || MAP_MANAGE_PAGE_COPY.SONG_TITLE_FALLBACK
-    );
 }
 
 function getItemDescription(item: MapItemResponse) {
@@ -46,7 +41,10 @@ export function MapManageSongList({
     return (
         <div className="overflow-hidden rounded-2xl bg-white shadow-[0_4px_16px_rgba(0,0,0,0.18)]">
             {sortedItems.map((item, index) => {
-                const title = getItemTitle(item);
+                const title = getMapItemDisplayTitle(
+                    item.answers,
+                    MAP_MANAGE_PAGE_COPY.SONG_TITLE_FALLBACK,
+                );
 
                 return (
                     <button

--- a/src/utils/mapFormat.ts
+++ b/src/utils/mapFormat.ts
@@ -58,6 +58,15 @@ export function formatMapAnswerCount(answerCount: number) {
     return `+${safeAnswerCount} 정답`;
 }
 
+export function getMapItemDisplayTitle(
+    answers: string[] | null | undefined,
+    fallback: string,
+) {
+    const primaryAnswer = answers?.[0]?.trim();
+
+    return primaryAnswer || fallback;
+}
+
 export function formatMapUpdatedAt(updatedAt: string) {
     const timestamp = new Date(updatedAt).getTime();
 


### PR DESCRIPTION
## 📣 Related Issue

- #91

## 📝 Summary

- 맵 관리 곡 목록과 상세 모달의 대표 표시명을 `answers[0]` 기준으로 통일했습니다.
- 관리 페이지 편집 카드에도 동일한 표시 정책을 적용했습니다.
- 첫 번째 정답이 없거나 빈 문자열이면 기존 fallback 문구를 표시합니다.
- 중복된 제목 계산을 `getMapItemDisplayTitle` 공통 유틸로 분리했습니다.
- YouTube 제목인 `item.title`은 대표 표시명으로 사용하지 않도록 변경했습니다.

## 🙏PR point

- 표시 우선순위는 `answers[0].trim()` 이후 fallback 문구입니다.
- 정답 후보 전체 목록, 저장 로직, API 호출 순서 및 타입/schema는 변경하지 않았습니다.
- `npm run lint`와 `npm run build`를 통과했습니다.
- lint의 MSW 미사용 directive 경고와 Vite 번들 크기 경고는 기존 경고입니다.

## 📬 Reference

