### PR TITLE
[fix/#116]: 배포 이미지를 ARM64로 빌드

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,9 @@ jobs:
           name=$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')
           echo "image=${name}" >> "$GITHUB_OUTPUT"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -46,6 +49,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/arm64
           tags: |
             ${{ steps.meta.outputs.image }}:latest
             ${{ steps.meta.outputs.image }}:${{ github.sha }}


### PR DESCRIPTION
## 📣 Related Issue
- #116

## 📝 Summary
- 운영 서버(OCI)가 ARM64(aarch64) 아키텍처라 기존 amd64 이미지가 실행되지 않는 문제 수정
- `docker/setup-qemu-action` 추가로 ARM64 에뮬레이션 빌드 지원
- `docker/build-push-action`에 `platforms: linux/arm64` 지정

## 🙏PR point
- GitHub Actions(amd64 러너)에서 QEMU 에뮬레이션으로 arm64 이미지를 빌드하므로 빌드 시간이 다소 늘어날 수 있습니다.
- 서버 측 Compose V2 플러그인 부재 문제는 서버에 직접 설치하여 해결했습니다(코드 변경 없음).

## 📬 Reference
- 관련 이슈: #116, #114
