### PR TITLE
[Feat/#104] 방장 로비 대기실 화면 개선

### DIFF
--- a/src/api/lobbyApi.ts
+++ b/src/api/lobbyApi.ts
@@ -17,6 +17,7 @@ import type {
     LobbyListItem,
     LobbyListQueryParams,
     LobbyPageResponse,
+    UpdateLobbyMapRequest,
     UpdateLobbyReadyRequest,
 } from '../types/lobby';
 
@@ -26,6 +27,7 @@ const DEFAULT_CREATE_LOBBY_ERROR_MESSAGE = '로비 생성에 실패했습니다.
 const DEFAULT_JOIN_LOBBY_ERROR_MESSAGE = '로비 입장에 실패했습니다.';
 const DEFAULT_FETCH_LOBBY_LIST_ERROR_MESSAGE = '로비 목록을 불러오는 데 실패했습니다.';
 const DEFAULT_FETCH_LOBBY_DETAIL_ERROR_MESSAGE = '로비 정보를 불러오는 데 실패했습니다.';
+const DEFAULT_UPDATE_LOBBY_MAP_ERROR_MESSAGE = '로비 맵 변경에 실패했습니다.';
 const DEFAULT_UPDATE_LOBBY_READY_ERROR_MESSAGE = '준비 상태 변경에 실패했습니다.';
 const DEFAULT_START_LOBBY_GAME_ERROR_MESSAGE = '게임 시작에 실패했습니다.';
 
@@ -203,6 +205,26 @@ export async function updateLobbyReady(
         throw await createApiError(
             response,
             DEFAULT_UPDATE_LOBBY_READY_ERROR_MESSAGE,
+        );
+    }
+}
+
+export async function updateLobbyMap(
+    code: string,
+    request: UpdateLobbyMapRequest,
+): Promise<void> {
+    const response = await fetchWithAuth(API_ENDPOINTS.LOBBY.MAP(code), {
+        method: 'PATCH',
+        headers: {
+            'Content-Type': JSON_CONTENT_TYPE,
+        },
+        body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            DEFAULT_UPDATE_LOBBY_MAP_ERROR_MESSAGE,
         );
     }
 }

--- a/src/components/lobby/HostLobbyActionCard.tsx
+++ b/src/components/lobby/HostLobbyActionCard.tsx
@@ -1,11 +1,16 @@
-import { Gamepad2 } from 'lucide-react';
+import { CircleCheck, Info, Gamepad2 } from 'lucide-react';
 
 import { LOBBY_ROOM_COPY } from '../../constants/lobby';
+import { LobbyReadySummary } from './LobbyReadySummary';
 
 interface HostLobbyActionCardProps {
     canStart: boolean;
     isStarting: boolean;
     startGuideMessage: string;
+    totalPlayerCount: number;
+    readyTargetCount: number;
+    readyCount: number;
+    waitingCount: number;
     onStartClick: () => void;
 }
 
