### PR TITLE
[Deploy/#112] FE Docker 배포 설정 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+.git
+.github
+.vscode
+.idea
+.DS_Store
+npm-debug.log
+.env
+.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+
+FROM node:22-alpine AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+
+FROM nginx:1.27-alpine AS runtime
+
+COPY nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  monomat-fe:
+    container_name: monomat-fe
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      - "3000:80"

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,28 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types
+        text/plain
+        text/css
+        application/json
+        application/javascript
+        text/xml
+        application/xml
+        application/xml+rss
+        image/svg+xml;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location ~* \.(?:js|css|png|jpg|jpeg|gif|ico|svg|webp|woff2?)$ {
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+}


### PR DESCRIPTION
## 📣 Related Issue

- #112

## 📝 Summary

- Monomat-FE 운영 배포용 Dockerfile 추가
- Nginx 정적 파일 서빙 설정 추가
- React Router 새로고침 대응을 위한 SPA fallback 설정 추가
- Docker 빌드 컨텍스트 최적화를 위한 `.dockerignore` 추가

## 🙏PR point

- BE와 같은 OCI 인스턴스에 배포하는 것을 기준으로 작성했습니다.
- `/api`, `/ws` 프록시는 FE 컨테이너 내부 Nginx가 아니라 Caddy에서 처리하는 것을 전제로 합니다.
- FE 컨테이너는 정적 파일 서빙만 담당합니다.

## 📬 Reference

- Vite production build
- Nginx static file serving
