### PR TITLE
[Feat/#105] 참가자 로비 대기실 UI 개선

### DIFF
--- a/src/components/lobby/GlobalChat.tsx
+++ b/src/components/lobby/GlobalChat.tsx
@@ -8,7 +8,7 @@ import { GLOBAL_CHAT_COPY } from '../../constants/lobby';
 import type { ChatMessage } from '../../types/chat';
 import { MonomatInput } from '../common/MonomatInput';
 
-const CHAT_COOLDOWN_MS = 3000;
+const CHAT_COOLDOWN_MS = 1500;
 const MAX_CHAT_LENGTH = 200;
 
 function formatTime(timestamp: string): string {

--- a/src/components/lobby/LobbyMapInfoCard.tsx
+++ b/src/components/lobby/LobbyMapInfoCard.tsx
@@ -27,8 +27,6 @@ function SettingRule({
     value: string;
     progress: number;
 }) {
-    const knobPosition = Math.min(Math.max(progress, 2.5), 97.5);
-
     return (
         <div className="min-w-0">
             <p className="text-base font-semibold leading-5 text-[var(--monomat-text-strong)]">
@@ -38,10 +36,6 @@ function SettingRule({
                 <span
                     className="absolute left-0 top-0 h-full rounded-[3px] bg-[var(--monomat-primary)]"
                     style={{ width: `${progress}%` }}
-                />
-                <span
-                    className="absolute top-1/2 h-3 w-3 -translate-y-1/2 rounded-full bg-[var(--monomat-primary)]"
-                    style={{ left: `calc(${knobPosition}% - 6px)` }}
                 />
             </div>
         </div>

--- a/src/components/lobby/LobbyPlayersCard.tsx
+++ b/src/components/lobby/LobbyPlayersCard.tsx
@@ -8,6 +8,8 @@ interface LobbyPlayersCardProps {
     currentPlayers: number;
     maxPlayers: number;
     currentUserIdentifier: string | null;
+    hostId: string;
+    hostNickname: string | null;
 }
 
 function maskUserIdentifier(userIdentifier: string) {
@@ -18,11 +20,18 @@ function maskUserIdentifier(userIdentifier: string) {
     return `${userIdentifier.slice(0, 4)}...${userIdentifier.slice(-4)}`;
 }
 
-function getPlayerDisplayName(player: LobbyPlayerResponse) {
+function getPlayerDisplayName(
+    player: LobbyPlayerResponse,
+    hostNickname: string | null,
+) {
     const nickname = player.nickname?.trim();
 
     if (nickname) {
         return nickname;
+    }
+
+    if (player.host && hostNickname?.trim()) {
+        return hostNickname.trim();
     }
 
     return maskUserIdentifier(player.userIdentifier);
@@ -32,8 +41,14 @@ function getAvatarLabel(displayName: string) {
     return displayName.trim().charAt(0).toUpperCase() || '?';
 }
 
-function PlayerReadyBadge({ player }: { player: LobbyPlayerResponse }) {
-    if (player.host) {
+function PlayerReadyBadge({
+    isHost,
+    isReady,
+}: {
+    isHost: boolean;
+    isReady: boolean;
+}) {
+    if (isHost) {
         return (
             <span className="inline-flex h-3 items-center gap-1 text-[10px] font-semibold leading-none text-[var(--monomat-primary)]">
                 <span className="h-2 w-2 rounded-full bg-[var(--monomat-primary)]" />
@@ -45,19 +60,19 @@ function PlayerReadyBadge({ player }: { player: LobbyPlayerResponse }) {
     return (
         <span
             className={`inline-flex h-3 items-center gap-1 text-[10px] font-semibold leading-none ${
-                player.ready
-                    ? 'text-emerald-600'
+                isReady
+                    ? 'text-[#00A259]'
                     : 'text-[var(--monomat-text-muted)]'
             }`}
         >
             <span
                 className={`h-2 w-2 rounded-full ${
-                    player.ready
-                        ? 'bg-emerald-500'
-                        : 'bg-[var(--monomat-border-input)]'
+                    isReady
+                        ? 'bg-[#00A259]'
+                        : 'border border-[var(--monomat-text-muted)] bg-white'
                 }`}
             />
-            {player.ready ? LOBBY_ROOM_COPY.READY : LOBBY_ROOM_COPY.WAITING}
+            {isReady ? LOBBY_ROOM_COPY.READY : LOBBY_ROOM_COPY.WAITING}
         </span>
     );
 }
@@ -65,15 +80,35 @@ function PlayerReadyBadge({ player }: { player: LobbyPlayerResponse }) {
 function PlayerSlot({
     player,
     currentUserIdentifier,
+    hostId,
+    hostNickname,
 }: {
     player: LobbyPlayerResponse;
     currentUserIdentifier: string | null;
+    hostId: string;
+    hostNickname: string | null;
 }) {
-    const displayName = getPlayerDisplayName(player);
+    const isCurrentUser =
+        player.userIdentifier === currentUserIdentifier;
+    const isHost =
+        player.host || player.userIdentifier === hostId;
+    const displayName = getPlayerDisplayName(
+        {
+            ...player,
+            host: isHost,
+        },
+        hostNickname,
+    );
     const avatarColor = getAvatarColor(player.userIdentifier);
 
     return (
-        <li className="flex h-[110px] min-w-0 flex-col items-center rounded-lg border border-[color:var(--monomat-border-default)] bg-white px-3 py-[15px] text-center">
+        <li
+            className={`flex h-[110px] min-w-0 flex-col items-center rounded-lg border bg-white px-3 py-[15px] text-center ${
+                isCurrentUser
+                    ? 'border-[var(--monomat-primary)] ring-2 ring-[color:var(--monomat-primary-light)]'
+                    : 'border-[color:var(--monomat-border-default)]'
+            }`}
+        >
             <span
                 className="flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-full text-base font-extrabold leading-none text-white"
                 style={{ backgroundColor: avatarColor }}
@@ -86,12 +121,15 @@ function PlayerSlot({
             </p>
 
             <div className="mt-1 flex h-3 max-w-full items-center justify-center gap-2">
-                {player.userIdentifier === currentUserIdentifier && (
-                    <span className="inline-flex h-3 items-center rounded-full bg-[var(--monomat-page-bg)] px-2 text-[10px] font-semibold leading-none text-[var(--monomat-text-muted)]">
+                {isCurrentUser && (
+                    <span className="inline-flex h-3 items-center rounded-full bg-[var(--monomat-primary-light)] px-2 text-[10px] font-bold leading-none text-[var(--monomat-primary)]">
                         {LOBBY_ROOM_COPY.ME}
                     </span>
                 )}
-                <PlayerReadyBadge player={player} />
+                <PlayerReadyBadge
+                    isHost={isHost}
+                    isReady={!isHost && player.ready}
+                />
             </div>
         </li>
     );
@@ -113,6 +151,8 @@ export function LobbyPlayersCard({
     currentPlayers,
     maxPlayers,
     currentUserIdentifier,
+    hostId,
+    hostNickname,
 }: LobbyPlayersCardProps) {
     const emptySlotCount = Math.max(maxPlayers - players.length, 0);
 
@@ -134,6 +174,8 @@ export function LobbyPlayersCard({
                             key={player.userIdentifier}
                             player={player}
                             currentUserIdentifier={currentUserIdentifier}
+                            hostId={hostId}
+                            hostNickname={hostNickname}
                         />
                     ))}
                     {Array.from({ length: emptySlotCount }).map((_, index) => (

--- a/src/components/lobby/ParticipantLobbyActionCard.tsx
+++ b/src/components/lobby/ParticipantLobbyActionCard.tsx
@@ -1,0 +1,114 @@
+import { CircleCheck, Clock3, Gamepad2, Info } from 'lucide-react';
+
+import { LOBBY_ROOM_COPY } from '../../constants/lobby';
+
+interface ParticipantLobbyActionCardProps {
+    hostNickname: string;
+    isReady: boolean;
+    isWaitingLobby: boolean;
+    hasCurrentPlayer: boolean;
+    isUpdating: boolean;
+    onReadyClick: () => void;
+}
+
+export function ParticipantLobbyActionCard({
+    hostNickname,
+    isReady,
+    isWaitingLobby,
+    hasCurrentPlayer,
+    isUpdating,
+    onReadyClick,
+}: ParticipantLobbyActionCardProps) {
+    const isButtonDisabled =
+        !isWaitingLobby || !hasCurrentPlayer || isUpdating;
+    const StatusIcon = isReady ? CircleCheck : Clock3;
+    const guideMessage = !isWaitingLobby
+        ? LOBBY_ROOM_COPY.PARTICIPANT_NOT_WAITING
+        : !hasCurrentPlayer
+            ? LOBBY_ROOM_COPY.READY_WAIT_PLAYER
+            : isReady
+                ? LOBBY_ROOM_COPY.PARTICIPANT_READY_GUIDE
+                : LOBBY_ROOM_COPY.PARTICIPANT_WAITING_GUIDE;
+
+    return (
+        <section
+            aria-labelledby="participant-lobby-action-title"
+            className="space-y-2"
+        >
+            <div
+                className={`rounded-lg px-4 py-3 ring-1 ${
+                    isReady
+                        ? 'bg-[#E5F7ED] ring-emerald-100'
+                        : 'bg-white ring-[color:var(--monomat-border-card)]'
+                }`}
+            >
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                            <StatusIcon
+                                size={18}
+                                strokeWidth={2.3}
+                                className={
+                                    isReady
+                                        ? 'text-[#00A259]'
+                                        : 'text-[var(--monomat-text-muted)]'
+                                }
+                                aria-hidden="true"
+                            />
+                            <h3
+                                id="participant-lobby-action-title"
+                                className="!m-0 !text-sm !font-extrabold !leading-5 !text-[var(--monomat-text-strong)]"
+                            >
+                                {LOBBY_ROOM_COPY.PARTICIPANT_ACTION_TITLE}
+                            </h3>
+                            <span
+                                className={`inline-flex h-6 items-center rounded-full px-2.5 text-[11px] font-bold leading-none ${
+                                    isReady
+                                        ? 'bg-white text-[#00A259]'
+                                        : 'bg-[var(--monomat-page-bg)] text-[var(--monomat-text-muted)]'
+                                }`}
+                            >
+                                {isReady
+                                    ? LOBBY_ROOM_COPY.READY
+                                    : LOBBY_ROOM_COPY.WAITING}
+                            </span>
+                        </div>
+
+                        <p className="mt-1.5 break-keep text-xs font-bold leading-5 text-[var(--monomat-text-muted)]">
+                            {guideMessage}
+                        </p>
+                    </div>
+
+                    <div className="flex shrink-0 items-center gap-2 text-xs font-semibold text-[var(--monomat-text-muted)]">
+                        <Info size={15} strokeWidth={2.2} aria-hidden="true" />
+                        <span>
+                            {LOBBY_ROOM_COPY.PARTICIPANT_HOST_PREFIX}{' '}
+                            <strong className="font-extrabold text-[var(--monomat-text-strong)]">
+                                {hostNickname}
+                            </strong>
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            <button
+                type="button"
+                onClick={onReadyClick}
+                disabled={isButtonDisabled}
+                aria-describedby="participant-lobby-action-title"
+                className={`flex h-[45px] w-full items-center justify-center gap-2 rounded-lg text-base font-bold leading-none text-white transition disabled:cursor-not-allowed disabled:bg-[#D3D3D7] ${
+                    isReady
+                        ? 'bg-[var(--monomat-text-strong)] hover:bg-black'
+                        : 'bg-[#00A259] hover:bg-[#008F4E]'
+                }`}
+            >
+                <Gamepad2 size={20} strokeWidth={2.3} aria-hidden="true" />
+                {isUpdating
+                    ? LOBBY_ROOM_COPY.READY_PENDING
+                    : isReady
+                        ? LOBBY_ROOM_COPY.CANCEL_READY
+                        : LOBBY_ROOM_COPY.SUBMIT_READY}
+            </button>
+        </section>
+    );
+}

--- a/src/constants/lobby.ts
+++ b/src/constants/lobby.ts
@@ -152,7 +152,15 @@ export const LOBBY_ROOM_COPY = {
     START_GAME: '게임 시작',
     READY_PENDING: '변경 중...',
     CANCEL_READY: '준비 취소',
-    SUBMIT_READY: '준비 완료',
+    SUBMIT_READY: '준비하기',
+    PARTICIPANT_ACTION_TITLE: '내 준비 상태',
+    PARTICIPANT_WAITING_GUIDE:
+        '준비를 완료하면 방장이 게임을 시작할 수 있습니다.',
+    PARTICIPANT_READY_GUIDE:
+        '방장이 게임을 시작할 때까지 기다려 주세요.',
+    PARTICIPANT_NOT_WAITING:
+        '대기 중인 로비에서만 준비 상태를 변경할 수 있습니다.',
+    PARTICIPANT_HOST_PREFIX: '게임 시작 권한 · 방장',
     START_AVAILABLE: '현재 조회 기준으로 시작할 수 있습니다.',
     START_UNAVAILABLE: '모든 참가자가 준비하면 시작할 수 있습니다.',
     START_GUIDE_MAP_MISSING: '선택된 맵이 없어 아직 시작할 수 없습니다.',

--- a/src/mocks/handlers/lobby.ts
+++ b/src/mocks/handlers/lobby.ts
@@ -28,6 +28,8 @@ const LOBBY_SORT_QUERIES = [
 ] as const;
 
 let latestCreatedLobby: LobbyDetailResponse | null = null;
+const MOCK_PARTICIPANT_USER_IDENTIFIER =
+    '22222222-2222-4222-8222-222222222222';
 const mockLobbyDetailOverrides = new Map<
     string,
     Partial<Pick<
@@ -40,10 +42,11 @@ const mockLobbyDetailOverrides = new Map<
         | 'timeLimitSeconds'
     >>
 >();
+const mockLobbyReadyOverrides = new Map<string, Map<string, boolean>>();
 
 const MOCK_PLAYER_POOL = [
     {
-        userIdentifier: 'mock-player-yuki',
+        userIdentifier: MOCK_PARTICIPANT_USER_IDENTIFIER,
         nickname: '유키',
         ready: false,
     },
@@ -186,6 +189,7 @@ function createLobbyDetailFromItem(
         host: true,
         ready: true,
     };
+    const readyOverrides = mockLobbyReadyOverrides.get(lobby.code);
     const players: LobbyPlayerResponse[] = [
         hostPlayer,
         ...selectMockPlayerPool(lobby)
@@ -194,7 +198,9 @@ function createLobbyDetailFromItem(
                 userIdentifier: player.userIdentifier,
                 nickname: player.nickname,
                 host: false,
-                ready: player.ready,
+                ready:
+                    readyOverrides?.get(player.userIdentifier) ??
+                    player.ready,
             })),
     ];
 
@@ -320,6 +326,125 @@ export const lobbyHandlers = [
 
         return HttpResponse.json(createLobbyDetailFromItem(lobby));
     }),
+
+    http.patch(
+        API_ENDPOINTS.LOBBY.READY(':code'),
+        async ({ params, request }) => {
+            const code = typeof params.code === 'string' ? params.code : '';
+            let payload: unknown;
+
+            try {
+                payload = await request.json();
+            } catch {
+                return HttpResponse.json(
+                    { message: '요청 본문 형식이 올바르지 않습니다.' },
+                    { status: 400 },
+                );
+            }
+
+            if (
+                !payload ||
+                typeof payload !== 'object' ||
+                Array.isArray(payload) ||
+                typeof (payload as { ready?: unknown }).ready !== 'boolean'
+            ) {
+                return HttpResponse.json(
+                    { message: '준비 상태는 필수입니다.' },
+                    { status: 400 },
+                );
+            }
+
+            const ready = (payload as { ready: boolean }).ready;
+
+            if (latestCreatedLobby?.inviteCode === code) {
+                if (latestCreatedLobby.status !== 'WAITING') {
+                    return HttpResponse.json(
+                        {
+                            message:
+                                '게임이 이미 시작된 로비에는 입장할 수 없습니다.',
+                        },
+                        { status: 409 },
+                    );
+                }
+
+                const participant = latestCreatedLobby.players.find(
+                    (player) => !player.host,
+                );
+
+                if (!participant) {
+                    return HttpResponse.json(
+                        {
+                            message:
+                                '로비 참여자만 준비 상태를 변경할 수 있습니다.',
+                        },
+                        { status: 403 },
+                    );
+                }
+
+                const players = latestCreatedLobby.players.map((player) =>
+                    player.userIdentifier === participant.userIdentifier
+                        ? { ...player, ready }
+                        : player,
+                );
+
+                latestCreatedLobby = {
+                    ...latestCreatedLobby,
+                    players,
+                    canStart: canStartMockLobby({
+                        status: latestCreatedLobby.status,
+                        mapId: latestCreatedLobby.mapId,
+                        mapTitle: latestCreatedLobby.mapTitle,
+                        players,
+                    }),
+                };
+
+                return new HttpResponse(null, { status: 204 });
+            }
+
+            const lobby = mockLobbyItems.find((item) => item.code === code);
+
+            if (!lobby) {
+                return HttpResponse.json(
+                    { message: '로비를 찾을 수 없습니다.' },
+                    { status: 404 },
+                );
+            }
+
+            if (lobby.status !== 'WAITING') {
+                return HttpResponse.json(
+                    {
+                        message:
+                            '게임이 이미 시작된 로비에는 입장할 수 없습니다.',
+                    },
+                    { status: 409 },
+                );
+            }
+
+            const lobbyDetail = createLobbyDetailFromItem(lobby);
+            const participant = lobbyDetail.players.find(
+                (player) =>
+                    player.userIdentifier ===
+                    MOCK_PARTICIPANT_USER_IDENTIFIER,
+            );
+
+            if (!participant) {
+                return HttpResponse.json(
+                    {
+                        message:
+                            '로비 참여자만 준비 상태를 변경할 수 있습니다.',
+                    },
+                    { status: 403 },
+                );
+            }
+
+            const readyOverrides =
+                mockLobbyReadyOverrides.get(code) ?? new Map<string, boolean>();
+            readyOverrides.set(participant.userIdentifier, ready);
+            mockLobbyReadyOverrides.set(code, readyOverrides);
+
+            return new HttpResponse(null, { status: 204 });
+        },
+    ),
 
     http.patch(API_ENDPOINTS.LOBBY.MAP(':code'), async ({ params, request }) => {
         const code = typeof params.code === 'string' ? params.code : '';

--- a/src/pages/LobbyRoom.tsx
+++ b/src/pages/LobbyRoom.tsx
@@ -1,6 +1,5 @@
 import { type ReactNode, useMemo, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Gamepad2 } from 'lucide-react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import {
@@ -15,6 +14,7 @@ import { LobbyChatPlaceholder } from '../components/lobby/LobbyChatPlaceholder';
 import { LobbyFooter } from '../components/lobby/LobbyFooter';
 import { LobbyHeaderCard } from '../components/lobby/LobbyHeaderCard';
 import { LobbyMapInfoCard } from '../components/lobby/LobbyMapInfoCard';
+import { ParticipantLobbyActionCard } from '../components/lobby/ParticipantLobbyActionCard';
 import { LobbyPlayersCard } from '../components/lobby/LobbyPlayersCard';
 import { LobbyRoomLayout } from '../components/lobby/LobbyRoomLayout';
 import { LobbyRoomTopControls } from '../components/lobby/LobbyRoomTopControls';
@@ -175,6 +175,24 @@ export function LobbyRoom() {
         userIdentifier &&
         lobbyDetail.hostId === userIdentifier,
     );
+    const hostNickname = useMemo(() => {
+        if (!lobbyDetail) {
+            return LOBBY_ROOM_COPY.HOST_UNKNOWN;
+        }
+
+        const hostPlayer =
+            lobbyDetail.players.find((player) => player.host) ??
+            lobbyDetail.players.find(
+                (player) =>
+                    player.userIdentifier === lobbyDetail.hostId,
+            );
+
+        return (
+            hostPlayer?.nickname?.trim() ||
+            lobbyDetail.hostNickname?.trim() ||
+            LOBBY_ROOM_COPY.HOST_UNKNOWN
+        );
+    }, [lobbyDetail]);
     const currentReady = currentPlayer?.ready ?? false;
     const readySummary = useMemo(() => {
         const players = lobbyDetail?.players ?? [];
@@ -332,7 +350,12 @@ export function LobbyRoom() {
     });
 
     const handleReadyClick = () => {
-        if (!currentPlayer || isHost || readyMutation.isPending) {
+        if (
+            !currentPlayer ||
+            isHost ||
+            lobbyDetail?.status !== 'WAITING' ||
+            readyMutation.isPending
+        ) {
             return;
         }
 
@@ -431,8 +454,6 @@ export function LobbyRoom() {
         );
     }
 
-    const isReadyButtonDisabled =
-        readyMutation.isPending || !currentPlayer || isHost;
     const isWaitingLobby = lobbyDetail.status === 'WAITING';
     const hasSelectedMap =
         lobbyDetail.mapId != null && Boolean(lobbyDetail.mapTitle?.trim());
@@ -513,6 +534,10 @@ export function LobbyRoom() {
                             currentPlayers={lobbyDetail.currentPlayers}
                             maxPlayers={lobbyDetail.maxPlayers}
                             currentUserIdentifier={userIdentifier}
+                            hostId={lobbyDetail.hostId}
+                            hostNickname={
+                                lobbyDetail.hostNickname ?? null
+                            }
                         />
                     }
                     settingsCard={
@@ -569,34 +594,14 @@ export function LobbyRoom() {
                                 onStartClick={handleStartClick}
                             />
                         ) : (
-                            <section aria-label={LOBBY_ROOM_COPY.ACTION_TITLE}>
-                                <p className="sr-only">
-                                    {currentPlayer
-                                        ? LOBBY_ROOM_COPY.READY_SYNCED
-                                        : LOBBY_ROOM_COPY.READY_WAIT_PLAYER}
-                                </p>
-                                <button
-                                    type="button"
-                                    onClick={handleReadyClick}
-                                    disabled={isReadyButtonDisabled}
-                                    className={`flex h-[45px] w-full items-center justify-center gap-2 rounded-lg text-base font-bold leading-none text-white transition disabled:cursor-not-allowed disabled:bg-[#D3D3D7] ${
-                                        currentReady
-                                            ? 'bg-[var(--monomat-text-strong)] hover:bg-black'
-                                            : 'bg-[#00B368] hover:bg-[#009b5a]'
-                                    }`}
-                                >
-                                    <Gamepad2
-                                        size={20}
-                                        strokeWidth={2.3}
-                                        aria-hidden="true"
-                                    />
-                                    {readyMutation.isPending
-                                        ? LOBBY_ROOM_COPY.READY_PENDING
-                                        : currentReady
-                                            ? LOBBY_ROOM_COPY.CANCEL_READY
-                                            : LOBBY_ROOM_COPY.SUBMIT_READY}
-                                </button>
-                            </section>
+                            <ParticipantLobbyActionCard
+                                hostNickname={hostNickname}
+                                isReady={currentReady}
+                                isWaitingLobby={isWaitingLobby}
+                                hasCurrentPlayer={Boolean(currentPlayer)}
+                                isUpdating={readyMutation.isPending}
+                                onReadyClick={handleReadyClick}
+                            />
                         )
                     }
                     chatSlot={


### PR DESCRIPTION
## 📣 Related Issue

- #105

## 📝 Summary

- 방장과 참가자의 로비 대기실 UI 렌더링 분기를 정리했습니다.
- 참가자 전용 준비 상태 안내와 준비하기/준비 취소 액션 영역을 추가했습니다.
- `WAITING` 상태의 비방장 참가자만 준비 상태를 변경할 수 있도록 제한했습니다.
- 참가자 목록에 방장, 나, 준비 완료, 대기 중 상태를 명확하게 표시했습니다.
- 방장 닉네임은 `players[].nickname`을 우선하고 `hostNickname`을 fallback으로 사용했습니다.
- ready MSW handler를 추가하고 변경된 `players[].ready`와 `canStart`가 상세 조회에 반영되도록 했습니다.
- 참가자 게임 설정 진행 막대의 원형 노브를 제거했습니다.
- 로비 목록 전체 채팅의 전송 제한을 3초에서 1.5초로 변경했습니다.

## 🙏PR point

- 기존 `updateLobbyReady(code, { ready })` API와 `204 No Content` 계약을 유지했습니다.
- ready 성공 후 기존 query invalidate와 WebSocket refresh 흐름을 유지했습니다.
- `LobbySettingsEditor`와 방장 설정 수정 로직은 변경하지 않았습니다.
- `WAITING`이 아닌 로비에서는 참가자 준비 버튼을 숨기지 않고 비활성화합니다.
- `npm run lint`는 오류 없이 통과했으며 기존 `mockServiceWorker.js` 경고 1건이 있습니다.
- `npm run build`가 성공했습니다.

## 📬 Reference

- Monomat-BE `develop` 로비 상세 조회 및 ready API 계약