### PR TITLE
[Feat/#99] 맵 선택 모달 카테고리 칩 필터 추가

### DIFF
--- a/src/components/lobby/LobbyCategoryFilter.tsx
+++ b/src/components/lobby/LobbyCategoryFilter.tsx
@@ -2,20 +2,25 @@ interface LobbyCategoryFilterProps<TCategory extends string> {
     categories: readonly TCategory[];
     selectedCategory: TCategory;
     onChange: (value: TCategory) => void;
+    className?: string;
 }
 
 export function LobbyCategoryFilter<TCategory extends string>({
-                                                                  categories,
-                                                                  selectedCategory,
-                                                              onChange,
-                                                          }: LobbyCategoryFilterProps<TCategory>) {
+    categories,
+    selectedCategory,
+    onChange,
+    className = 'mb-[18px]',
+}: LobbyCategoryFilterProps<TCategory>) {
     return (
-        <div className="mb-[18px] flex min-w-0 flex-wrap items-center gap-[9px]">
+        <div
+            className={`${className} flex min-w-0 flex-wrap items-center gap-[9px]`}
+        >
             {categories.map((category) => (
                 <button
                     key={category}
                     type="button"
                     onClick={() => onChange(category)}
+                    aria-pressed={selectedCategory === category}
                     className={`h-8 shrink-0 rounded-full px-[15px] text-[13px] leading-none transition ${
                         selectedCategory === category
                             ? 'bg-[var(--monomat-primary)] font-semibold text-white'

--- a/src/components/lobby/MapSelectModal.tsx
+++ b/src/components/lobby/MapSelectModal.tsx
@@ -21,6 +21,9 @@ import {
 import { ApiError } from '../../api/apiError';
 import {
     DEFAULT_MAP_LIST_PAGE,
+    MAP_ALL_CATEGORY_FILTER,
+    MAP_CATEGORY_FILTERS,
+    MAP_CATEGORY_QUERY_VALUE,
     MAP_SELECT_MODAL_PAGE_SIZE,
 } from '../../constants/map';
 import { useAuthStore } from '../../store/useAuthStore';
@@ -28,8 +31,12 @@ import {
     formatMapDescription,
     formatMapOwnerNickname,
 } from '../../utils/mapFormat';
+import { LobbyCategoryFilter } from './LobbyCategoryFilter';
 
-import type { MapSummary } from '../../types/map';
+import type {
+    MapCategoryQueryValue,
+    MapSummary,
+} from '../../types/map';
 
 interface MapSelectModalProps {
     isOpen: boolean;
@@ -44,6 +51,15 @@ const PUBLIC_MAP_TAB = 'public';
 const MY_MAP_TAB = 'my';
 
 type MapSelectTab = typeof PUBLIC_MAP_TAB | typeof MY_MAP_TAB;
+type MapCategoryFilter = (typeof MAP_CATEGORY_FILTERS)[number];
+
+function toMapCategoryQueryValue(
+    category: MapCategoryFilter,
+): MapCategoryQueryValue | undefined {
+    return category === MAP_ALL_CATEGORY_FILTER
+        ? undefined
+        : MAP_CATEGORY_QUERY_VALUE[category];
+}
 
 function getErrorMessage(error: unknown, fallbackMessage: string) {
     if (error instanceof Error && error.message) {
@@ -95,6 +111,8 @@ export function MapSelectModal({
     const [debouncedKeyword, setDebouncedKeyword] = useState('');
     const [activeTab, setActiveTab] =
         useState<MapSelectTab>(PUBLIC_MAP_TAB);
+    const [selectedCategory, setSelectedCategory] =
+        useState<MapCategoryFilter>(MAP_ALL_CATEGORY_FILTER);
     const [maps, setMaps] = useState<MapSummary[]>([]);
     const [page, setPage] = useState(DEFAULT_MAP_LIST_PAGE);
     const [hasNext, setHasNext] = useState(false);
@@ -105,12 +123,14 @@ export function MapSelectModal({
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const canUseMyMapTab = userType === 'REGISTERED';
     const isPublicMapTab = activeTab === PUBLIC_MAP_TAB;
+    const category = toMapCategoryQueryValue(selectedCategory);
     const emptyMessage = isPublicMapTab
         ? '조건에 맞는 공개 맵이 없습니다.'
         : '아직 만든 맵이 없습니다.';
 
     useEffect(() => {
         if (!isOpen) {
+            setSelectedCategory(MAP_ALL_CATEGORY_FILTER);
             return;
         }
 
@@ -154,6 +174,7 @@ export function MapSelectModal({
                         page: DEFAULT_MAP_LIST_PAGE,
                         size: MAP_SELECT_MODAL_PAGE_SIZE,
                         keyword: debouncedKeyword,
+                        category,
                         sort: MAP_LIST_SORT,
                     })
                     : await getMyMaps({
@@ -188,7 +209,7 @@ export function MapSelectModal({
         return () => {
             isCurrent = false;
         };
-    }, [isOpen, isPublicMapTab, debouncedKeyword]);
+    }, [isOpen, isPublicMapTab, debouncedKeyword, category]);
 
     useEffect(() => {
         if (!isOpen) {
@@ -220,6 +241,20 @@ export function MapSelectModal({
 
     const handleKeywordChange = (event: ChangeEvent<HTMLInputElement>) => {
         setKeyword(event.target.value);
+        setPage(DEFAULT_MAP_LIST_PAGE);
+        setHasNext(false);
+    };
+
+    const handleCategoryChange = (nextCategory: MapCategoryFilter) => {
+        if (selectedCategory === nextCategory) {
+            return;
+        }
+
+        setSelectedCategory(nextCategory);
+        setPage(DEFAULT_MAP_LIST_PAGE);
+        setHasNext(false);
+        setMaps([]);
+        setErrorMessage(null);
     };
 
     const handleTabChange = (nextTab: MapSelectTab) => {
@@ -255,6 +290,7 @@ export function MapSelectModal({
                     page: nextPage,
                     size: MAP_SELECT_MODAL_PAGE_SIZE,
                     keyword: debouncedKeyword,
+                    category,
                     sort: MAP_LIST_SORT,
                 })
                 : await getMyMaps({
@@ -356,6 +392,15 @@ export function MapSelectModal({
                         </button>
                     </div>
 
+                    {isPublicMapTab && (
+                        <LobbyCategoryFilter
+                            categories={MAP_CATEGORY_FILTERS}
+                            selectedCategory={selectedCategory}
+                            onChange={handleCategoryChange}
+                            className="mt-3"
+                        />
+                    )}
+
                     <label
                         className={`mt-[9px] flex h-11 items-center rounded-lg border border-[var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-[11px] focus-within:border-[var(--monomat-primary)] ${
                             isPublicMapTab ? '' : 'opacity-70'
@@ -374,7 +419,7 @@ export function MapSelectModal({
                             disabled={!isPublicMapTab}
                             placeholder={
                                 isPublicMapTab
-                                    ? '맵 제목이나 카테고리를 검색하세요'
+                                    ? '맵 제목으로 검색하세요'
                                     : '내 맵 검색은 추후 제공 예정입니다.'
                             }
                             className="ml-3 h-full min-w-0 flex-1 bg-transparent text-sm font-medium text-[var(--monomat-text-strong)] outline-none placeholder:text-[var(--monomat-border-input)] disabled:cursor-not-allowed"

--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -1,10 +1,22 @@
 import { LOBBY_CATEGORY_FILTERS } from './lobby';
 
+import type {
+    MapCategory,
+    MapCategoryQueryValue,
+} from '../types/map';
+
 export const MAP_CATEGORY_FILTERS = LOBBY_CATEGORY_FILTERS;
 export const MAP_ALL_CATEGORY_FILTER = MAP_CATEGORY_FILTERS[0];
 export const MAP_CATEGORY_OPTIONS = MAP_CATEGORY_FILTERS.filter(
     (category) => category !== MAP_ALL_CATEGORY_FILTER,
 );
+export const MAP_CATEGORY_QUERY_VALUE = {
+    'K-POP': 'KPOP',
+    'J-POP': 'JPOP',
+    POP: 'POP',
+    OST: 'OST',
+    애니: 'ANIME',
+} as const satisfies Record<MapCategory, MapCategoryQueryValue>;
 
 export const MAP_SORT_LABELS = {
     NEWEST: '최신순',

--- a/src/mocks/handlers/map.ts
+++ b/src/mocks/handlers/map.ts
@@ -5,6 +5,8 @@ import {
     DEFAULT_MAP_LIST_PAGE,
     DEFAULT_MAP_LIST_SIZE,
     DEFAULT_MAP_SORT_OPTION,
+    MAP_CATEGORY_OPTIONS,
+    MAP_CATEGORY_QUERY_VALUE,
     MY_MAP_LIST_PAGE_SIZE,
 } from '../../constants/map';
 import {
@@ -14,12 +16,12 @@ import {
 
 import type {
     MapCategory,
+    MapCategoryQueryValue,
     MapListQueryParams,
     MapSortOption,
     MapSummary,
 } from '../../types/map';
 
-const MAP_CATEGORIES = ['K-POP', 'J-POP', 'POP', 'OST', '애니'] as const;
 const MAP_SORT_OPTIONS = [
     'NEWEST',
     'OLDEST',
@@ -28,7 +30,29 @@ const MAP_SORT_OPTIONS = [
 ] as const;
 
 function isMapCategory(value: string | null): value is MapCategory {
-    return MAP_CATEGORIES.some((category) => category === value);
+    return MAP_CATEGORY_OPTIONS.some((category) => category === value);
+}
+
+function isMapCategoryQueryValue(
+    value: string | null,
+): value is MapCategoryQueryValue {
+    return Object.values(MAP_CATEGORY_QUERY_VALUE).some(
+        (category) => category === value,
+    );
+}
+
+function parseMapCategory(value: string | null): MapCategory | undefined {
+    if (isMapCategory(value)) {
+        return value;
+    }
+
+    if (!isMapCategoryQueryValue(value)) {
+        return undefined;
+    }
+
+    return MAP_CATEGORY_OPTIONS.find(
+        (category) => MAP_CATEGORY_QUERY_VALUE[category] === value,
+    );
 }
 
 function isMapSortOption(value: string | null): value is MapSortOption {
@@ -57,16 +81,18 @@ function filterMapItems(
     allowedPrivateMaps: boolean,
 ) {
     const keyword = requestUrl.searchParams.get('keyword')?.trim().toLowerCase();
-    const category = requestUrl.searchParams.get('category');
+    const category = parseMapCategory(
+        requestUrl.searchParams.get('category'),
+    );
 
     return maps.filter((map) => {
         const matchesVisibility = allowedPrivateMaps || map.isPublic;
         const matchesKeyword =
             !keyword ||
             map.title.toLowerCase().includes(keyword) ||
-            map.category.toLowerCase().includes(keyword);
-        const matchesCategory =
-            !isMapCategory(category) || map.category === category;
+            (allowedPrivateMaps &&
+                map.category.toLowerCase().includes(keyword));
+        const matchesCategory = !category || map.category === category;
 
         return matchesVisibility && matchesKeyword && matchesCategory;
     });

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -2,6 +2,13 @@ import type { LobbyCategory } from './lobby';
 
 export type MapCategory = LobbyCategory;
 
+export type MapCategoryQueryValue =
+    | 'KPOP'
+    | 'JPOP'
+    | 'POP'
+    | 'OST'
+    | 'ANIME';
+
 export type MapSortOption =
     | 'NEWEST'
     | 'OLDEST'
@@ -35,7 +42,7 @@ export interface MapListQueryParams {
     page?: number;
     size?: number;
     keyword?: string;
-    category?: MapCategory;
+    category?: MapCategory | MapCategoryQueryValue;
     sort?: MapSortOption;
 }
 


### PR DESCRIPTION
## 📣 Related Issue

- #99

## 📝 Summary

- 로비 생성 화면의 맵 선택 모달에 카테고리 칩 필터를 추가했습니다.
- `전체`, `K-POP`, `J-POP`, `POP`, `OST`, `애니` 선택지를 제공합니다.
- 검색어와 카테고리 조건을 공개 맵 목록 API에 함께 전달합니다.
- `전체` 선택 시 `category` query parameter를 제외합니다.
- 카테고리 및 검색어 변경 시 목록을 첫 페이지로 초기화합니다.
- 공개 맵 MSW 검색 범위를 BE 구현과 동일하게 제목 검색 기준으로 변경했습니다.
- `npm run lint`, `npm run build`를 통과했습니다.

## 🙏PR point

- 기존 `LobbyCategoryFilter`의 칩 스타일을 재사용하고, 모달 배치를 위해 최소한의 확장만 적용했습니다.
- 화면 표시값과 API query parameter 값을 분리했습니다.
  - `K-POP` → `KPOP`
  - `J-POP` → `JPOP`
  - `애니` → `ANIME`
- MSW는 API enum 값과 기존 표시값을 모두 허용합니다.
- 카테고리 변경 후 선택한 맵이 목록에서 사라져도 임시 선택 상태와 기존 선택 완료 정책은 유지됩니다.
- lint의 기존 `mockServiceWorker.js` 경고와 Vite 번들 크기 경고가 각각 존재합니다.

## 📬 Reference

- 기존 로비 목록 `LobbyCategoryFilter` 칩 UI
- 기존 내 맵 목록 카테고리 필터 처리
- Monomat-BE `develop`의 공개 맵 목록 API
  - `GET /api/maps?keyword=&category=&sort=&page=&size=`