### PR TITLE
[Feat/#97] 로비 방 참가자 닉네임 표시

### DIFF
--- a/src/mocks/handlers/lobby.ts
+++ b/src/mocks/handlers/lobby.ts
@@ -104,6 +104,7 @@ function createLobbyDetailFromItem(
         inviteCode: lobby.code,
         title: lobby.title,
         hostId: lobby.hostId ?? 'mock-host',
+        hostNickname: lobby.hostNickname ?? 'Mock Host',
         maxPlayers: lobby.maxPlayers,
         currentPlayers: lobby.currentPlayers,
         status: lobby.status,
@@ -118,6 +119,7 @@ function createLobbyDetailFromItem(
         players: [
             {
                 userIdentifier: lobby.hostId ?? 'mock-host',
+                nickname: lobby.hostNickname ?? 'Mock Host',
                 host: true,
                 ready: true,
             },
@@ -152,6 +154,7 @@ export const lobbyHandlers = [
             inviteCode,
             title,
             hostId: 'mock-host',
+            hostNickname: 'Mock Host',
             maxPlayers,
             currentPlayers: 1,
             status: 'WAITING',
@@ -163,6 +166,7 @@ export const lobbyHandlers = [
             players: [
                 {
                     userIdentifier: 'mock-host',
+                    nickname: 'Mock Host',
                     host: true,
                     ready: true,
                 },

--- a/src/pages/LobbyRoom.tsx
+++ b/src/pages/LobbyRoom.tsx
@@ -47,6 +47,16 @@ function maskUserIdentifier(userIdentifier: string) {
     return `${userIdentifier.slice(0, 4)}...${userIdentifier.slice(-4)}`;
 }
 
+function getPlayerDisplayName(player: LobbyPlayerResponse) {
+    const nickname = player.nickname?.trim();
+
+    if (nickname) {
+        return nickname;
+    }
+
+    return maskUserIdentifier(player.userIdentifier);
+}
+
 function formatMapInfo(
     mapTitle: string | null,
     mapCategory: string | null,
@@ -387,9 +397,7 @@ export function LobbyRoom() {
                                     >
                                         <div className="min-w-0">
                                             <p className="truncate font-mono text-sm font-bold text-gray-900">
-                                                {maskUserIdentifier(
-                                                    player.userIdentifier,
-                                                )}
+                                                {getPlayerDisplayName(player)}
                                             </p>
                                             <p className="mt-1 text-xs font-semibold text-gray-500">
                                                 {player.userIdentifier ===

--- a/src/schemas/lobbySchema.ts
+++ b/src/schemas/lobbySchema.ts
@@ -53,6 +53,7 @@ export const lobbyListItemSchema = z.object({
 
 export const lobbyPlayerResponseSchema = z.object({
     userIdentifier: z.string().min(1),
+    nickname: z.string().nullable().optional(),
     host: z.boolean(),
     ready: z.boolean(),
 });
@@ -61,6 +62,7 @@ export const lobbyDetailResponseSchema = z.object({
     inviteCode: z.string().min(1),
     title: z.string().min(1),
     hostId: z.string().min(1),
+    hostNickname: z.string().nullable().optional(),
     maxPlayers: z.number().int().positive(),
     currentPlayers: z.number().int().min(0),
     status: lobbyStatusSchema,

--- a/src/types/lobby.ts
+++ b/src/types/lobby.ts
@@ -69,6 +69,7 @@ export interface JoinLobbyResponse {
 
 export interface LobbyPlayerResponse {
     userIdentifier: string;
+    nickname?: string | null;
     host: boolean;
     ready: boolean;
 }
@@ -77,6 +78,7 @@ export interface LobbyDetailResponse {
     inviteCode: string;
     title: string;
     hostId: string;
+    hostNickname?: string | null;
     maxPlayers: number;
     currentPlayers: number;
     status: LobbyStatus;


### PR DESCRIPTION
## 📣 Related Issue

- #97

## 📝 Summary

- 로비 상세 응답의 `players[]` 타입과 Zod schema에 `nickname` 필드를 추가했습니다.
- 로비 방 참가자 목록에서 `userIdentifier` 마스킹 값 대신 `player.nickname`을 우선 표시하도록 변경했습니다.
- `nickname`이 없거나 빈 문자열인 경우 기존 `maskUserIdentifier(player.userIdentifier)` fallback을 유지했습니다.
- MSW 로비 상세 mock 응답의 `players[]`에 `nickname`을 추가했습니다.

## 🙏PR point

- 배포 전환 안정성을 위해 `nickname`은 `optional | null` 허용 구조로 처리했습니다.
- 방장 표시, 준비 상태 표시, 준비/시작 버튼, WebSocket refresh 흐름은 기존 로직을 유지했습니다.
- `players` 필드명은 BE develop 계약에 맞춰 그대로 유지했습니다.

## 📬 Reference

- BE 로비 상세 응답 계약: `GET /api/lobbies/{inviteCode}`
- 검증: `npm run lint`, `npm run build`