### PR TITLE
[Refactor/#93] 맵 관리 저장 API 일괄 호출로 교체

### DIFF
--- a/src/api/mapApi.ts
+++ b/src/api/mapApi.ts
@@ -1,5 +1,6 @@
 import { API_ENDPOINTS } from '../constants/endpoints';
 import {
+    manageMapResponseSchema,
     mapDetailResponseSchema,
     mapItemListResponseSchema,
     mapItemResponseSchema,
@@ -11,6 +12,8 @@ import { fetchWithAuth } from './apiClient';
 import type {
     CreateMapItemRequest,
     CreateMapRequest,
+    ManageMapRequest,
+    ManageMapResponse,
     MapDetailResponse,
     MapItemResponse,
     MapListQueryParams,
@@ -32,6 +35,8 @@ const DEFAULT_FETCH_MAP_ITEMS_ERROR_MESSAGE =
 const DEFAULT_CREATE_MAP_ERROR_MESSAGE = '맵 생성에 실패했습니다.';
 const DEFAULT_CREATE_MAP_ITEM_ERROR_MESSAGE = '곡 등록에 실패했습니다.';
 const DEFAULT_UPDATE_MAP_ERROR_MESSAGE = '맵 수정에 실패했습니다.';
+const DEFAULT_UPDATE_MANAGED_MAP_ERROR_MESSAGE =
+    '맵 정보를 수정하지 못했습니다.';
 const DEFAULT_UPDATE_MAP_ITEM_ERROR_MESSAGE = '곡 수정에 실패했습니다.';
 const DEFAULT_DELETE_MAP_ITEM_ERROR_MESSAGE = '곡 삭제에 실패했습니다.';
 const DEFAULT_REORDER_MAP_ITEMS_ERROR_MESSAGE =
@@ -218,6 +223,37 @@ export async function updateMap(
         console.error('[mapApi] 맵 수정 응답 검증 실패:', parsed.error);
 
         throw new Error('맵 수정 응답 형식이 올바르지 않습니다.');
+    }
+
+    return parsed.data;
+}
+
+export async function updateManagedMap(
+    mapId: number,
+    request: ManageMapRequest,
+): Promise<ManageMapResponse> {
+    const response = await fetchWithAuth(API_ENDPOINTS.MAP.MANAGE(mapId), {
+        method: 'PUT',
+        headers: {
+            'Content-Type': JSON_CONTENT_TYPE,
+        },
+        body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            DEFAULT_UPDATE_MANAGED_MAP_ERROR_MESSAGE,
+        );
+    }
+
+    const payload = await response.json() as unknown;
+    const parsed = manageMapResponseSchema.safeParse(payload);
+
+    if (!parsed.success) {
+        console.error('[mapApi] 맵 관리 저장 응답 검증 실패:', parsed.error);
+
+        throw new Error('맵 관리 저장 응답 형식이 올바르지 않습니다.');
     }
 
     return parsed.data;

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -60,6 +60,8 @@ export const API_ENDPOINTS = {
             createApiEndpoint(`/api/maps/${mapId}/items/${itemId}`),
         ITEM_ORDER: (mapId: number) =>
             createApiEndpoint(`/api/maps/${mapId}/items/order`),
+        MANAGE: (mapId: number) =>
+            createApiEndpoint(`/api/maps/${mapId}/manage`),
         UPDATE: (mapId: number) => createApiEndpoint(`/api/maps/${mapId}`),
         DELETE: (mapId: number) => createApiEndpoint(`/api/maps/${mapId}`),
     },

--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -217,8 +217,6 @@ export const MAP_MANAGE_PAGE_COPY = {
     PUBLIC: '공개',
     PRIVATE: '비공개',
     UPDATE_ERROR: '맵 정보를 수정하지 못했습니다.',
-    UPDATE_PARTIAL_ERROR:
-        '일부 변경만 저장되었습니다. 최신 정보를 다시 불러온 뒤 확인해주세요.',
     DESCRIPTION_FALLBACK: '맵 설명이 없습니다.',
     UPDATED_PREFIX: '업데이트',
     PLAY_SUFFIX: '플레이',

--- a/src/pages/MapManage.tsx
+++ b/src/pages/MapManage.tsx
@@ -7,14 +7,10 @@ import {
 import { useNavigate, useParams } from 'react-router-dom';
 
 import {
-    createMapItem,
-    deleteMapItem,
     deleteMap,
     getMapItems,
     getMyMapDetail,
-    reorderMapItems,
-    updateMap,
-    updateMapItem,
+    updateManagedMap,
 } from '../api/mapApi';
 import { NavigationBar } from '../components/common/NavigationBar';
 import { LobbyFooter } from '../components/lobby/LobbyFooter';
@@ -35,7 +31,7 @@ import {
 } from '../constants/lobby';
 
 import type {
-    CreateMapItemRequest,
+    ManageMapRequest,
     MapDetailResponse,
     MapItemResponse,
     ManageMapSongFormState,
@@ -91,101 +87,33 @@ function createEmptyManageSong(): ManageMapSongFormState {
     };
 }
 
-function hasMapItemChanges(
-    item: MapItemResponse,
-    request: CreateMapItemRequest,
-) {
-    return (
-        item.youtubeUrl !== request.youtubeUrl ||
-        item.startTime !== request.startTime ||
-        item.endTime !== request.endTime ||
-        item.hint !== request.hint ||
-        item.hintTime !== (request.hintTime ?? item.hintTime) ||
-        item.answers.length !== request.answers.length ||
-        item.answers.some(
-            (answer, index) => answer !== request.answers[index],
-        )
-    );
-}
-
-async function synchronizeMapItems(
-    mapId: number,
+function createManageMapRequest(
+    mapRequest: UpdateMapRequest,
     originalItems: MapItemResponse[],
     songs: ManageMapSongFormState[],
-    onApplied: () => void,
-) {
+): ManageMapRequest {
     const retainedItemIds = new Set(
         songs.flatMap((song) => song.itemId == null ? [] : [song.itemId]),
     );
-    const deletedItems = originalItems.filter(
-        (item) => !retainedItemIds.has(item.id),
-    );
 
-    for (const item of deletedItems) {
-        await deleteMapItem(mapId, item.id);
-        onApplied();
-    }
-
-    const existingSongs = songs.filter(
-        (song): song is ManageMapSongFormState & { itemId: number } =>
-            song.itemId != null,
-    );
-    const existingItemIds = existingSongs.map((song) => song.itemId);
-    const originalItemsById = new Map(
-        originalItems.map((item) => [item.id, item]),
-    );
-
-    if (existingItemIds.length > 0) {
-        await reorderMapItems(mapId, { itemIds: existingItemIds });
-        onApplied();
-    }
-
-    for (const [index, song] of existingSongs.entries()) {
-        const originalItem = originalItemsById.get(song.itemId);
-        const request = createMapItemRequestFromSong(song, index + 1);
-
-        if (
-            originalItem &&
-            !hasMapItemChanges(originalItem, request)
-        ) {
-            continue;
-        }
-
-        await updateMapItem(
-            mapId,
-            song.itemId,
-            request,
-        );
-        onApplied();
-    }
-
-    const createdItemIds = new Map<string, number>();
-    const newSongs = songs.filter((song) => song.itemId == null);
-
-    for (const [index, song] of newSongs.entries()) {
-        const createdItem = await createMapItem(
-            mapId,
-            createMapItemRequestFromSong(
+    return {
+        ...mapRequest,
+        items: songs.map((song, index) => {
+            const itemRequest = createMapItemRequestFromSong(
                 song,
-                existingSongs.length + index + 1,
-            ),
-        );
-        createdItemIds.set(song.id, createdItem.id);
-        onApplied();
-    }
+                index + 1,
+            );
 
-    const finalItemIds = songs.map((song) => {
-        const itemId = song.itemId ?? createdItemIds.get(song.id);
-
-        if (itemId == null) {
-            throw new Error('저장된 곡 ID를 확인할 수 없습니다.');
-        }
-
-        return itemId;
-    });
-
-    await reorderMapItems(mapId, { itemIds: finalItemIds });
-    onApplied();
+            return {
+                ...itemRequest,
+                id: song.itemId,
+                hintTime: itemRequest.hintTime ?? null,
+            };
+        }),
+        deletedItemIds: originalItems
+            .filter((item) => !retainedItemIds.has(item.id))
+            .map((item) => item.id),
+    };
 }
 
 function MapManageLoadingCard({ message }: { message: string }) {
@@ -256,69 +184,30 @@ export function MapManage() {
     });
 
     const updateMapMutation = useMutation({
-        mutationFn: async ({
+        mutationFn: ({
             mapRequest,
             songs,
         }: SaveMapManageChanges) => {
-            let hasAppliedChange = false;
+            const request = createManageMapRequest(
+                mapRequest,
+                mapItemsQuery.data ?? [],
+                songs,
+            );
 
-            try {
-                await synchronizeMapItems(
-                    mapId,
-                    mapItemsQuery.data ?? [],
-                    songs,
-                    () => {
-                        hasAppliedChange = true;
-                    },
-                );
-                const updatedMap = await updateMap(mapId, mapRequest);
-                hasAppliedChange = true;
-
-                return updatedMap;
-            } catch (error) {
-                const message = getErrorMessage(
-                    error,
-                    MAP_MANAGE_PAGE_COPY.UPDATE_ERROR,
-                );
-
-                if (hasAppliedChange) {
-                    throw new Error(
-                        `${MAP_MANAGE_PAGE_COPY.UPDATE_PARTIAL_ERROR} ${message}`,
-                    );
-                }
-
-                throw error;
-            }
+            return updateManagedMap(mapId, request);
         },
-        onSuccess: async (updatedMap) => {
+        onSuccess: async (response) => {
             queryClient.setQueryData(
                 ['myMapDetail', mapId],
-                updatedMap,
+                response.map,
             );
-            await Promise.all([
-                queryClient.invalidateQueries({
-                    queryKey: ['myMapDetail', mapId],
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: ['myMaps'],
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: ['mapItems', mapId],
-                }),
-            ]);
-        },
-        onError: async () => {
-            await Promise.all([
-                queryClient.invalidateQueries({
-                    queryKey: ['myMapDetail', mapId],
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: ['myMaps'],
-                }),
-                queryClient.invalidateQueries({
-                    queryKey: ['mapItems', mapId],
-                }),
-            ]);
+            queryClient.setQueryData(
+                ['mapItems', mapId],
+                response.items,
+            );
+            await queryClient.invalidateQueries({
+                queryKey: ['myMaps'],
+            });
         },
     });
 

--- a/src/schemas/mapSchema.ts
+++ b/src/schemas/mapSchema.ts
@@ -69,3 +69,8 @@ export const mapItemResponseSchema = z.object({
 });
 
 export const mapItemListResponseSchema = z.array(mapItemResponseSchema);
+
+export const manageMapResponseSchema = z.object({
+    map: mapDetailResponseSchema,
+    items: mapItemListResponseSchema,
+});

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -53,6 +53,22 @@ export interface UpdateMapRequest {
     isPublic: boolean;
 }
 
+export interface ManageMapItemRequest {
+    id: number | null;
+    orderNum: number;
+    youtubeUrl: string;
+    startTime: number;
+    endTime: number;
+    answers: string[];
+    hint: string;
+    hintTime: number | null;
+}
+
+export interface ManageMapRequest extends UpdateMapRequest {
+    items: ManageMapItemRequest[];
+    deletedItemIds: number[];
+}
+
 export interface CreateMapItemRequest {
     orderNum: number;
     youtubeUrl: string;
@@ -101,6 +117,11 @@ export interface MapItemResponse {
     hintTime: number;
     createdAt: string;
     updatedAt: string;
+}
+
+export interface ManageMapResponse {
+    map: MapDetailResponse;
+    items: MapItemResponse[];
 }
 
 export interface CreateMapSongFormState {


### PR DESCRIPTION
## 📣 Related Issue

- #93

## 📝 Summary

- `PUT /api/maps/{mapId}/manage` 일괄 저장 API를 추가했습니다.
- 일괄 저장 요청 및 응답 타입과 Zod 스키마를 추가했습니다.
- 맵 정보와 곡 생성·수정·삭제·순서 변경을 순차 처리하던 로직을 단일 API 호출로 교체했습니다.
- 활성 곡 전체를 화면 순서대로 전송하고, 삭제된 기존 곡 ID는 `deletedItemIds`로 분리했습니다.
- 저장 성공 시 맵 상세와 곡 목록 캐시를 응답값으로 갱신하고 내 맵 목록 캐시를 무효화했습니다.
- 부분 저장 감지 로직과 부분 실패 안내 문구를 제거했습니다.

## 🙏PR point

- 신규 곡은 `id: null`로 전송합니다.
- 빈 맵 설명은 기존 정책과 동일하게 `null`로 전송합니다.
- 저장 실패 시 편집 상태와 사용자 입력값을 유지하며 캐시를 다시 조회하지 않습니다.
- 기존 개별 곡 API 함수는 다른 사용처를 고려해 제거하지 않았습니다.
- `npm run lint`, `npm run build`를 통과했습니다.
- lint의 MSW 파일 경고와 build의 번들 크기 경고는 기존 경고입니다.

## 📬 Reference

- `PUT /api/maps/{mapId}/manage`