### PR TITLE
[Feat/#111] 방장 로비 설정 수정 UI 연동

### DIFF
--- a/src/api/lobbyApi.ts
+++ b/src/api/lobbyApi.ts
@@ -19,6 +19,7 @@ import type {
     LobbyPageResponse,
     UpdateLobbyMapRequest,
     UpdateLobbyReadyRequest,
+    UpdateLobbySettingsRequest,
 } from '../types/lobby';
 
 const JSON_CONTENT_TYPE = 'application/json';
@@ -28,6 +29,7 @@ const DEFAULT_JOIN_LOBBY_ERROR_MESSAGE = '로비 입장에 실패했습니다.';
 const DEFAULT_FETCH_LOBBY_LIST_ERROR_MESSAGE = '로비 목록을 불러오는 데 실패했습니다.';
 const DEFAULT_FETCH_LOBBY_DETAIL_ERROR_MESSAGE = '로비 정보를 불러오는 데 실패했습니다.';
 const DEFAULT_UPDATE_LOBBY_MAP_ERROR_MESSAGE = '로비 맵 변경에 실패했습니다.';
+const DEFAULT_UPDATE_LOBBY_SETTINGS_ERROR_MESSAGE = '로비 설정 변경에 실패했습니다.';
 const DEFAULT_UPDATE_LOBBY_READY_ERROR_MESSAGE = '준비 상태 변경에 실패했습니다.';
 const DEFAULT_START_LOBBY_GAME_ERROR_MESSAGE = '게임 시작에 실패했습니다.';
 
@@ -225,6 +227,26 @@ export async function updateLobbyMap(
         throw await createApiError(
             response,
             DEFAULT_UPDATE_LOBBY_MAP_ERROR_MESSAGE,
+        );
+    }
+}
+
+export async function updateLobbySettings(
+    code: string,
+    request: UpdateLobbySettingsRequest,
+): Promise<void> {
+    const response = await fetchWithAuth(API_ENDPOINTS.LOBBY.SETTINGS(code), {
+        method: 'PATCH',
+        headers: {
+            'Content-Type': JSON_CONTENT_TYPE,
+        },
+        body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            DEFAULT_UPDATE_LOBBY_SETTINGS_ERROR_MESSAGE,
         );
     }
 }

--- a/src/components/common/AccountModal.tsx
+++ b/src/components/common/AccountModal.tsx
@@ -14,6 +14,7 @@ import {
     updateMyNickname,
 } from '../../api/userApi';
 import { GUEST_NICKNAME_POLICY } from '../../constants/auth';
+import { STORAGE_KEYS } from '../../constants/storage';
 import { useAuthStore } from '../../store/useAuthStore';
 import { getAvatarColor } from '../../utils/avatarColor';
 import { validateGuestNickname } from '../../utils/validateNickname';