@@ -13,17 +18,71 @@ export function HostLobbyActionCard({
     canStart,
     isStarting,
     startGuideMessage,
+    totalPlayerCount,
+    readyTargetCount,
+    readyCount,
+    waitingCount,
     onStartClick,
 }: HostLobbyActionCardProps) {
     const isStartButtonDisabled = !canStart || isStarting;
+    const GuideIcon = canStart ? CircleCheck : Info;
 
     return (
-        <section aria-label={LOBBY_ROOM_COPY.HOST_ACTION_TITLE}>
-            <p className="sr-only">{startGuideMessage}</p>
+        <section
+            aria-labelledby="host-lobby-action-title"
+            className="space-y-2"
+        >
+            <div
+                className={`rounded-lg px-4 py-3 ring-1 ${
+                    canStart
+                        ? 'bg-[var(--monomat-primary-light)] text-[var(--monomat-primary)] ring-blue-100'
+                        : 'bg-white text-[var(--monomat-text-muted)] ring-[color:var(--monomat-border-card)]'
+                }`}
+            >
+                <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="min-w-0 lg:max-w-[360px]">
+                        <div className="flex items-center gap-2">
+                            <GuideIcon
+                                size={18}
+                                strokeWidth={2.3}
+                                aria-hidden="true"
+                            />
+                            <h3
+                                id="host-lobby-action-title"
+                                className={`!m-0 !text-sm !font-extrabold !leading-5 ${
+                                    canStart
+                                        ? '!text-[var(--monomat-primary)]'
+                                        : '!text-[var(--monomat-text-strong)]'
+                                }`}
+                            >
+                                {LOBBY_ROOM_COPY.HOST_ACTION_TITLE}
+                            </h3>
+                        </div>
+                        <p
+                            id="host-start-guide"
+                            className="mt-1.5 break-keep text-xs font-bold leading-5"
+                        >
+                            {startGuideMessage}
+                        </p>
+                    </div>
+
+                    <div className="min-w-0 lg:w-[470px]">
+                        <LobbyReadySummary
+                            totalPlayerCount={totalPlayerCount}
+                            readyTargetCount={readyTargetCount}
+                            readyCount={readyCount}
+                            waitingCount={waitingCount}
+                            variant="inline"
+                        />
+                    </div>
+                </div>
+            </div>
+
             <button
                 type="button"
                 onClick={onStartClick}
                 disabled={isStartButtonDisabled}
+                aria-describedby="host-start-guide"
                 className="flex h-[45px] w-full items-center justify-center gap-2 rounded-lg bg-[var(--monomat-primary)] text-base font-bold leading-none text-white transition hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:bg-[#D3D3D7]"
             >
                 <Gamepad2 size={20} strokeWidth={2.3} aria-hidden="true" />

--- a/src/components/lobby/LobbyHeaderCard.tsx
+++ b/src/components/lobby/LobbyHeaderCard.tsx
@@ -5,6 +5,9 @@ interface LobbyHeaderCardProps {
     mapTitle: string | null;
     mapCategory: string | null;
     questionCount: number;
+    canChangeMap?: boolean;
+    isMapChangePending?: boolean;
+    onMapChangeClick?: () => void;
 }
 
 export function LobbyHeaderCard({
@@ -12,6 +15,9 @@ export function LobbyHeaderCard({
     mapTitle,
     mapCategory,
     questionCount,
+    canChangeMap = false,
+    isMapChangePending = false,
+    onMapChangeClick,
 }: LobbyHeaderCardProps) {
     const hasSelectedMap = Boolean(mapTitle?.trim());
     const mapSummary = hasSelectedMap
@@ -20,12 +26,27 @@ export function LobbyHeaderCard({
 
     return (
         <section className="flex min-h-[107px] min-w-0 flex-col justify-center rounded-2xl bg-white px-[25px] py-5 text-left shadow-[0_4px_16px_rgba(0,0,0,0.16)]">
-            <h1 className="!m-0 truncate !text-[28px] !font-extrabold !leading-[43px] !text-[var(--monomat-text-strong)]">
-                {title}
-            </h1>
-            <p className="mt-[9px] truncate text-base font-medium leading-none text-[var(--monomat-text-muted)]">
-                {mapSummary}
-            </p>
+            <div className="flex min-w-0 flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div className="min-w-0">
+                    <h1 className="!m-0 truncate !text-[28px] !font-extrabold !leading-[43px] !text-[var(--monomat-text-strong)]">
+                        {title}
+                    </h1>
+                    <p className="mt-[9px] truncate text-base font-medium leading-none text-[var(--monomat-text-muted)]">
+                        {mapSummary}
+                    </p>
+                </div>
+
+                {canChangeMap && (
+                    <button
+                        type="button"
+                        onClick={onMapChangeClick}
+                        disabled={isMapChangePending}
+                        className="h-[43px] w-[90px] shrink-0 rounded-lg border border-[var(--monomat-border-input)] bg-white text-[15px] font-bold text-black transition hover:bg-[var(--monomat-page-bg)] disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                        {isMapChangePending ? '변경 중' : '맵 변경'}
+                    </button>
+                )}
+            </div>
         </section>
     );
 }

--- a/src/components/lobby/LobbyReadySummary.tsx
+++ b/src/components/lobby/LobbyReadySummary.tsx
@@ -5,16 +5,19 @@ interface LobbyReadySummaryProps {
     readyTargetCount: number;
     readyCount: number;
     waitingCount: number;
+    variant?: 'default' | 'compact' | 'inline';
 }
 
 function SummaryMetric({
     label,
     value,
     tone = 'default',
+    variant = 'default',
 }: {
     label: string;
     value: number;
     tone?: 'default' | 'ready' | 'waiting';
+    variant?: 'default' | 'compact' | 'inline';
 }) {
     const valueClassName = {
         default: 'text-[var(--monomat-text-strong)]',
@@ -22,12 +25,34 @@ function SummaryMetric({
         waiting: 'text-amber-600',
     }[tone];
 
+    if (variant === 'inline') {
+        return (
+            <div className="inline-flex h-7 min-w-0 items-center gap-1.5 rounded-full border border-[color:var(--monomat-border-default)] bg-white px-2.5">
+                <dt className="text-[11px] font-semibold leading-none text-[var(--monomat-text-muted)]">
+                    {label}
+                </dt>
+                <dd className={`text-xs font-extrabold leading-none ${valueClassName}`}>
+                    {value}
+                </dd>
+            </div>
+        );
+    }
+
+    const metricClassName =
+        variant === 'compact'
+            ? 'min-w-0 rounded-lg border border-[color:var(--monomat-border-default)] bg-white px-3 py-2'
+            : 'min-w-0 rounded-lg border border-[color:var(--monomat-border-default)] bg-[var(--monomat-page-bg)] px-3 py-3';
+    const valueTextClassName =
+        variant === 'compact'
+            ? 'mt-1 text-lg font-extrabold leading-none'
+            : 'mt-2 text-xl font-extrabold leading-none';
+
     return (
-        <div className="min-w-0 rounded-lg border border-[color:var(--monomat-border-default)] bg-[var(--monomat-page-bg)] px-3 py-3">
+        <div className={metricClassName}>
             <dt className="truncate text-[11px] font-semibold leading-none text-[var(--monomat-text-muted)]">
                 {label}
             </dt>
-            <dd className={`mt-2 text-xl font-extrabold leading-none ${valueClassName}`}>
+            <dd className={`${valueTextClassName} ${valueClassName}`}>
                 {value}
             </dd>
         </div>
@@ -39,13 +64,24 @@ export function LobbyReadySummary({
     readyTargetCount,
     readyCount,
     waitingCount,
+    variant = 'default',
 }: LobbyReadySummaryProps) {
+    const isInline = variant === 'inline';
+    const metricListClassName = isInline
+        ? 'mt-2 flex flex-wrap gap-1.5'
+        : variant === 'compact'
+            ? 'mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4'
+            : 'mt-3 grid grid-cols-2 gap-3';
+    const titleClassName = isInline
+        ? '!m-0 !text-sm !font-extrabold !leading-5 !text-[var(--monomat-text-strong)]'
+        : '!m-0 !text-base !font-extrabold !leading-5 !text-[var(--monomat-text-strong)]';
+
     return (
         <section aria-labelledby="lobby-ready-summary-title">
             <div className="flex items-center justify-between gap-3">
                 <h3
                     id="lobby-ready-summary-title"
-                    className="!m-0 !text-base !font-extrabold !leading-5 !text-[var(--monomat-text-strong)]"
+                    className={titleClassName}
                 >
                     {LOBBY_ROOM_COPY.READY_SUMMARY_TITLE}
                 </h3>
@@ -54,29 +90,39 @@ export function LobbyReadySummary({
                 </span>
             </div>
 
-            <dl className="mt-3 grid grid-cols-2 gap-3">
+            <dl className={metricListClassName}>
                 <SummaryMetric
                     label={LOBBY_ROOM_COPY.READY_SUMMARY_TOTAL}
                     value={totalPlayerCount}
+                    variant={variant}
                 />
                 <SummaryMetric
                     label={LOBBY_ROOM_COPY.READY_SUMMARY_TARGET}
                     value={readyTargetCount}
+                    variant={variant}
                 />
                 <SummaryMetric
                     label={LOBBY_ROOM_COPY.READY_SUMMARY_READY}
                     value={readyCount}
                     tone="ready"
+                    variant={variant}
                 />
                 <SummaryMetric
                     label={LOBBY_ROOM_COPY.READY_SUMMARY_WAITING}
                     value={waitingCount}
                     tone="waiting"
+                    variant={variant}
                 />
             </dl>
 
             {readyTargetCount === 0 && (
-                <p className="mt-3 break-keep rounded-lg bg-[var(--monomat-page-bg)] px-3 py-2 text-xs font-semibold leading-5 text-[var(--monomat-text-muted)]">
+                <p
+                    className={`break-keep text-xs font-semibold leading-5 text-[var(--monomat-text-muted)] ${
+                        isInline
+                            ? 'mt-2'
+                            : 'mt-3 rounded-lg bg-[var(--monomat-page-bg)] px-3 py-2'
+                    }`}
+                >
                     {LOBBY_ROOM_COPY.READY_SUMMARY_EMPTY}
                 </p>
             )}

--- a/src/components/lobby/MapSelectModal.tsx
+++ b/src/components/lobby/MapSelectModal.tsx
@@ -41,6 +41,7 @@ import type {
 interface MapSelectModalProps {
     isOpen: boolean;
     selectedMap: MapSummary | null;
+    selectedMapId?: number | null;
     onConfirm: (map: MapSummary) => void;
     onClose: () => void;
 }
@@ -103,6 +104,7 @@ function MapSelectModalSkeleton() {
 export function MapSelectModal({
     isOpen,
     selectedMap,
+    selectedMapId,
     onConfirm,
     onClose,
 }: MapSelectModalProps) {
@@ -330,11 +332,11 @@ export function MapSelectModal({
                 aria-modal="true"
                 aria-labelledby="map-select-modal-title"
                 onMouseDown={handleContentMouseDown}
-                className="flex max-h-[calc(100vh-64px)] w-full max-w-[500px] flex-col overflow-hidden rounded-[14px] bg-white shadow-[0_18px_48px_rgba(15,23,42,0.22)]"
+                className="flex max-h-[calc(100vh-64px)] w-full max-w-[500px] flex-col overflow-hidden rounded-[14px] bg-white text-left shadow-[0_18px_48px_rgba(15,23,42,0.22)]"
             >
                 <header className="px-[25px] pb-0 pt-9">
                     <div className="flex items-start justify-between gap-4">
-                        <div className="min-w-0">
+                        <div className="min-w-0 text-left">
                             <h2
                                 id="map-select-modal-title"
                                 className="!m-0 !text-[24px] !font-extrabold !leading-[33px] !text-black"
@@ -446,8 +448,10 @@ export function MapSelectModal({
                     ) : (
                         <div className="space-y-0">
                             {maps.map((map) => {
+                                const selectedMapIdForCompare =
+                                    tempSelectedMap?.mapId ?? selectedMapId;
                                 const isSelected =
-                                    tempSelectedMap?.mapId === map.mapId;
+                                    selectedMapIdForCompare === map.mapId;
 
                                 return (
                                     <div
@@ -514,7 +518,7 @@ export function MapSelectModal({
                                         </button>
 
                                         {isSelected && (
-                                            <div className="mb-4 ml-[5px] mr-[5px] whitespace-pre-line break-keep border-t border-[color:var(--monomat-border-default)] px-[50px] pb-2 pt-[10px] text-xs font-medium leading-5 text-[var(--monomat-text-muted)] [overflow-wrap:anywhere]">
+                                            <div className="mb-4 ml-[5px] mr-[5px] whitespace-pre-line break-keep border-t border-[color:var(--monomat-border-default)] px-[50px] pb-2 pt-[10px] text-left text-xs font-medium leading-5 text-[var(--monomat-text-muted)] [overflow-wrap:anywhere]">
                                                 {formatMapDescription(
                                                     map.description,
                                                 )}

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -44,6 +44,7 @@ export const API_ENDPOINTS = {
         JOIN: createApiEndpoint('/api/lobbies/join'),
         LIST: createApiEndpoint('/api/lobbies'),
         DETAIL: (code: string) => createApiEndpoint(`/api/lobbies/${code}`),
+        MAP: (code: string) => createApiEndpoint(`/api/lobbies/${code}/map`),
         READY: (code: string) => createApiEndpoint(`/api/lobbies/${code}/ready`),
         START: (code: string) => createApiEndpoint(`/api/lobbies/${code}/start`),
     },

--- a/src/constants/lobby.ts
+++ b/src/constants/lobby.ts
@@ -162,11 +162,14 @@ export const LOBBY_ROOM_COPY = {
         '현재 서버 기준으로 아직 시작할 수 없습니다.',
     START_GUIDE_AVAILABLE:
         '모든 조건이 충족되었습니다. 게임을 시작할 수 있습니다.',
+    MAP_CHANGE_PENDING_GUIDE:
+        '맵 변경 사항을 반영하는 중입니다. 잠시 후 시작할 수 있습니다.',
     READY_SYNCED: '준비 상태는 서버 이벤트로 다시 동기화됩니다.',
     READY_WAIT_PLAYER: '참여자 정보 동기화 후 준비할 수 있습니다.',
     START_REQUESTED: '게임 시작 요청을 보냈습니다.',
     GAME_STARTED_PENDING_ROUTE:
         '게임이 시작되었습니다. 게임 화면 전환은 추후 연결됩니다.',
+    MAP_CHANGE_FAILED: '로비 맵 변경에 실패했습니다.',
     READY_CHANGE_FAILED: '준비 상태 변경에 실패했습니다.',
     START_FAILED: '게임 시작에 실패했습니다.',
     INVALID_INVITE_CODE: '초대 코드가 올바르지 않습니다.',

--- a/src/mocks/handlers/lobby.ts
+++ b/src/mocks/handlers/lobby.ts
@@ -26,6 +26,13 @@ const LOBBY_SORT_QUERIES = [
 ] as const;
 
 let latestCreatedLobby: LobbyDetailResponse | null = null;
+const mockLobbyDetailOverrides = new Map<
+    string,
+    Partial<Pick<
+        LobbyDetailResponse,
+        'mapId' | 'mapTitle' | 'mapCategory' | 'questionCount'
+    >>
+>();
 
 const MOCK_PLAYER_POOL = [
     {
@@ -165,6 +172,7 @@ function canStartMockLobby(lobby: {
 function createLobbyDetailFromItem(
     lobby: LobbyListItem,
 ): LobbyDetailResponse {
+    const override = mockLobbyDetailOverrides.get(lobby.code);
     const hostPlayer: LobbyPlayerResponse = {
         userIdentifier: lobby.hostId ?? 'mock-host',
         nickname: lobby.hostNickname ?? 'Mock Host',
@@ -191,10 +199,11 @@ function createLobbyDetailFromItem(
         maxPlayers: lobby.maxPlayers,
         currentPlayers: lobby.currentPlayers,
         status: lobby.status,
-        mapId: lobby.mapId,
-        mapTitle: lobby.mapTitle,
-        mapCategory: lobby.mapCategory,
+        mapId: override?.mapId ?? lobby.mapId,
+        mapTitle: override?.mapTitle ?? lobby.mapTitle,
+        mapCategory: override?.mapCategory ?? lobby.mapCategory,
         questionCount:
+            override?.questionCount ??
             lobby.questionCount ?? CREATE_LOBBY_POLICY.DEFAULT_QUESTION_COUNT,
         timeLimitSeconds:
             lobby.timeLimitSeconds ??
@@ -202,8 +211,8 @@ function createLobbyDetailFromItem(
         players,
         canStart: canStartMockLobby({
             status: lobby.status,
-            mapId: lobby.mapId,
-            mapTitle: lobby.mapTitle,
+            mapId: override?.mapId ?? lobby.mapId,
+            mapTitle: override?.mapTitle ?? lobby.mapTitle,
             players,
         }),
     };
@@ -302,6 +311,69 @@ export const lobbyHandlers = [
         }
 
         return HttpResponse.json(createLobbyDetailFromItem(lobby));
+    }),
+
+    http.patch(API_ENDPOINTS.LOBBY.MAP(':code'), async ({ params, request }) => {
+        const code = typeof params.code === 'string' ? params.code : '';
+        const payload = (await request.json()) as { mapId?: unknown };
+        const mapId = typeof payload.mapId === 'number' ? payload.mapId : null;
+        const selectedMap = mapId == null
+            ? null
+            : mockMapItems.find((map) => map.mapId === mapId) ?? null;
+
+        if (!selectedMap) {
+            return HttpResponse.json(
+                { message: '맵을 찾을 수 없습니다.' },
+                { status: 404 },
+            );
+        }
+
+        if (latestCreatedLobby?.inviteCode === code) {
+            const nextLobby: LobbyDetailResponse = {
+                ...latestCreatedLobby,
+                mapId: selectedMap.mapId,
+                mapTitle: selectedMap.title,
+                mapCategory: selectedMap.category,
+                questionCount: selectedMap.numOfSong,
+            };
+
+            latestCreatedLobby = {
+                ...nextLobby,
+                canStart: canStartMockLobby({
+                    status: nextLobby.status,
+                    mapId: nextLobby.mapId,
+                    mapTitle: nextLobby.mapTitle,
+                    players: nextLobby.players,
+                }),
+            };
+
+            return new HttpResponse(null, { status: 204 });
+        }
+
+        const lobby = mockLobbyItems.find((item) => item.code === code);
+
+        if (!lobby) {
+            return HttpResponse.json(
+                { message: '로비를 찾을 수 없습니다.' },
+                { status: 404 },
+            );
+        }
+
+        if (lobby.status !== 'WAITING') {
+            return HttpResponse.json(
+                { message: '대기 중인 로비에서만 맵을 변경할 수 있습니다.' },
+                { status: 409 },
+            );
+        }
+
+        mockLobbyDetailOverrides.set(code, {
+            mapId: selectedMap.mapId,
+            mapTitle: selectedMap.title,
+            mapCategory: selectedMap.category,
+            questionCount: selectedMap.numOfSong,
+        });
+
+        return new HttpResponse(null, { status: 204 });
     }),
 
     // 클라이언트가 GET 메서드로 로비 목록 엔드포인트에 요청을 보낼 때 이를 가로챈다.

--- a/src/pages/LobbyRoom.tsx
+++ b/src/pages/LobbyRoom.tsx
@@ -3,7 +3,11 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Gamepad2 } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 
-import { startLobbyGame, updateLobbyReady } from '../api/lobbyApi';
+import {
+    startLobbyGame,
+    updateLobbyMap,
+    updateLobbyReady,
+} from '../api/lobbyApi';
 import { NavigationBar } from '../components/common/NavigationBar';
 import { HostLobbyActionCard } from '../components/lobby/HostLobbyActionCard';
 import { LobbyChatPlaceholder } from '../components/lobby/LobbyChatPlaceholder';
@@ -13,6 +17,7 @@ import { LobbyMapInfoCard } from '../components/lobby/LobbyMapInfoCard';
 import { LobbyPlayersCard } from '../components/lobby/LobbyPlayersCard';
 import { LobbyRoomLayout } from '../components/lobby/LobbyRoomLayout';
 import { LobbyRoomTopControls } from '../components/lobby/LobbyRoomTopControls';
+import { MapSelectModal } from '../components/lobby/MapSelectModal';
 import { LOBBY_ROOM_COPY, LOBBY_ROUTES } from '../constants/lobby';
 import {
     lobbyDetailQueryKey,
@@ -20,6 +25,7 @@ import {
 } from '../hooks/useLobbyDetail';
 import { useLobbySocket } from '../hooks/useLobbySocket';
 import { useAuthStore } from '../store/useAuthStore';
+import type { MapSummary } from '../types/map';
 
 interface LobbyActionMessage {
     inviteCode: string;
@@ -149,6 +155,7 @@ export function LobbyRoom() {
         useState<LobbyActionMessage | null>(null);
     const [actionErrorMessage, setActionErrorMessage] =
         useState<LobbyActionMessage | null>(null);
+    const [isMapSelectModalOpen, setIsMapSelectModalOpen] = useState(false);
 
     const currentPlayer = useMemo(() => {
         if (!lobbyDetail || !userIdentifier) {
@@ -224,6 +231,36 @@ export function LobbyRoom() {
         },
     });
 
+    const mapMutation = useMutation({
+        mutationFn: (map: MapSummary) => {
+            if (!inviteCode) {
+                throw new Error(LOBBY_ROOM_COPY.INVALID_INVITE_CODE);
+            }
+
+            return updateLobbyMap(inviteCode, { mapId: map.mapId });
+        },
+        onMutate: () => {
+            setActionMessage(null);
+            setActionErrorMessage(null);
+        },
+        onSuccess: async () => {
+            await invalidateLobbyDetail();
+        },
+        onError: (mutationError) => {
+            if (!inviteCode) {
+                return;
+            }
+
+            setActionErrorMessage({
+                inviteCode,
+                message: getErrorMessage(
+                    mutationError,
+                    LOBBY_ROOM_COPY.MAP_CHANGE_FAILED,
+                ),
+            });
+        },
+    });
+
     const startMutation = useMutation({
         mutationFn: () => {
             if (!inviteCode) {
@@ -270,11 +307,43 @@ export function LobbyRoom() {
     };
 
     const handleStartClick = () => {
-        if (!isHost || !lobbyDetail?.canStart || startMutation.isPending) {
+        if (
+            !isHost ||
+            !lobbyDetail?.canStart ||
+            startMutation.isPending ||
+            mapMutation.isPending
+        ) {
             return;
         }
 
         startMutation.mutate();
+    };
+
+    const handleMapChangeClick = () => {
+        if (
+            !isHost ||
+            lobbyDetail?.status !== 'WAITING' ||
+            mapMutation.isPending ||
+            startMutation.isPending
+        ) {
+            return;
+        }
+
+        setActionMessage(null);
+        setActionErrorMessage(null);
+        setIsMapSelectModalOpen(true);
+    };
+
+    const handleMapConfirm = (map: MapSummary) => {
+        if (!isHost || mapMutation.isPending) {
+            return;
+        }
+
+        if (map.mapId === lobbyDetail?.mapId) {
+            return;
+        }
+
+        mapMutation.mutate(map);
     };
 
     if (!inviteCode) {
@@ -315,6 +384,7 @@ export function LobbyRoom() {
 
     const isReadyButtonDisabled =
         readyMutation.isPending || !currentPlayer || isHost;
+    const isWaitingLobby = lobbyDetail.status === 'WAITING';
     const hasSelectedMap =
         lobbyDetail.mapId != null && Boolean(lobbyDetail.mapTitle?.trim());
     const hostStartGuideMessage = getHostStartGuideMessage({
@@ -323,6 +393,9 @@ export function LobbyRoom() {
         readyTargetCount: readySummary.readyTargetCount,
         waitingCount: readySummary.waitingCount,
     });
+    const displayedHostStartGuideMessage = mapMutation.isPending
+        ? LOBBY_ROOM_COPY.MAP_CHANGE_PENDING_GUIDE
+        : hostStartGuideMessage;
     const currentActionMessage =
         actionMessage?.inviteCode === inviteCode ? actionMessage.message : null;
     const currentActionErrorMessage =
@@ -378,6 +451,9 @@ export function LobbyRoom() {
                             mapTitle={lobbyDetail.mapTitle}
                             mapCategory={lobbyDetail.mapCategory}
                             questionCount={lobbyDetail.questionCount}
+                            canChangeMap={isHost && isWaitingLobby}
+                            isMapChangePending={mapMutation.isPending}
+                            onMapChangeClick={handleMapChangeClick}
                         />
                     }
                     playersCard={
@@ -398,9 +474,22 @@ export function LobbyRoom() {
                     actionSlot={
                         isHost ? (
                             <HostLobbyActionCard
-                                canStart={lobbyDetail.canStart}
+                                canStart={
+                                    lobbyDetail.canStart &&
+                                    !mapMutation.isPending
+                                }
                                 isStarting={startMutation.isPending}
-                                startGuideMessage={hostStartGuideMessage}
+                                startGuideMessage={
+                                    displayedHostStartGuideMessage
+                                }
+                                totalPlayerCount={
+                                    readySummary.totalPlayerCount
+                                }
+                                readyTargetCount={
+                                    readySummary.readyTargetCount
+                                }
+                                readyCount={readySummary.readyCount}
+                                waitingCount={readySummary.waitingCount}
                                 onStartClick={handleStartClick}
                             />
                         ) : (
@@ -441,6 +530,14 @@ export function LobbyRoom() {
                     }
                 />
             </main>
+
+            <MapSelectModal
+                isOpen={isMapSelectModalOpen}
+                selectedMap={null}
+                selectedMapId={lobbyDetail.mapId}
+                onConfirm={handleMapConfirm}
+                onClose={() => setIsMapSelectModalOpen(false)}
+            />
         </LobbyRoomShell>
     );
 }

--- a/src/types/lobby.ts
+++ b/src/types/lobby.ts
@@ -97,6 +97,10 @@ export interface UpdateLobbyReadyRequest {
     ready: boolean;
 }
 
+export interface UpdateLobbyMapRequest {
+    mapId: number;
+}
+
 export interface CreateLobbyRequest {
     title: string;
     maxPlayers: number;


### PR DESCRIPTION
## 📣 Related Issue

- #104

## 📝 Summary

- 방장 전용 액션 영역에 준비 상태 요약, 시작 가능/불가 안내, 게임 시작 CTA를 추가했습니다.
- 방장을 제외한 참가자 기준으로 준비 대상/준비 완료/대기 중 인원을 계산하도록 반영했습니다.
- 방장 대기실의 로비 제목 카드에 `맵 변경` 버튼을 추가하고, 기존 맵 선택 모달을 재사용해 `PATCH /api/lobbies/{code}/map` API와 연결했습니다.
- 맵 변경 중에는 게임 시작 버튼을 비활성화해 중복 액션을 막았습니다.
- 맵 선택 모달의 제목/설명/선택 맵 설명 영역을 왼쪽 정렬로 정리했습니다.
- MSW에서 로비 맵 변경 mock 응답을 보강했습니다.

## 🙏PR point

- 게임 시작 가능 여부의 최종 판단은 기존처럼 BE의 `canStart` 값을 사용합니다.
- 준비 상태 요약은 `players` 기준으로 계산하며, 방장은 준비 대상에서 제외합니다.
- BE develop 기준으로 확인된 로비 수정 API는 맵 변경 API뿐이라 `maxPlayers`, `questionCount`, `timeLimitSeconds` 직접 수정 UI는 포함하지 않았습니다.

## 📬 Reference

- Figma 방장 로비 대기실 프레임
- Monomat-BE develop `PATCH /api/lobbies/{code}/map` 계약