### PR TITLE
[Feat/#96] 맵 생성 일괄 API 연동

### DIFF
--- a/src/api/mapApi.ts
+++ b/src/api/mapApi.ts
@@ -1,5 +1,6 @@
 import { API_ENDPOINTS } from '../constants/endpoints';
 import {
+    createMapWithItemsResponseSchema,
     manageMapResponseSchema,
     mapDetailResponseSchema,
     mapItemListResponseSchema,
@@ -12,6 +13,8 @@ import { fetchWithAuth } from './apiClient';
 import type {
     CreateMapItemRequest,
     CreateMapRequest,
+    CreateMapWithItemsRequest,
+    CreateMapWithItemsResponse,
     ManageMapRequest,
     ManageMapResponse,
     MapDetailResponse,
@@ -33,6 +36,8 @@ const DEFAULT_FETCH_MY_MAP_DETAIL_ERROR_MESSAGE =
 const DEFAULT_FETCH_MAP_ITEMS_ERROR_MESSAGE =
     '곡 목록을 불러오는 데 실패했습니다.';
 const DEFAULT_CREATE_MAP_ERROR_MESSAGE = '맵 생성에 실패했습니다.';
+const DEFAULT_CREATE_MAP_WITH_ITEMS_ERROR_MESSAGE =
+    '맵 생성에 실패했습니다.';
 const DEFAULT_CREATE_MAP_ITEM_ERROR_MESSAGE = '곡 등록에 실패했습니다.';
 const DEFAULT_UPDATE_MAP_ERROR_MESSAGE = '맵 수정에 실패했습니다.';
 const DEFAULT_UPDATE_MANAGED_MAP_ERROR_MESSAGE =
@@ -193,6 +198,42 @@ export async function createMap(
 
     if (!parsed.success) {
         console.error('[mapApi] 맵 생성 응답 검증 실패:', parsed.error);
+
+        throw new Error('맵 생성 응답 형식이 올바르지 않습니다.');
+    }
+
+    return parsed.data;
+}
+
+export async function createMapWithItems(
+    request: CreateMapWithItemsRequest,
+): Promise<CreateMapWithItemsResponse> {
+    const response = await fetchWithAuth(
+        API_ENDPOINTS.MAP.CREATE_WITH_ITEMS,
+        {
+            method: 'POST',
+            headers: {
+                'Content-Type': JSON_CONTENT_TYPE,
+            },
+            body: JSON.stringify(request),
+        },
+    );
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            DEFAULT_CREATE_MAP_WITH_ITEMS_ERROR_MESSAGE,
+        );
+    }
+
+    const payload = await response.json() as unknown;
+    const parsed = createMapWithItemsResponseSchema.safeParse(payload);
+
+    if (!parsed.success) {
+        console.error(
+            '[mapApi] 맵 일괄 생성 응답 검증 실패:',
+            parsed.error,
+        );
 
         throw new Error('맵 생성 응답 형식이 올바르지 않습니다.');
     }

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -51,6 +51,7 @@ export const API_ENDPOINTS = {
     MAP: {
         LIST: createApiEndpoint('/api/maps'),
         CREATE: createApiEndpoint('/api/maps'),
+        CREATE_WITH_ITEMS: createApiEndpoint('/api/maps/with-items'),
         MY_LIST: createApiEndpoint('/api/maps/me'),
         MY_DETAIL: (mapId: number) =>
             createApiEndpoint(`/api/maps/me/${mapId}`),

--- a/src/constants/map.ts
+++ b/src/constants/map.ts
@@ -49,6 +49,8 @@ export const MAP_CREATE_POLICY = {
     MIN_SONG_COUNT: 1,
     MAX_SONG_COUNT: 200,
     MIN_START_TIME_SECONDS: 0,
+    MIN_HINT_TIME_SECONDS: 1,
+    MAX_HINT_TIME_SECONDS: 100,
     API_FALLBACK_PLAY_DURATION_SECONDS: 30,
     DEFAULT_CATEGORY: 'J-POP',
     DEFAULT_IS_PUBLIC: true,
@@ -88,8 +90,6 @@ export const MAP_CREATE_PAGE_COPY = {
     SUBMIT: '맵 만들기',
     SUBMITTING: '맵 만드는 중...',
     CREATE_ERROR: '맵 생성에 실패했습니다. 잠시 후 다시 시도해주세요.',
-    PARTIAL_CREATE_ERROR:
-        '맵은 생성되었지만 일부 곡 등록에 실패했습니다. 내 맵 관리에서 생성된 맵을 확인해주세요.',
 } as const;
 
 export const MAP_CREATE_SONG_COPY = {

--- a/src/mocks/handlers/map.ts
+++ b/src/mocks/handlers/map.ts
@@ -15,6 +15,7 @@ import {
 } from '../data/maps';
 
 import type {
+    CreateMapWithItemsRequest,
     MapCategory,
     MapCategoryQueryValue,
     MapListQueryParams,
@@ -169,6 +170,85 @@ function createMapListResponse(
 }
 
 export const mapHandlers = [
+    http.post(
+        API_ENDPOINTS.MAP.CREATE_WITH_ITEMS,
+        async ({ request }) => {
+            const payload =
+                await request.json() as CreateMapWithItemsRequest;
+            const nextMapId =
+                Math.max(
+                    0,
+                    ...mockPublicMapItems.map((map) => map.mapId),
+                    ...mockMyMapItems.map((map) => map.mapId),
+                ) + 1;
+            const createdAt = new Date().toISOString();
+            const totalPlayTime = payload.items.reduce(
+                (total, item) =>
+                    total + (item.endTime - item.startTime),
+                0,
+            );
+            const createdMap = {
+                id: nextMapId,
+                ownerId: 999,
+                ownerNickname: '내계정',
+                title: payload.title,
+                description: payload.description,
+                category: payload.category,
+                numOfSong: payload.items.length,
+                totalPlayTime,
+                isPublic: payload.isPublic,
+                pendingPublic: false,
+                playCount: 0,
+                createdAt,
+                updatedAt: createdAt,
+            };
+            const createdItems = payload.items.map((item, index) => ({
+                id: nextMapId * 1_000 + index + 1,
+                mapId: nextMapId,
+                orderNum: item.orderNum,
+                youtubeUrl: item.youtubeUrl,
+                videoId: null,
+                startTime: item.startTime,
+                endTime: item.endTime,
+                title: null,
+                artist: null,
+                thumbnailUrl: null,
+                answers: item.answers,
+                hint: item.hint,
+                hintTime: item.hintTime ?? 15,
+                createdAt,
+                updatedAt: createdAt,
+            }));
+            const mapSummary: MapSummary = {
+                mapId: createdMap.id,
+                title: createdMap.title,
+                description: createdMap.description,
+                category: createdMap.category,
+                numOfSong: createdMap.numOfSong,
+                totalPlayTime: createdMap.totalPlayTime,
+                playCount: createdMap.playCount,
+                isPublic: createdMap.isPublic,
+                pendingPublic: createdMap.pendingPublic,
+                ownerId: createdMap.ownerId,
+                ownerNickname: createdMap.ownerNickname,
+            };
+
+            mockMyMapItems.unshift(mapSummary);
+
+            if (mapSummary.isPublic) {
+                mockPublicMapItems.unshift(mapSummary);
+            }
+
+            return HttpResponse.json(
+                {
+                    map: createdMap,
+                    items: createdItems,
+                },
+                { status: 201 },
+            );
+        },
+    ),
+
     http.get(API_ENDPOINTS.MAP.LIST, ({ request }) => {
         return createMapListResponse(
             mockPublicMapItems,

--- a/src/pages/MapCreate.tsx
+++ b/src/pages/MapCreate.tsx
@@ -5,7 +5,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 
-import { createMap, createMapItem } from '../api/mapApi';
+import { createMapWithItems } from '../api/mapApi';
 import { MonomatInput } from '../components/common/MonomatInput';
 import { NavigationBar } from '../components/common/NavigationBar';
 import { LobbyFooter } from '../components/lobby/LobbyFooter';
@@ -91,7 +91,6 @@ export function MapCreate() {
     const queryClient = useQueryClient();
     const [formState, setFormState] = useState(createInitialFormState);
     const [isSubmitting, setIsSubmitting] = useState(false);
-    const [hasPartialFailure, setHasPartialFailure] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
     const hasValidTitle =
@@ -109,7 +108,7 @@ export function MapCreate() {
             MAP_CREATE_POLICY.DESCRIPTION_MAX_LENGTH &&
         MAP_CATEGORY_OPTIONS.includes(formState.category) &&
         hasValidSongs;
-    const isFormLocked = isSubmitting || hasPartialFailure;
+    const isFormLocked = isSubmitting;
 
     const updateFormState = <TKey extends keyof Omit<
         CreateMapFormState,
@@ -303,29 +302,15 @@ export function MapCreate() {
         setErrorMessage(null);
 
         try {
-            const createdMap = await createMap({
+            await createMapWithItems({
                 title: formState.title.trim(),
                 description: formState.description.trim() || null,
                 category: formState.category,
                 isPublic: formState.isPublic,
+                items: formState.songs.map((song, index) =>
+                    createMapItemRequestFromSong(song, index + 1),
+                ),
             });
-
-            try {
-                for (const [index, song] of formState.songs.entries()) {
-                    await createMapItem(
-                        createdMap.id,
-                        createMapItemRequestFromSong(song, index + 1),
-                    );
-                }
-            } catch (itemError) {
-                console.error('[MapCreate] 일부 곡 생성 실패:', itemError);
-                setHasPartialFailure(true);
-                setErrorMessage(MAP_CREATE_PAGE_COPY.PARTIAL_CREATE_ERROR);
-                await queryClient.invalidateQueries({
-                    queryKey: ['myMaps'],
-                });
-                return;
-            }
 
             await queryClient.invalidateQueries({
                 queryKey: ['myMaps'],
@@ -585,17 +570,6 @@ export function MapCreate() {
                             className="mt-5 rounded-lg border border-[var(--monomat-danger)] bg-[var(--monomat-danger-light)] px-4 py-3 text-sm font-medium leading-5 text-[var(--monomat-danger)]"
                         >
                             <p>{errorMessage}</p>
-                            {hasPartialFailure && (
-                                <button
-                                    type="button"
-                                    onClick={() =>
-                                        navigate(MAP_ROUTES.MY_MAPS)
-                                    }
-                                    className="mt-2 font-bold underline underline-offset-2"
-                                >
-                                    내 맵 관리로 이동
-                                </button>
-                            )}
                         </div>
                     )}
 
@@ -610,11 +584,7 @@ export function MapCreate() {
                         </button>
                         <button
                             type="submit"
-                            disabled={
-                                !isFormValid ||
-                                isSubmitting ||
-                                hasPartialFailure
-                            }
+                            disabled={!isFormValid || isSubmitting}
                             className="h-[45px] min-w-[110px] rounded-lg bg-[var(--monomat-primary)] px-5 text-[15px] font-bold text-white transition hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:bg-[var(--monomat-primary-disabled)]"
                         >
                             {isSubmitting

--- a/src/schemas/mapSchema.ts
+++ b/src/schemas/mapSchema.ts
@@ -74,3 +74,8 @@ export const manageMapResponseSchema = z.object({
     map: mapDetailResponseSchema,
     items: mapItemListResponseSchema,
 });
+
+export const createMapWithItemsResponseSchema = z.object({
+    map: mapDetailResponseSchema,
+    items: mapItemListResponseSchema,
+});

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -86,6 +86,12 @@ export interface CreateMapItemRequest {
     hintTime?: number | null;
 }
 
+export type CreateMapWithItemsItemRequest = CreateMapItemRequest;
+
+export interface CreateMapWithItemsRequest extends CreateMapRequest {
+    items: CreateMapWithItemsItemRequest[];
+}
+
 export type UpdateMapItemRequest = CreateMapItemRequest;
 
 export interface ReorderMapItemsRequest {
@@ -127,6 +133,11 @@ export interface MapItemResponse {
 }
 
 export interface ManageMapResponse {
+    map: MapDetailResponse;
+    items: MapItemResponse[];
+}
+
+export interface CreateMapWithItemsResponse {
     map: MapDetailResponse;
     items: MapItemResponse[];
 }

--- a/src/utils/mapSongForm.ts
+++ b/src/utils/mapSongForm.ts
@@ -6,7 +6,7 @@ import {
 } from './mapCreateTiming';
 
 import type {
-    CreateMapItemRequest,
+    CreateMapWithItemsItemRequest,
     CreateMapSongFormState,
 } from '../types/map';
 
@@ -42,12 +42,18 @@ export function isValidMapSongForm(song: CreateMapSongFormState) {
 export function createMapItemRequestFromSong(
     song: CreateMapSongFormState,
     orderNum: number,
-): CreateMapItemRequest {
+): CreateMapWithItemsItemRequest {
     const timing = getMapCreateTiming(
         Number(song.startTime),
         song.playDurationSeconds ??
             MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS,
     );
+    const hintTime = song.hintTime;
+    const hasValidHintTime =
+        typeof hintTime === 'number' &&
+        Number.isInteger(hintTime) &&
+        hintTime >= MAP_CREATE_POLICY.MIN_HINT_TIME_SECONDS &&
+        hintTime <= MAP_CREATE_POLICY.MAX_HINT_TIME_SECONDS;
 
     return {
         orderNum,
@@ -58,6 +64,6 @@ export function createMapItemRequestFromSong(
             .map((answer) => answer.trim())
             .filter(Boolean),
         hint: song.hint.trim(),
-        hintTime: song.hintTime ?? undefined,
+        ...(hasValidHintTime ? { hintTime } : {}),
     };
 }


### PR DESCRIPTION
## 📣 Related Issue

- #96

## 📝 Summary

- 맵 생성 로직을 `POST /api/maps/with-items` 단일 요청 방식으로 변경했습니다.
- 일괄 생성 요청·응답 타입과 Zod 스키마를 추가했습니다.
- 곡 순서를 기준으로 `orderNum`을 1부터 연속 지정합니다.
- 기존 정책대로 `endTime`을 시작 시간과 재생 시간으로 계산합니다.
- 유효한 `hintTime`만 전송하고, 비어 있거나 유효하지 않으면 생략합니다.
- partial failure 상태와 관련 안내 및 입력 잠금 로직을 제거했습니다.
- 생성 성공 시 `myMaps` 쿼리를 무효화하고 `/maps/me`로 이동합니다.
- 일괄 생성 API용 MSW 핸들러를 추가했습니다.
- 기존 `createMap()`, `createMapItem()` API는 호환성을 위해 유지했습니다.

## 🙏PR point

- 맵 생성 화면에서는 기존 맵 생성 및 곡별 생성 API를 더 이상 호출하지 않습니다.
- `hintTime` 미전송 시 BE 기본값인 15초가 적용됩니다.
- 생성 요청 실패는 부분 생성 없이 전체 실패로 처리됩니다.
- `npm run lint`는 오류 없이 통과했으며 기존 MSW 파일 경고 1건이 있습니다.
- `npm run build`가 통과했습니다.

## 📬 Reference

- Monomat-BE `develop`
- `POST /api/maps/with-items`
- `CreateMapWithItemsRequest`
- `CreateMapWithItemsResponse`