@@ -168,8 +169,24 @@ function AccountModalContent({
 
     const handleRegisterClick = () => {
         handleClose();
+
+        try {
+            sessionStorage.setItem(
+                STORAGE_KEYS.REGISTER_ENTRY_INTENT,
+                'true',
+            );
+        } catch (error) {
+            console.error(
+                '[AccountModal] 회원가입 화면 이동 상태 저장 실패:',
+                error,
+            );
+        }
+
         clearSession();
-        navigate('/', { state: { authMode: 'register' } });
+        navigate('/?authMode=register', {
+            replace: true,
+            flushSync: true,
+        });
     };
 
     const handleLogout = () => {

--- a/src/components/lobby/LobbySettingsEditor.tsx
+++ b/src/components/lobby/LobbySettingsEditor.tsx
@@ -1,0 +1,234 @@
+import {
+    type ChangeEvent,
+    type FormEvent,
+    useState,
+} from 'react';
+
+import {
+    CREATE_LOBBY_POLICY,
+    LOBBY_ROOM_COPY,
+} from '../../constants/lobby';
+import { updateLobbySettingsRequestSchema } from '../../schemas/lobbySchema';
+import type { UpdateLobbySettingsRequest } from '../../types/lobby';
+
+interface LobbySettingsEditorProps extends UpdateLobbySettingsRequest {
+    currentPlayers: number;
+    isEditable: boolean;
+    isSaving: boolean;
+    onSubmit: (request: UpdateLobbySettingsRequest) => void;
+}
+
+interface LobbySettingsRangeProps {
+    id: string;
+    label: string;
+    value: number;
+    unit?: string;
+    min: number;
+    max: number;
+    disabled: boolean;
+    onChange: (value: number) => void;
+}
+
+function getRangeBackground(value: number, min: number, max: number) {
+    const progress = ((value - min) / (max - min)) * 100;
+
+    return `linear-gradient(to right, var(--monomat-primary) ${progress}%, var(--monomat-border-input) ${progress}%)`;
+}
+
+function LobbySettingsRange({
+    id,
+    label,
+    value,
+    unit = '',
+    min,
+    max,
+    disabled,
+    onChange,
+}: LobbySettingsRangeProps) {
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+        onChange(Number(event.target.value));
+    };
+
+    return (
+        <label htmlFor={id} className="block min-w-0">
+            <span className="mb-[9px] block text-base leading-5 text-[var(--monomat-text-muted)]">
+                {label} :{' '}
+                <strong className="font-semibold text-[var(--monomat-text-strong)]">
+                    {value}
+                    {unit}
+                </strong>
+            </span>
+
+            <input
+                id={id}
+                type="range"
+                min={min}
+                max={max}
+                value={value}
+                disabled={disabled}
+                onChange={handleChange}
+                style={{
+                    background: getRangeBackground(value, min, max),
+                }}
+                className="block h-[7px] w-full cursor-pointer appearance-none rounded-[3px] border border-[var(--monomat-border-input)] outline-none transition disabled:cursor-not-allowed disabled:opacity-50 [&::-moz-range-thumb]:h-3 [&::-moz-range-thumb]:w-3 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-[var(--monomat-primary)] [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[var(--monomat-primary)]"
+            />
+        </label>
+    );
+}
+
+export function LobbySettingsEditor({
+    maxPlayers,
+    questionCount,
+    timeLimitSeconds,
+    currentPlayers,
+    isEditable,
+    isSaving,
+    onSubmit,
+}: LobbySettingsEditorProps) {
+    const [formState, setFormState] = useState<UpdateLobbySettingsRequest>({
+        maxPlayers,
+        questionCount,
+        timeLimitSeconds,
+    });
+    const [validationMessage, setValidationMessage] = useState<string | null>(
+        null,
+    );
+
+    const isDirty =
+        formState.maxPlayers !== maxPlayers ||
+        formState.questionCount !== questionCount ||
+        formState.timeLimitSeconds !== timeLimitSeconds;
+    const isDisabled = !isEditable || isSaving;
+    const hasPlayerCountConflict = formState.maxPlayers < currentPlayers;
+
+    const updateFormState = (
+        key: keyof UpdateLobbySettingsRequest,
+        value: number,
+    ) => {
+        setFormState((currentFormState) => ({
+            ...currentFormState,
+            [key]: value,
+        }));
+        setValidationMessage(null);
+    };
+
+    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        if (isDisabled) {
+            return;
+        }
+
+        if (!isDirty) {
+            setValidationMessage(LOBBY_ROOM_COPY.SETTINGS_UNCHANGED);
+            return;
+        }
+
+        if (hasPlayerCountConflict) {
+            setValidationMessage(
+                LOBBY_ROOM_COPY.SETTINGS_MAX_PLAYERS_CONFLICT,
+            );
+            return;
+        }
+
+        const parsed = updateLobbySettingsRequestSchema.safeParse(formState);
+
+        if (!parsed.success) {
+            setValidationMessage('설정값의 허용 범위를 확인해주세요.');
+            return;
+        }
+
+        setValidationMessage(null);
+        onSubmit(parsed.data);
+    };
+
+    return (
+        <form
+            onSubmit={handleSubmit}
+            className="rounded-2xl bg-white px-[25px] py-5 text-left shadow-[0_4px_16px_rgba(0,0,0,0.16)]"
+        >
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                    <h2 className="!m-0 !text-lg !font-bold !leading-6 !text-[var(--monomat-text-strong)]">
+                        {LOBBY_ROOM_COPY.GAME_SETTING_TITLE}
+                    </h2>
+                    <p className="mt-1 text-xs font-medium leading-5 text-[var(--monomat-text-muted)]">
+                        현재 참가자 {currentPlayers}명 · 저장 후 서버 설정으로 다시 동기화됩니다.
+                    </p>
+                </div>
+
+                {!isEditable && (
+                    <p className="break-keep text-xs font-bold leading-5 text-amber-700">
+                        {LOBBY_ROOM_COPY.SETTINGS_NOT_WAITING}
+                    </p>
+                )}
+            </div>
+
+            <div className="mt-[15px] grid gap-5 md:grid-cols-3 md:gap-[60px]">
+                <LobbySettingsRange
+                    id="lobby-settings-max-players"
+                    label={LOBBY_ROOM_COPY.MAX_PLAYERS}
+                    value={formState.maxPlayers}
+                    unit="명"
+                    min={CREATE_LOBBY_POLICY.MIN_PLAYERS}
+                    max={CREATE_LOBBY_POLICY.MAX_PLAYERS}
+                    disabled={isDisabled}
+                    onChange={(value) =>
+                        updateFormState('maxPlayers', value)
+                    }
+                />
+                <LobbySettingsRange
+                    id="lobby-settings-question-count"
+                    label={LOBBY_ROOM_COPY.QUESTION_COUNT}
+                    value={formState.questionCount}
+                    min={CREATE_LOBBY_POLICY.MIN_QUESTION_COUNT}
+                    max={CREATE_LOBBY_POLICY.MAX_QUESTION_COUNT}
+                    disabled={isDisabled}
+                    onChange={(value) =>
+                        updateFormState('questionCount', value)
+                    }
+                />
+                <LobbySettingsRange
+                    id="lobby-settings-time-limit"
+                    label={LOBBY_ROOM_COPY.TIME_LIMIT}
+                    value={formState.timeLimitSeconds}
+                    unit="초"
+                    min={CREATE_LOBBY_POLICY.MIN_TIME_LIMIT_SECONDS}
+                    max={CREATE_LOBBY_POLICY.MAX_TIME_LIMIT_SECONDS}
+                    disabled={isDisabled}
+                    onChange={(value) =>
+                        updateFormState('timeLimitSeconds', value)
+                    }
+                />
+            </div>
+
+            <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="min-h-5">
+                    {(validationMessage || hasPlayerCountConflict) && (
+                        <p
+                            role="alert"
+                            className="break-keep text-xs font-bold leading-5 text-[var(--monomat-danger)]"
+                        >
+                            {validationMessage ??
+                                LOBBY_ROOM_COPY.SETTINGS_MAX_PLAYERS_CONFLICT}
+                        </p>
+                    )}
+                </div>
+
+                <button
+                    type="submit"
+                    disabled={
+                        isDisabled ||
+                        !isDirty ||
+                        hasPlayerCountConflict
+                    }
+                    className="h-10 w-full rounded-lg bg-[var(--monomat-primary)] px-5 text-sm font-bold text-white transition hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:bg-[var(--monomat-primary-disabled)] sm:w-auto"
+                >
+                    {isSaving
+                        ? LOBBY_ROOM_COPY.SETTINGS_SAVE_PENDING
+                        : LOBBY_ROOM_COPY.SETTINGS_SAVE}
+                </button>
+            </div>
+        </form>
+    );
+}

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -45,6 +45,8 @@ export const API_ENDPOINTS = {
         LIST: createApiEndpoint('/api/lobbies'),
         DETAIL: (code: string) => createApiEndpoint(`/api/lobbies/${code}`),
         MAP: (code: string) => createApiEndpoint(`/api/lobbies/${code}/map`),
+        SETTINGS: (code: string) =>
+            createApiEndpoint(`/api/lobbies/${code}/settings`),
         READY: (code: string) => createApiEndpoint(`/api/lobbies/${code}/ready`),
         START: (code: string) => createApiEndpoint(`/api/lobbies/${code}/start`),
     },

--- a/src/constants/lobby.ts
+++ b/src/constants/lobby.ts
@@ -164,6 +164,16 @@ export const LOBBY_ROOM_COPY = {
         '모든 조건이 충족되었습니다. 게임을 시작할 수 있습니다.',
     MAP_CHANGE_PENDING_GUIDE:
         '맵 변경 사항을 반영하는 중입니다. 잠시 후 시작할 수 있습니다.',
+    SETTINGS_CHANGE_PENDING_GUIDE:
+        '설정 변경 사항을 반영하는 중입니다. 잠시 후 시작할 수 있습니다.',
+    SETTINGS_SAVE: '설정 저장',
+    SETTINGS_SAVE_PENDING: '저장 중...',
+    SETTINGS_SAVE_FAILED: '로비 설정 변경에 실패했습니다.',
+    SETTINGS_UNCHANGED: '변경된 설정이 없습니다.',
+    SETTINGS_NOT_WAITING:
+        '게임이 시작된 로비에서는 설정을 변경할 수 없습니다.',
+    SETTINGS_MAX_PLAYERS_CONFLICT:
+        '최대 인원은 현재 참가자 수보다 작을 수 없습니다.',
     READY_SYNCED: '준비 상태는 서버 이벤트로 다시 동기화됩니다.',
     READY_WAIT_PLAYER: '참여자 정보 동기화 후 준비할 수 있습니다.',
     START_REQUESTED: '게임 시작 요청을 보냈습니다.',

--- a/src/constants/storage.ts
+++ b/src/constants/storage.ts
@@ -8,6 +8,7 @@
 // 상수로 정의해두면 오타 시 TypeScript가 즉시 에러를 알려준다.
 export const STORAGE_KEYS = {
     GUEST_SESSION: 'monomat_guest_session', // 게스트 세션 정보 저장 키
+    REGISTER_ENTRY_INTENT: 'monomat_register_entry_intent',
 } as const;
 
 // 세션 만료 기간

--- a/src/mocks/handlers/lobby.ts
+++ b/src/mocks/handlers/lobby.ts
@@ -6,6 +6,7 @@
 import { http, HttpResponse } from 'msw';
 import { API_ENDPOINTS } from '../../constants/endpoints';
 import { CREATE_LOBBY_POLICY } from '../../constants/lobby';
+import { updateLobbySettingsRequestSchema } from '../../schemas/lobbySchema';
 import { mockLobbyItems, mockLobbyPageResponse } from '../data/lobbies';
 import { mockMapItems } from '../data/maps';
 
@@ -16,6 +17,7 @@ import type {
     LobbyListItem,
     LobbyPlayerResponse,
     LobbySortQuery,
+    UpdateLobbySettingsRequest,
 } from '../../types/lobby';
 
 const LOBBY_CATEGORIES = ['K-POP', 'J-POP', 'POP', 'OST', '애니'] as const;
@@ -30,7 +32,12 @@ const mockLobbyDetailOverrides = new Map<
     string,
     Partial<Pick<
         LobbyDetailResponse,
-        'mapId' | 'mapTitle' | 'mapCategory' | 'questionCount'
+        | 'mapId'
+        | 'mapTitle'
+        | 'mapCategory'
+        | 'maxPlayers'
+        | 'questionCount'
+        | 'timeLimitSeconds'
     >>
 >();
 
@@ -196,7 +203,7 @@ function createLobbyDetailFromItem(
         title: lobby.title,
         hostId: lobby.hostId ?? 'mock-host',
         hostNickname: lobby.hostNickname ?? 'Mock Host',
-        maxPlayers: lobby.maxPlayers,
+        maxPlayers: override?.maxPlayers ?? lobby.maxPlayers,
         currentPlayers: lobby.currentPlayers,
         status: lobby.status,
         mapId: override?.mapId ?? lobby.mapId,
@@ -206,6 +213,7 @@ function createLobbyDetailFromItem(
             override?.questionCount ??
             lobby.questionCount ?? CREATE_LOBBY_POLICY.DEFAULT_QUESTION_COUNT,
         timeLimitSeconds:
+            override?.timeLimitSeconds ??
             lobby.timeLimitSeconds ??
             CREATE_LOBBY_POLICY.DEFAULT_TIME_LIMIT_SECONDS,
         players,
@@ -367,6 +375,7 @@ export const lobbyHandlers = [
         }
 
         mockLobbyDetailOverrides.set(code, {
+            ...mockLobbyDetailOverrides.get(code),
             mapId: selectedMap.mapId,
             mapTitle: selectedMap.title,
             mapCategory: selectedMap.category,
@@ -375,6 +384,138 @@ export const lobbyHandlers = [
 
         return new HttpResponse(null, { status: 204 });
     }),
+
+    http.patch(
+        API_ENDPOINTS.LOBBY.SETTINGS(':code'),
+        async ({ params, request }) => {
+            const code = typeof params.code === 'string' ? params.code : '';
+            let payload: unknown;
+
+            try {
+                payload = await request.json();
+            } catch {
+                return HttpResponse.json(
+                    { message: '요청 본문 형식이 올바르지 않습니다.' },
+                    { status: 400 },
+                );
+            }
+
+            const parsed = updateLobbySettingsRequestSchema.safeParse(payload);
+
+            if (!parsed.success) {
+                return HttpResponse.json(
+                    { message: '로비 설정값의 허용 범위를 확인해주세요.' },
+                    { status: 400 },
+                );
+            }
+
+            const settings: UpdateLobbySettingsRequest = parsed.data;
+
+            if (latestCreatedLobby?.inviteCode === code) {
+                if (latestCreatedLobby.status !== 'WAITING') {
+                    return HttpResponse.json(
+                        {
+                            message:
+                                '게임이 이미 시작된 로비에서는 설정을 변경할 수 없습니다.',
+                        },
+                        { status: 409 },
+                    );
+                }
+
+                if (settings.maxPlayers < latestCreatedLobby.currentPlayers) {
+                    return HttpResponse.json(
+                        {
+                            message:
+                                '최대 인원은 현재 참가자 수보다 작을 수 없습니다.',
+                        },
+                        { status: 409 },
+                    );
+                }
+
+                const selectedMap = latestCreatedLobby.mapId == null
+                    ? null
+                    : mockMapItems.find(
+                        (map) => map.mapId === latestCreatedLobby?.mapId,
+                    ) ?? null;
+
+                if (
+                    selectedMap &&
+                    settings.questionCount > selectedMap.numOfSong
+                ) {
+                    return HttpResponse.json(
+                        {
+                            message:
+                                '문제 수는 선택된 맵의 등록 곡 수를 초과할 수 없습니다.',
+                        },
+                        { status: 409 },
+                    );
+                }
+
+                latestCreatedLobby = {
+                    ...latestCreatedLobby,
+                    ...settings,
+                };
+
+                return new HttpResponse(null, { status: 204 });
+            }
+
+            const lobby = mockLobbyItems.find((item) => item.code === code);
+
+            if (!lobby) {
+                return HttpResponse.json(
+                    { message: '로비를 찾을 수 없습니다.' },
+                    { status: 404 },
+                );
+            }
+
+            if (lobby.status !== 'WAITING') {
+                return HttpResponse.json(
+                    {
+                        message:
+                            '게임이 이미 시작된 로비에서는 설정을 변경할 수 없습니다.',
+                    },
+                    { status: 409 },
+                );
+            }
+
+            if (settings.maxPlayers < lobby.currentPlayers) {
+                return HttpResponse.json(
+                    {
+                        message:
+                            '최대 인원은 현재 참가자 수보다 작을 수 없습니다.',
+                    },
+                    { status: 409 },
+                );
+            }
+
+            const override = mockLobbyDetailOverrides.get(code);
+            const selectedMapId = override?.mapId ?? lobby.mapId;
+            const selectedMap = selectedMapId == null
+                ? null
+                : mockMapItems.find((map) => map.mapId === selectedMapId) ??
+                    null;
+
+            if (
+                selectedMap &&
+                settings.questionCount > selectedMap.numOfSong
+            ) {
+                return HttpResponse.json(
+                    {
+                        message:
+                            '문제 수는 선택된 맵의 등록 곡 수를 초과할 수 없습니다.',
+                    },
+                    { status: 409 },
+                );
+            }
+
+            mockLobbyDetailOverrides.set(code, {
+                ...override,
+                ...settings,
+            });
+
+            return new HttpResponse(null, { status: 204 });
+        },
+    ),
 
     // 클라이언트가 GET 메서드로 로비 목록 엔드포인트에 요청을 보낼 때 이를 가로챈다.
     http.get(API_ENDPOINTS.LOBBY.LIST, ({ request }) => {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,7 +5,7 @@ import {
     Users,
     type LucideIcon,
 } from 'lucide-react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import {
     NicknameForm,
@@ -15,6 +15,7 @@ import {
     HOME_COPY,
     HOME_FEATURES,
 } from '../constants/home';
+import { STORAGE_KEYS } from '../constants/storage';
 import { useAuthStore } from '../store/useAuthStore';
 import { MonomatLogo } from '../components/common/MonomatLogo';
 
@@ -27,30 +28,29 @@ const FEATURE_ICON: Record<
     users: Users,
 };
 
-interface HomeLocationState {
-    authMode?: AuthMode;
-}
-
-function getRequestedAuthMode(state: unknown): AuthMode | null {
-    if (
-        state &&
-        typeof state === 'object' &&
-        'authMode' in state &&
-        (state as HomeLocationState).authMode === 'register'
-    ) {
-        return 'register';
+function shouldOpenRegisterForm(searchParams: URLSearchParams) {
+    if (searchParams.get('authMode') === 'register') {
+        return true;
     }
 
-    return null;
+    try {
+        return sessionStorage.getItem(
+            STORAGE_KEYS.REGISTER_ENTRY_INTENT,
+        ) === 'true';
+    } catch {
+        return false;
+    }
 }
 
 export const Home = () => {
     const navigate = useNavigate();
-    const location = useLocation();
+    const [searchParams, setSearchParams] = useSearchParams();
     const accessToken = useAuthStore((state) => state.accessToken);
     const isHydrated = useAuthStore((state) => state.isHydrated);
     const [authMode, setAuthMode] = useState<AuthMode>(
-        () => getRequestedAuthMode(location.state) ?? 'member',
+        () => shouldOpenRegisterForm(searchParams)
+            ? 'register'
+            : 'member',
     );
     const isRegisterMode = authMode === 'register';
 
@@ -65,6 +65,30 @@ export const Home = () => {
         }
     }, [accessToken, isHydrated, navigate]);
 
+    useEffect(() => {
+        try {
+            sessionStorage.removeItem(
+                STORAGE_KEYS.REGISTER_ENTRY_INTENT,
+            );
+        } catch {
+            // sessionStorage를 사용할 수 없어도 현재 화면 상태는 유지한다.
+        }
+    }, []);
+
+    const handleAuthModeChange = (nextMode: AuthMode) => {
+        setAuthMode(nextMode);
+
+        if (
+            nextMode !== 'register' &&
+            searchParams.get('authMode') === 'register'
+        ) {
+            const nextSearchParams = new URLSearchParams(searchParams);
+
+            nextSearchParams.delete('authMode');
+            setSearchParams(nextSearchParams, { replace: true });
+        }
+    };
+
     if (!isHydrated || accessToken) {
         return null;
     }
@@ -74,7 +98,7 @@ export const Home = () => {
             <main className="flex min-h-screen min-w-0 items-start justify-center bg-[var(--monomat-page-bg)] px-5 py-8 sm:py-[72px] lg:pt-[105px]">
                 <NicknameForm
                     mode={authMode}
-                    onModeChange={setAuthMode}
+                    onModeChange={handleAuthModeChange}
                 />
             </main>
         );
@@ -125,7 +149,7 @@ export const Home = () => {
             <section className="flex min-w-0 items-start justify-center bg-[var(--monomat-page-bg)] px-5 py-8 sm:px-8 sm:py-12 md:px-6 md:pt-[72px] lg:px-8 lg:pt-[105px] xl:px-10">
                 <NicknameForm
                     mode={authMode}
-                    onModeChange={setAuthMode}
+                    onModeChange={handleAuthModeChange}
                 />
             </section>
         </main>

--- a/src/pages/LobbyRoom.tsx
+++ b/src/pages/LobbyRoom.tsx
@@ -7,6 +7,7 @@ import {
     startLobbyGame,
     updateLobbyMap,
     updateLobbyReady,
+    updateLobbySettings,
 } from '../api/lobbyApi';
 import { NavigationBar } from '../components/common/NavigationBar';
 import { HostLobbyActionCard } from '../components/lobby/HostLobbyActionCard';
@@ -17,6 +18,7 @@ import { LobbyMapInfoCard } from '../components/lobby/LobbyMapInfoCard';
 import { LobbyPlayersCard } from '../components/lobby/LobbyPlayersCard';
 import { LobbyRoomLayout } from '../components/lobby/LobbyRoomLayout';
 import { LobbyRoomTopControls } from '../components/lobby/LobbyRoomTopControls';
+import { LobbySettingsEditor } from '../components/lobby/LobbySettingsEditor';
 import { MapSelectModal } from '../components/lobby/MapSelectModal';
 import { LOBBY_ROOM_COPY, LOBBY_ROUTES } from '../constants/lobby';
 import {
@@ -26,6 +28,7 @@ import {
 import { useLobbySocket } from '../hooks/useLobbySocket';
 import { useAuthStore } from '../store/useAuthStore';
 import type { MapSummary } from '../types/map';
+import type { UpdateLobbySettingsRequest } from '../types/lobby';
 
 interface LobbyActionMessage {
     inviteCode: string;
@@ -261,6 +264,36 @@ export function LobbyRoom() {
         },
     });
 
+    const settingsMutation = useMutation({
+        mutationFn: (request: UpdateLobbySettingsRequest) => {
+            if (!inviteCode) {
+                throw new Error(LOBBY_ROOM_COPY.INVALID_INVITE_CODE);
+            }
+
+            return updateLobbySettings(inviteCode, request);
+        },
+        onMutate: () => {
+            setActionMessage(null);
+            setActionErrorMessage(null);
+        },
+        onSuccess: async () => {
+            await invalidateLobbyDetail();
+        },
+        onError: (mutationError) => {
+            if (!inviteCode) {
+                return;
+            }
+
+            setActionErrorMessage({
+                inviteCode,
+                message: getErrorMessage(
+                    mutationError,
+                    LOBBY_ROOM_COPY.SETTINGS_SAVE_FAILED,
+                ),
+            });
+        },
+    });
+
     const startMutation = useMutation({
         mutationFn: () => {
             if (!inviteCode) {
@@ -311,7 +344,8 @@ export function LobbyRoom() {
             !isHost ||
             !lobbyDetail?.canStart ||
             startMutation.isPending ||
-            mapMutation.isPending
+            mapMutation.isPending ||
+            settingsMutation.isPending
         ) {
             return;
         }
@@ -324,7 +358,8 @@ export function LobbyRoom() {
             !isHost ||
             lobbyDetail?.status !== 'WAITING' ||
             mapMutation.isPending ||
-            startMutation.isPending
+            startMutation.isPending ||
+            settingsMutation.isPending
         ) {
             return;
         }
@@ -344,6 +379,20 @@ export function LobbyRoom() {
         }
 
         mapMutation.mutate(map);
+    };
+
+    const handleSettingsSubmit = (
+        request: UpdateLobbySettingsRequest,
+    ) => {
+        if (
+            !isHost ||
+            lobbyDetail?.status !== 'WAITING' ||
+            settingsMutation.isPending
+        ) {
+            return;
+        }
+
+        settingsMutation.mutate(request);
     };
 
     if (!inviteCode) {
@@ -393,9 +442,11 @@ export function LobbyRoom() {
         readyTargetCount: readySummary.readyTargetCount,
         waitingCount: readySummary.waitingCount,
     });
-    const displayedHostStartGuideMessage = mapMutation.isPending
-        ? LOBBY_ROOM_COPY.MAP_CHANGE_PENDING_GUIDE
-        : hostStartGuideMessage;
+    const displayedHostStartGuideMessage = settingsMutation.isPending
+        ? LOBBY_ROOM_COPY.SETTINGS_CHANGE_PENDING_GUIDE
+        : mapMutation.isPending
+            ? LOBBY_ROOM_COPY.MAP_CHANGE_PENDING_GUIDE
+            : hostStartGuideMessage;
     const currentActionMessage =
         actionMessage?.inviteCode === inviteCode ? actionMessage.message : null;
     const currentActionErrorMessage =
@@ -465,18 +516,43 @@ export function LobbyRoom() {
                         />
                     }
                     settingsCard={
-                        <LobbyMapInfoCard
-                            questionCount={lobbyDetail.questionCount}
-                            timeLimitSeconds={lobbyDetail.timeLimitSeconds}
-                            maxPlayers={lobbyDetail.maxPlayers}
-                        />
+                        isHost ? (
+                            <LobbySettingsEditor
+                                key={[
+                                    lobbyDetail.inviteCode,
+                                    lobbyDetail.maxPlayers,
+                                    lobbyDetail.questionCount,
+                                    lobbyDetail.timeLimitSeconds,
+                                ].join(':')}
+                                maxPlayers={lobbyDetail.maxPlayers}
+                                questionCount={lobbyDetail.questionCount}
+                                timeLimitSeconds={
+                                    lobbyDetail.timeLimitSeconds
+                                }
+                                currentPlayers={
+                                    lobbyDetail.currentPlayers
+                                }
+                                isEditable={isWaitingLobby}
+                                isSaving={settingsMutation.isPending}
+                                onSubmit={handleSettingsSubmit}
+                            />
+                        ) : (
+                            <LobbyMapInfoCard
+                                questionCount={lobbyDetail.questionCount}
+                                timeLimitSeconds={
+                                    lobbyDetail.timeLimitSeconds
+                                }
+                                maxPlayers={lobbyDetail.maxPlayers}
+                            />
+                        )
                     }
                     actionSlot={
                         isHost ? (
                             <HostLobbyActionCard
                                 canStart={
                                     lobbyDetail.canStart &&
-                                    !mapMutation.isPending
+                                    !mapMutation.isPending &&
+                                    !settingsMutation.isPending
                                 }
                                 isStarting={startMutation.isPending}
                                 startGuideMessage={

--- a/src/schemas/lobbySchema.ts
+++ b/src/schemas/lobbySchema.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
 
+import { CREATE_LOBBY_POLICY } from '../constants/lobby';
+import type { UpdateLobbySettingsRequest } from '../types/lobby';
+
 export const lobbyCategorySchema = z.enum([
     'K-POP',
     'J-POP',
@@ -74,6 +77,19 @@ export const lobbyDetailResponseSchema = z.object({
     players: z.array(lobbyPlayerResponseSchema),
     canStart: z.boolean(),
 });
+
+export const updateLobbySettingsRequestSchema: z.ZodType<UpdateLobbySettingsRequest> =
+    z.object({
+        maxPlayers: z.number().int()
+            .min(CREATE_LOBBY_POLICY.MIN_PLAYERS)
+            .max(CREATE_LOBBY_POLICY.MAX_PLAYERS),
+        questionCount: z.number().int()
+            .min(CREATE_LOBBY_POLICY.MIN_QUESTION_COUNT)
+            .max(CREATE_LOBBY_POLICY.MAX_QUESTION_COUNT),
+        timeLimitSeconds: z.number().int()
+            .min(CREATE_LOBBY_POLICY.MIN_TIME_LIMIT_SECONDS)
+            .max(CREATE_LOBBY_POLICY.MAX_TIME_LIMIT_SECONDS),
+    });
 
 export const lobbyPageResponseSchema = z.object({
     items: z.array(lobbyListItemSchema),

--- a/src/types/lobby.ts
+++ b/src/types/lobby.ts
@@ -101,6 +101,12 @@ export interface UpdateLobbyMapRequest {
     mapId: number;
 }
 
+export interface UpdateLobbySettingsRequest {
+    maxPlayers: number;
+    questionCount: number;
+    timeLimitSeconds: number;
+}
+
 export interface CreateLobbyRequest {
     title: string;
     maxPlayers: number;


### PR DESCRIPTION
## 📣 Related Issue

- #111

## 📝 Summary

- `PATCH /api/lobbies/{code}/settings` API를 연동했습니다.
- `maxPlayers`, `questionCount`, `timeLimitSeconds` 요청 타입과 Zod 검증을 추가했습니다.
- 방장에게만 로비 설정 편집 UI를 제공하고 참가자는 기존 읽기 전용 UI를 유지했습니다.
- `WAITING` 상태에서만 설정을 수정할 수 있도록 제어했습니다.
- 저장 성공 후 기존 로비 상세 query를 invalidate하여 서버 응답 기준으로 다시 동기화했습니다.
- 설정값과 무관한 WebSocket refresh가 작성 중인 값을 덮어쓰지 않도록 처리했습니다.
- MSW 설정 변경 handler와 `204 No Content` 응답을 추가했습니다.
- 게스트 계정 모달의 회원가입 버튼이 로그인 화면이 아닌 회원가입 폼으로 이동하도록 수정했습니다.

## 🙏PR point

- 설정 변경 성공 응답은 `204 No Content`이므로 response body를 파싱하지 않습니다.
- response DTO와 response Zod schema는 추가하지 않았습니다.
- 설정 저장값을 로컬에서 확정하지 않고 `GET /api/lobbies/{code}` 재조회 결과를 사용합니다.
- ready/start/WebSocket 및 인증 세션 구조는 변경하지 않았습니다.
- 회원가입 진입 의도는 보호 라우트 리다이렉트 과정에서 유실되지 않도록 일회성으로 전달합니다.
- `npm run lint`: 오류 없음, 기존 MSW 생성 파일 경고 1건
- `npm run build`: 성공, 기존 번들 크기 경고 1건

## 📬 Reference

- Monomat-BE `develop`
- `PATCH /api/lobbies/{code}/settings`
- GitHub Issue #111