### PR TITLE
[Feat/#95] 내 맵 목록 서버 검색 필터 정렬 연동

### DIFF
--- a/src/api/mapApi.ts
+++ b/src/api/mapApi.ts
@@ -115,7 +115,7 @@ export async function getPublicMaps(
 }
 
 export async function getMyMaps(
-    params?: Pick<MapListQueryParams, 'page' | 'size'>,
+    params?: MapListQueryParams,
 ): Promise<MapPageResponse> {
     return fetchMapPage(
         createMapListUrl(API_ENDPOINTS.MAP.MY_LIST, params),

--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -15,9 +15,9 @@ export const MAP_SORT_LABELS = {
 
 export const DEFAULT_MAP_LIST_PAGE = 0;
 export const DEFAULT_MAP_LIST_SIZE = 20;
+export const DEFAULT_MAP_SORT_OPTION = 'NEWEST' as const;
 export const MAP_SELECT_MODAL_PAGE_SIZE = 5;
 export const MY_MAP_LIST_PAGE_SIZE = 10;
-export const MY_MAP_SEARCH_PAGE_SIZE = 100;
 
 export const MAP_ROUTES = {
     MY_MAPS: '/maps/me',
@@ -138,7 +138,8 @@ export const MY_MAPS_PAGE_COPY = {
     TITLE: '맵 관리',
     DESCRIPTION: '직접 만든 맵을 관리하고, 새 맵을 생성하세요',
     CREATE_MAP: '+ 새 맵 만들기',
-    SEARCH_PLACEHOLDER: '맵 제목이나 카테고리로 검색하세요',
+    SEARCH_PLACEHOLDER: '맵 제목으로 검색하세요',
+    SORT_ARIA_LABEL: '내 맵 정렬',
     MAP_TITLE: '맵 제목',
     CATEGORY: '카테고리',
     SONG_COUNT: '곡 수',

--- a/src/hooks/useMyMaps.ts
+++ b/src/hooks/useMyMaps.ts
@@ -3,19 +3,24 @@ import { useQuery } from '@tanstack/react-query';
 import { getMyMaps } from '../api/mapApi';
 import {
     DEFAULT_MAP_LIST_PAGE,
+    DEFAULT_MAP_SORT_OPTION,
     MY_MAP_LIST_PAGE_SIZE,
 } from '../constants/map';
 
-import type { MapPageResponse } from '../types/map';
+import type {
+    MapListQueryParams,
+    MapPageResponse,
+} from '../types/map';
 
-interface UseMyMapsParams {
-    page?: number;
-    size?: number;
+interface UseMyMapsParams extends MapListQueryParams {
     enabled?: boolean;
 }
 
 export function useMyMaps(params: UseMyMapsParams = {}) {
     const normalizedParams = {
+        keyword: params.keyword?.trim() || undefined,
+        category: params.category,
+        sort: params.sort ?? DEFAULT_MAP_SORT_OPTION,
         page: params.page ?? DEFAULT_MAP_LIST_PAGE,
         size: params.size ?? MY_MAP_LIST_PAGE_SIZE,
     };
@@ -23,6 +28,9 @@ export function useMyMaps(params: UseMyMapsParams = {}) {
     return useQuery<MapPageResponse>({
         queryKey: [
             'myMaps',
+            normalizedParams.keyword,
+            normalizedParams.category,
+            normalizedParams.sort,
             normalizedParams.page,
             normalizedParams.size,
         ],

--- a/src/mocks/handlers/map.ts
+++ b/src/mocks/handlers/map.ts
@@ -4,6 +4,8 @@ import { API_ENDPOINTS } from '../../constants/endpoints';
 import {
     DEFAULT_MAP_LIST_PAGE,
     DEFAULT_MAP_LIST_SIZE,
+    DEFAULT_MAP_SORT_OPTION,
+    MY_MAP_LIST_PAGE_SIZE,
 } from '../../constants/map';
 import {
     mockMyMapItems,
@@ -70,7 +72,7 @@ function filterMapItems(
     });
 }
 
-function sortMapItems(maps: MapSummary[], sortOption: MapSortOption | null) {
+function sortMapItems(maps: MapSummary[], sortOption: MapSortOption) {
     const copiedMaps = [...maps];
 
     switch (sortOption) {
@@ -88,7 +90,6 @@ function sortMapItems(maps: MapSummary[], sortOption: MapSortOption | null) {
             );
 
         case 'NEWEST':
-        default:
             return copiedMaps.sort((left, right) => right.mapId - left.mapId);
     }
 }
@@ -120,7 +121,9 @@ function createMapListResponse(
     defaultParams: Pick<MapListQueryParams, 'page' | 'size'>,
 ) {
     const sortParam = requestUrl.searchParams.get('sort');
-    const sortOption = isMapSortOption(sortParam) ? sortParam : null;
+    const sortOption = isMapSortOption(sortParam)
+        ? sortParam
+        : DEFAULT_MAP_SORT_OPTION;
     const page = parsePageParam(
         requestUrl.searchParams.get('page'),
         defaultParams.page ?? DEFAULT_MAP_LIST_PAGE,
@@ -153,18 +156,14 @@ export const mapHandlers = [
     }),
 
     http.get(API_ENDPOINTS.MAP.MY_LIST, ({ request }) => {
-        const requestUrl = new URL(request.url);
-        const page = parsePageParam(
-            requestUrl.searchParams.get('page'),
-            DEFAULT_MAP_LIST_PAGE,
-        );
-        const size = parseSizeParam(
-            requestUrl.searchParams.get('size'),
-            DEFAULT_MAP_LIST_SIZE,
-        );
-
-        return HttpResponse.json(
-            createMapPageResponse(mockMyMapItems, page, size),
+        return createMapListResponse(
+            mockMyMapItems,
+            new URL(request.url),
+            true,
+            {
+                page: DEFAULT_MAP_LIST_PAGE,
+                size: MY_MAP_LIST_PAGE_SIZE,
+            },
         );
     }),
 ];

--- a/src/pages/MyMaps.tsx
+++ b/src/pages/MyMaps.tsx
@@ -28,11 +28,14 @@ import { LobbyFooter } from '../components/lobby/LobbyFooter';
 import { MapDeleteConfirmModal } from '../components/map/MapDeleteConfirmModal';
 import {
     DEFAULT_MAP_LIST_PAGE,
+    DEFAULT_MAP_SORT_OPTION,
+    MAP_ALL_CATEGORY_FILTER,
+    MAP_CATEGORY_FILTERS,
     MAP_DELETE_CONFIRM_MODAL_COPY,
     MAP_PUBLIC_STATUS_META,
     MAP_ROUTES,
+    MAP_SORT_LABELS,
     MY_MAP_LIST_PAGE_SIZE,
-    MY_MAP_SEARCH_PAGE_SIZE,
     MY_MAPS_EMPTY_STATE_COPY,
     MY_MAPS_ERROR_COPY,
     MY_MAPS_PAGE_COPY,
@@ -44,9 +47,21 @@ import {
     formatMapPlayCount,
 } from '../utils/mapFormat';
 
-import type { MapSummary } from '../types/map';
+import type {
+    MapCategory,
+    MapSortOption,
+    MapSummary,
+} from '../types/map';
 
 const numberFormatter = new Intl.NumberFormat('ko-KR');
+
+type MyMapCategoryFilter = (typeof MAP_CATEGORY_FILTERS)[number];
+
+function toMapCategory(
+    category: MyMapCategoryFilter,
+): MapCategory | undefined {
+    return category === MAP_ALL_CATEGORY_FILTER ? undefined : category;
+}
 
 function getMapPublicStatusMeta(map: MapSummary) {
     if (map.isPublic) {
@@ -87,27 +102,6 @@ function getDeleteErrorMessage(error: unknown) {
     }
 
     return MAP_DELETE_CONFIRM_MODAL_COPY.ERROR_FALLBACK;
-}
-
-function matchesMyMapSearch(map: MapSummary, keyword: string) {
-    const normalizedKeyword = keyword.trim().toLowerCase();
-
-    if (!normalizedKeyword) {
-        return true;
-    }
-
-    const statusLabel = getMapPublicStatusMeta(map).label;
-    const searchableText = [
-        map.title,
-        map.category,
-        formatMapDescription(map.description),
-        statusLabel,
-        `${map.numOfSong}${MY_MAPS_PAGE_COPY.SONG_UNIT}`,
-    ]
-        .join(' ')
-        .toLowerCase();
-
-    return searchableText.includes(normalizedKeyword);
 }
 
 function MyMapStatusBadge({ map }: { map: MapSummary }) {
@@ -308,11 +302,11 @@ function MyMapsErrorState({
     );
 }
 
-function MyMapsEmptyState({ isSearching }: { isSearching: boolean }) {
-    const title = isSearching
+function MyMapsEmptyState({ hasActiveFilter }: { hasActiveFilter: boolean }) {
+    const title = hasActiveFilter
         ? MY_MAPS_EMPTY_STATE_COPY.SEARCH_TITLE
         : MY_MAPS_EMPTY_STATE_COPY.TITLE;
-    const description = isSearching
+    const description = hasActiveFilter
         ? MY_MAPS_EMPTY_STATE_COPY.SEARCH_DESCRIPTION
         : MY_MAPS_EMPTY_STATE_COPY.DESCRIPTION;
 
@@ -405,32 +399,31 @@ export function MyMaps() {
     const queryClient = useQueryClient();
     const [currentPage, setCurrentPage] = useState(DEFAULT_MAP_LIST_PAGE);
     const [searchKeyword, setSearchKeyword] = useState('');
+    const [selectedCategory, setSelectedCategory] =
+        useState<MyMapCategoryFilter>(MAP_ALL_CATEGORY_FILTER);
+    const [sortOption, setSortOption] =
+        useState<MapSortOption>(DEFAULT_MAP_SORT_OPTION);
     const [deleteTargetMap, setDeleteTargetMap] =
         useState<MapSummary | null>(null);
     const [deleteErrorMessage, setDeleteErrorMessage] =
         useState<string | null>(null);
     const trimmedSearchKeyword = searchKeyword.trim();
-    const isSearching = trimmedSearchKeyword.length > 0;
+    const category = toMapCategory(selectedCategory);
+    const hasActiveFilter =
+        trimmedSearchKeyword.length > 0 ||
+        selectedCategory !== MAP_ALL_CATEGORY_FILTER;
 
-    const pagedMyMapsQuery = useMyMaps({
+    const myMapsQuery = useMyMaps({
+        keyword: trimmedSearchKeyword,
+        category,
+        sort: sortOption,
         page: currentPage,
         size: MY_MAP_LIST_PAGE_SIZE,
-        enabled: !isSearching,
     });
-    const searchedMyMapsQuery = useMyMaps({
-        page: DEFAULT_MAP_LIST_PAGE,
-        size: MY_MAP_SEARCH_PAGE_SIZE,
-        enabled: isSearching,
-    });
-
-    const activeQuery = isSearching ? searchedMyMapsQuery : pagedMyMapsQuery;
-    const rawMaps = activeQuery.data?.content ?? [];
-    const maps = isSearching
-        ? rawMaps.filter((map) => matchesMyMapSearch(map, trimmedSearchKeyword))
-        : rawMaps;
-    const page = activeQuery.data?.page ?? currentPage;
-    const totalPages = activeQuery.data?.totalPages ?? 0;
-    const hasNext = activeQuery.data?.hasNext ?? false;
+    const maps = myMapsQuery.data?.content ?? [];
+    const page = myMapsQuery.data?.page ?? currentPage;
+    const totalPages = myMapsQuery.data?.totalPages ?? 0;
+    const hasNext = myMapsQuery.data?.hasNext ?? false;
 
     const deleteMapMutation = useMutation({
         mutationFn: (mapId: number) => deleteMap(mapId),
@@ -450,6 +443,16 @@ export function MyMaps() {
 
     const handleSearchKeywordChange = (event: ChangeEvent<HTMLInputElement>) => {
         setSearchKeyword(event.target.value);
+        setCurrentPage(DEFAULT_MAP_LIST_PAGE);
+    };
+
+    const handleCategoryChange = (categoryFilter: MyMapCategoryFilter) => {
+        setSelectedCategory(categoryFilter);
+        setCurrentPage(DEFAULT_MAP_LIST_PAGE);
+    };
+
+    const handleSortChange = (event: ChangeEvent<HTMLSelectElement>) => {
+        setSortOption(event.target.value as MapSortOption);
         setCurrentPage(DEFAULT_MAP_LIST_PAGE);
     };
 
@@ -530,6 +533,20 @@ export function MyMaps() {
                                 className="min-w-0 flex-1 bg-transparent text-sm text-[var(--monomat-text-strong)] outline-none placeholder:text-[var(--monomat-border-input)]"
                             />
                         </label>
+                        <select
+                            value={sortOption}
+                            onChange={handleSortChange}
+                            aria-label={MY_MAPS_PAGE_COPY.SORT_ARIA_LABEL}
+                            className="h-11 w-full shrink-0 rounded-lg border border-[color:var(--monomat-border-input)] bg-white px-4 text-sm font-medium text-[var(--monomat-text-muted)] outline-none transition focus:border-[var(--monomat-primary)] sm:w-[150px]"
+                        >
+                            {(Object.keys(MAP_SORT_LABELS) as MapSortOption[]).map(
+                                (option) => (
+                                    <option key={option} value={option}>
+                                        {MAP_SORT_LABELS[option]}
+                                    </option>
+                                ),
+                            )}
+                        </select>
                         <button
                             type="button"
                             onClick={handleCreateMapClick}
@@ -540,10 +557,32 @@ export function MyMaps() {
                         </button>
                     </div>
 
+                    <div className="mt-3 flex min-w-0 flex-wrap items-center gap-[9px]">
+                        {MAP_CATEGORY_FILTERS.map((categoryFilter) => (
+                            <button
+                                key={categoryFilter}
+                                type="button"
+                                onClick={() =>
+                                    handleCategoryChange(categoryFilter)
+                                }
+                                aria-pressed={
+                                    selectedCategory === categoryFilter
+                                }
+                                className={`h-8 shrink-0 rounded-full px-[15px] text-[13px] leading-none transition ${
+                                    selectedCategory === categoryFilter
+                                        ? 'bg-[var(--monomat-primary)] font-semibold text-white'
+                                        : 'border border-[color:var(--monomat-border-input)] bg-white font-normal text-[var(--monomat-text-muted)] hover:bg-[var(--monomat-page-bg)]'
+                                }`}
+                            >
+                                {categoryFilter}
+                            </button>
+                        ))}
+                    </div>
+
                     <div className="mt-[22px] overflow-hidden rounded-lg border border-[color:var(--monomat-border-input)] bg-white">
                         <MyMapsTableHeader />
 
-                        {activeQuery.isLoading && (
+                        {myMapsQuery.isLoading && (
                             <>
                                 {Array.from({ length: 4 }).map((_, index) => (
                                     <MyMapRowSkeleton key={index} />
@@ -551,21 +590,23 @@ export function MyMaps() {
                             </>
                         )}
 
-                        {!activeQuery.isLoading && activeQuery.isError && (
+                        {!myMapsQuery.isLoading && myMapsQuery.isError && (
                             <MyMapsErrorState
-                                error={activeQuery.error}
-                                onRetry={() => void activeQuery.refetch()}
+                                error={myMapsQuery.error}
+                                onRetry={() => void myMapsQuery.refetch()}
                             />
                         )}
 
-                        {!activeQuery.isLoading &&
-                            !activeQuery.isError &&
+                        {!myMapsQuery.isLoading &&
+                            !myMapsQuery.isError &&
                             maps.length === 0 && (
-                            <MyMapsEmptyState isSearching={isSearching} />
+                            <MyMapsEmptyState
+                                hasActiveFilter={hasActiveFilter}
+                            />
                         )}
 
-                        {!activeQuery.isLoading &&
-                            !activeQuery.isError &&
+                        {!myMapsQuery.isLoading &&
+                            !myMapsQuery.isError &&
                             maps.length > 0 && (
                             <>
                                 {maps.map((map) => (
@@ -580,9 +621,8 @@ export function MyMaps() {
                         )}
                     </div>
 
-                    {!isSearching &&
-                        !activeQuery.isLoading &&
-                        !activeQuery.isError &&
+                    {!myMapsQuery.isLoading &&
+                        !myMapsQuery.isError &&
                         maps.length > 0 && (
                         <MyMapsPagination
                             page={page}


### PR DESCRIPTION
## 📣 Related Issue

- #95

## 📝 Summary

- `GET /api/maps/me` 요청에 `keyword`, `category`, `sort`, `page`, `size` 조건을 전달하도록 수정했습니다.
- `useMyMaps` query key에 모든 조회 조건을 포함했습니다.
- 대용량 데이터를 조회한 뒤 클라이언트에서 검색하던 로직을 제거했습니다.
- 검색어, 카테고리, 정렬 변경 시 첫 페이지로 초기화하도록 처리했습니다.
- `전체` 카테고리는 서버 요청의 `category` query parameter에서 제외했습니다.
- 검색 및 필터 상태에서도 서버 응답을 기준으로 페이지네이션을 유지합니다.
- 검색어 또는 카테고리 필터 적용 여부에 따라 빈 상태 문구를 구분했습니다.
- MSW 내 맵 목록 응답에도 검색, 필터, 정렬 로직을 반영했습니다.

## 🙏PR point

- BE `MapSortType`과 동일한 `NEWEST`, `OLDEST`, `MOST_SONGS`, `TITLE_ASC` 값을 사용합니다.
- 기존 삭제, 수정, 설명 토글, 플레이 횟수 표시 동작은 유지했습니다.
- `npm run lint`, `npm run build`를 통과했습니다.
- lint의 기존 MSW 생성 파일 경고와 Vite 번들 크기 경고가 각각 1건 존재합니다.

## 📬 Reference

- Monomat-BE `develop`의 `GET /api/maps/me` 계약
