### PR TITLE
[Deploy/114]: GitHub Actions 자동 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,73 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+jobs:
+  build-and-push:
+    if: github.repository == 'AS-Crew/Monomat-FE'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve image tags
+        id: meta
+        run: |
+          name=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')
+          echo "image=${name}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.image }}:latest
+            ${{ steps.meta.outputs.image }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build-and-push
+    if: github.repository == 'AS-Crew/Monomat-FE'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_SSH_HOST }}
+          username: ${{ secrets.DEPLOY_SSH_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            set -e
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+            cd ~/monomat-fe
+            docker compose pull
+            docker compose up -d
+            docker image prune -f
+            docker logout ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,13 @@ COPY package.json package-lock.json ./
 RUN npm ci
 
 COPY . .
+
+# Vite 환경변수는 빌드 시점에 번들로 포함되므로 build stage에서 주입한다.
+ARG VITE_API_BASE_URL=https://api.monomat.games
+ARG VITE_WS_URL=https://api.monomat.games/ws
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
+ENV VITE_WS_URL=$VITE_WS_URL
+
 RUN npm run build
 
 


### PR DESCRIPTION
## 📣 Related Issue
- #114

## 📝 Summary
- `main` 브랜치 push 시 동작하는 GitHub Actions 자동 배포 워크플로우(`.github/workflows/deploy.yml`) 추가
- Docker 이미지를 빌드해 GHCR(`ghcr.io/as-crew/monomat-fe`)에 푸시한 뒤, OCI 서버에 SSH로 접속해 이미지 pull & 컨테이너 재시작
- Vite 빌드 환경변수(`VITE_API_BASE_URL`, `VITE_WS_URL`)를 build stage에서 주입하도록 Dockerfile 수정 (기본값: `https://api.monomat.games`)
- 수동 실행(`workflow_dispatch`) 지원 및 포크/PR 실행 방지용 레포지토리 가드 포함

## 🙏PR point
- 배포 동작을 위해 **upstream 레포 Settings → Secrets에 아래 3개 등록이 필요**합니다:
  - `DEPLOY_SSH_HOST` (OCI 서버 IP)
  - `DEPLOY_SSH_USER` (SSH 접속 계정)
  - `DEPLOY_SSH_KEY` (배포용 SSH 개인키)
- GHCR 푸시는 `GITHUB_TOKEN`으로 처리되어 별도 토큰 secret은 불필요합니다.
- 서버 측에는 `~/monomat-fe/docker-compose.yml`(GHCR 이미지 참조)과 Caddy `monomat.games` 리버스 프록시 설정이 필요합니다. (별도 진행)
- 워크플로우 트리거를 `main`으로 설정했습니다. develop → main 머지 시점에 배포가 동작합니다.

## 📬 Reference
- 관련 이슈: #114, #112
