### PR TITLE
[Feat/#124] 맵 곡 수 기반 로비 라운드 설정 적용

### DIFF
--- a/src/components/lobby/LobbyMapInfoCard.tsx
+++ b/src/components/lobby/LobbyMapInfoCard.tsx
@@ -2,9 +2,11 @@ import {
     CREATE_LOBBY_POLICY,
     LOBBY_ROOM_COPY,
 } from '../../constants/lobby';
+import { getLobbyQuestionCountMax } from '../../utils/lobbyQuestionCount';
 
 interface LobbyMapInfoCardProps {
     questionCount: number;
+    mapNumOfSong: number | null;
     timeLimitSeconds: number;
     maxPlayers: number;
 }
@@ -44,9 +46,12 @@ function SettingRule({
 
 export function LobbyMapInfoCard({
     questionCount,
+    mapNumOfSong,
     timeLimitSeconds,
     maxPlayers,
 }: LobbyMapInfoCardProps) {
+    const questionCountMax = getLobbyQuestionCountMax(mapNumOfSong);
+
     return (
         <section className="min-h-[123px] rounded-2xl bg-white px-[25px] py-5 text-left shadow-[0_4px_16px_rgba(0,0,0,0.16)]">
             <h2 className="!m-0 !text-lg !font-bold !leading-6 !text-[var(--monomat-text-strong)]">
@@ -69,7 +74,7 @@ export function LobbyMapInfoCard({
                     progress={getProgressPercent(
                         questionCount,
                         CREATE_LOBBY_POLICY.MIN_QUESTION_COUNT,
-                        CREATE_LOBBY_POLICY.MAX_QUESTION_COUNT,
+                        questionCountMax,
                     )}
                 />
                 <SettingRule

--- a/src/components/lobby/LobbySettingsEditor.tsx
+++ b/src/components/lobby/LobbySettingsEditor.tsx
@@ -10,8 +10,14 @@ import {
 } from '../../constants/lobby';
 import { updateLobbySettingsRequestSchema } from '../../schemas/lobbySchema';
 import type { UpdateLobbySettingsRequest } from '../../types/lobby';
+import {
+    clampLobbyQuestionCount,
+    getLobbyQuestionCountMax,
+    hasValidLobbyMapSongCount,
+} from '../../utils/lobbyQuestionCount';
 
 interface LobbySettingsEditorProps extends UpdateLobbySettingsRequest {
+    mapNumOfSong: number | null;
     currentPlayers: number;
     isEditable: boolean;
     isSaving: boolean;
@@ -30,6 +36,10 @@ interface LobbySettingsRangeProps {
 }
 
 function getRangeBackground(value: number, min: number, max: number) {
+    if (max <= min) {
+        return 'var(--monomat-primary)';
+    }
+
     const progress = ((value - min) / (max - min)) * 100;
 
     return `linear-gradient(to right, var(--monomat-primary) ${progress}%, var(--monomat-border-input) ${progress}%)`;
@@ -80,14 +90,23 @@ export function LobbySettingsEditor({
     maxPlayers,
     questionCount,
     timeLimitSeconds,
+    mapNumOfSong,
     currentPlayers,
     isEditable,
     isSaving,
     onSubmit,
 }: LobbySettingsEditorProps) {
+    const questionCountMax = getLobbyQuestionCountMax(mapNumOfSong);
+    const hasValidMapSongCount =
+        hasValidLobbyMapSongCount(mapNumOfSong);
+    const hasEmptySelectedMap =
+        mapNumOfSong !== null && !hasValidMapSongCount;
     const [formState, setFormState] = useState<UpdateLobbySettingsRequest>({
         maxPlayers,
-        questionCount,
+        questionCount: clampLobbyQuestionCount(
+            questionCount,
+            mapNumOfSong,
+        ),
         timeLimitSeconds,
     });
     const [validationMessage, setValidationMessage] = useState<string | null>(
@@ -131,7 +150,21 @@ export function LobbySettingsEditor({
             return;
         }
 
-        const parsed = updateLobbySettingsRequestSchema.safeParse(formState);
+        if (hasEmptySelectedMap) {
+            setValidationMessage(
+                LOBBY_ROOM_COPY.SETTINGS_QUESTION_COUNT_EMPTY_MAP,
+            );
+            return;
+        }
+
+        const request = {
+            ...formState,
+            questionCount: clampLobbyQuestionCount(
+                formState.questionCount,
+                mapNumOfSong,
+            ),
+        };
+        const parsed = updateLobbySettingsRequestSchema.safeParse(request);
 
         if (!parsed.success) {
             setValidationMessage('설정값의 허용 범위를 확인해주세요.');
@@ -182,8 +215,8 @@ export function LobbySettingsEditor({
                     label={LOBBY_ROOM_COPY.QUESTION_COUNT}
                     value={formState.questionCount}
                     min={CREATE_LOBBY_POLICY.MIN_QUESTION_COUNT}
-                    max={CREATE_LOBBY_POLICY.MAX_QUESTION_COUNT}
-                    disabled={isDisabled}
+                    max={questionCountMax}
+                    disabled={isDisabled || !hasValidMapSongCount}
                     onChange={(value) =>
                         updateFormState('questionCount', value)
                     }
@@ -201,6 +234,16 @@ export function LobbySettingsEditor({
                     }
                 />
             </div>
+
+            <p className="mt-3 break-keep text-xs font-medium leading-5 text-[var(--monomat-text-muted)]">
+                {hasValidMapSongCount
+                    ? mapNumOfSong > questionCountMax
+                        ? `이 맵은 최대 ${mapNumOfSong}곡이지만, 로비는 최대 ${questionCountMax}라운드까지 설정할 수 있습니다.`
+                        : `이 맵은 최대 ${questionCountMax}라운드까지 진행할 수 있습니다.`
+                    : hasEmptySelectedMap
+                        ? LOBBY_ROOM_COPY.SETTINGS_QUESTION_COUNT_EMPTY_MAP
+                        : LOBBY_ROOM_COPY.SETTINGS_QUESTION_COUNT_MAP_REQUIRED}
+            </p>
 
             <div className="mt-5 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <div className="min-h-5">
@@ -220,7 +263,8 @@ export function LobbySettingsEditor({
                     disabled={
                         isDisabled ||
                         !isDirty ||
-                        hasPlayerCountConflict
+                        hasPlayerCountConflict ||
+                        hasEmptySelectedMap
                     }
                     className="h-10 w-full rounded-lg bg-[var(--monomat-primary)] px-5 text-sm font-bold text-white transition hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:bg-[var(--monomat-primary-disabled)] sm:w-auto"
                 >

--- a/src/constants/lobby.ts
+++ b/src/constants/lobby.ts
@@ -182,6 +182,10 @@ export const LOBBY_ROOM_COPY = {
         '게임이 시작된 로비에서는 설정을 변경할 수 없습니다.',
     SETTINGS_MAX_PLAYERS_CONFLICT:
         '최대 인원은 현재 참가자 수보다 작을 수 없습니다.',
+    SETTINGS_QUESTION_COUNT_MAP_REQUIRED:
+        '맵을 선택하면 라운드 수를 설정할 수 있습니다.',
+    SETTINGS_QUESTION_COUNT_EMPTY_MAP:
+        '등록된 곡이 없는 맵에서는 로비 설정을 저장할 수 없습니다.',
     READY_SYNCED: '준비 상태는 서버 이벤트로 다시 동기화됩니다.',
     READY_WAIT_PLAYER: '참여자 정보 동기화 후 준비할 수 있습니다.',
     START_REQUESTED: '게임 시작 요청을 보냈습니다.',

--- a/src/mocks/handlers/lobby.ts
+++ b/src/mocks/handlers/lobby.ts
@@ -38,6 +38,7 @@ const mockLobbyDetailOverrides = new Map<
         | 'mapId'
         | 'mapTitle'
         | 'mapCategory'
+        | 'mapNumOfSong'
         | 'maxPlayers'
         | 'questionCount'
         | 'timeLimitSeconds'
@@ -219,6 +220,10 @@ function createLobbyDetailFromItem(
     lobby: LobbyListItem,
 ): LobbyDetailResponse {
     const override = mockLobbyDetailOverrides.get(lobby.code);
+    const mapId = override?.mapId ?? lobby.mapId;
+    const selectedMap = mapId == null
+        ? null
+        : mockMapItems.find((map) => map.mapId === mapId) ?? null;
     const hostPlayer: LobbyPlayerResponse = {
         userIdentifier: lobby.hostId ?? 'mock-host',
         nickname: lobby.hostNickname ?? 'Mock Host',
@@ -248,9 +253,11 @@ function createLobbyDetailFromItem(
         maxPlayers: override?.maxPlayers ?? lobby.maxPlayers,
         currentPlayers: lobby.currentPlayers,
         status: lobby.status,
-        mapId: override?.mapId ?? lobby.mapId,
+        mapId,
         mapTitle: override?.mapTitle ?? lobby.mapTitle,
         mapCategory: override?.mapCategory ?? lobby.mapCategory,
+        mapNumOfSong:
+            override?.mapNumOfSong ?? selectedMap?.numOfSong ?? null,
         questionCount:
             override?.questionCount ??
             lobby.questionCount ?? CREATE_LOBBY_POLICY.DEFAULT_QUESTION_COUNT,
@@ -279,15 +286,16 @@ export const lobbyHandlers = [
             ? payload.maxPlayers
             : CREATE_LOBBY_POLICY.DEFAULT_MAX_PLAYERS;
         const isPrivate = Boolean(payload.isPrivate);
-        const questionCount = typeof payload.questionCount === 'number'
-            ? payload.questionCount
-            : CREATE_LOBBY_POLICY.DEFAULT_QUESTION_COUNT;
-        const timeLimitSeconds = typeof payload.timeLimitSeconds === 'number'
-            ? payload.timeLimitSeconds
-            : CREATE_LOBBY_POLICY.DEFAULT_TIME_LIMIT_SECONDS;
         const selectedMap = typeof payload.mapId === 'number'
             ? mockMapItems.find((map) => map.mapId === payload.mapId) ?? null
             : null;
+        const questionCount = typeof payload.questionCount === 'number'
+            ? payload.questionCount
+            : selectedMap?.numOfSong ??
+                CREATE_LOBBY_POLICY.DEFAULT_QUESTION_COUNT;
+        const timeLimitSeconds = typeof payload.timeLimitSeconds === 'number'
+            ? payload.timeLimitSeconds
+            : CREATE_LOBBY_POLICY.DEFAULT_TIME_LIMIT_SECONDS;
         const inviteCode = 'NEW123';
 
         latestCreatedLobby = {
@@ -301,6 +309,7 @@ export const lobbyHandlers = [
             mapId: selectedMap?.mapId ?? null,
             mapTitle: selectedMap?.title ?? null,
             mapCategory: selectedMap?.category ?? null,
+            mapNumOfSong: selectedMap?.numOfSong ?? null,
             questionCount,
             timeLimitSeconds,
             players: [
@@ -521,6 +530,7 @@ export const lobbyHandlers = [
                 mapId: selectedMap.mapId,
                 mapTitle: selectedMap.title,
                 mapCategory: selectedMap.category,
+                mapNumOfSong: selectedMap.numOfSong,
                 questionCount: selectedMap.numOfSong,
             };
 
@@ -558,6 +568,7 @@ export const lobbyHandlers = [
             mapId: selectedMap.mapId,
             mapTitle: selectedMap.title,
             mapCategory: selectedMap.category,
+            mapNumOfSong: selectedMap.numOfSong,
             questionCount: selectedMap.numOfSong,
         });
 

--- a/src/pages/LobbyCreate.tsx
+++ b/src/pages/LobbyCreate.tsx
@@ -4,6 +4,7 @@ import {
     type ReactNode,
     type MouseEvent,
     useEffect,
+    useRef,
     useState,
 } from 'react';
 import { useQuery } from '@tanstack/react-query';
@@ -31,6 +32,11 @@ import {
     formatMapDescription,
     formatMapOwnerNickname,
 } from '../utils/mapFormat';
+import {
+    clampLobbyQuestionCount,
+    getLobbyQuestionCountMax,
+    hasValidLobbyMapSongCount,
+} from '../utils/lobbyQuestionCount';
 
 interface LobbyCreateFormState {
     title: string;
@@ -77,6 +83,10 @@ function getErrorMessage(error: unknown, fallbackMessage: string) {
 }
 
 function getRangeBackground(value: number, min: number, max: number) {
+    if (max <= min) {
+        return 'var(--monomat-primary)';
+    }
+
     const progress = ((value - min) / (max - min)) * 100;
 
     return `linear-gradient(to right, var(--monomat-primary) ${progress}%, var(--monomat-border-input) ${progress}%)`;
@@ -96,12 +106,22 @@ function createRequestFromFormState(
         return `로비 이름은 최대 ${CREATE_LOBBY_POLICY.TITLE_MAX_LENGTH}자까지 입력할 수 있습니다.`;
     }
 
+    if (
+        selectedMap &&
+        !hasValidLobbyMapSongCount(selectedMap.numOfSong)
+    ) {
+        return '곡이 1개 이상 등록된 맵을 선택해주세요.';
+    }
+
     return {
         title,
         maxPlayers: formState.maxPlayers,
         isPrivate: formState.isPrivate,
         mapId: selectedMap?.mapId ?? null,
-        questionCount: formState.questionCount,
+        questionCount: clampLobbyQuestionCount(
+            formState.questionCount,
+            selectedMap?.numOfSong,
+        ),
         timeLimitSeconds: formState.timeLimitSeconds,
     };
 }
@@ -257,6 +277,7 @@ export function LobbyCreate() {
     const [isMapSelectModalOpen, setIsMapSelectModalOpen] = useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const appliedPreselectedMapIdRef = useRef<number | null>(null);
     const mapIdParam = searchParams.get(LOBBY_QUERY_PARAMS.MAP_ID);
     const parsedMapId = Number(mapIdParam);
     const hasPreselectedMapId = mapIdParam !== null;
@@ -273,9 +294,22 @@ export function LobbyCreate() {
     });
 
     useEffect(() => {
-        if (preselectedMapQuery.data) {
-            setSelectedMap(mapDetailToSummary(preselectedMapQuery.data));
+        if (
+            !preselectedMapQuery.data ||
+            appliedPreselectedMapIdRef.current ===
+                preselectedMapQuery.data.id
+        ) {
+            return;
         }
+
+        const map = mapDetailToSummary(preselectedMapQuery.data);
+
+        appliedPreselectedMapIdRef.current = map.mapId;
+        setSelectedMap(map);
+        setFormState((currentFormState) => ({
+            ...currentFormState,
+            questionCount: getLobbyQuestionCountMax(map.numOfSong),
+        }));
     }, [preselectedMapQuery.data]);
 
     const preselectedMapErrorMessage = !hasPreselectedMapId
@@ -314,7 +348,18 @@ export function LobbyCreate() {
     };
 
     const handleMapConfirm = (map: MapSummary) => {
+        const isSameMap = selectedMap?.mapId === map.mapId;
+
         setSelectedMap(map);
+        setFormState((currentFormState) => ({
+            ...currentFormState,
+            questionCount: isSameMap
+                ? clampLobbyQuestionCount(
+                    currentFormState.questionCount,
+                    map.numOfSong,
+                )
+                : getLobbyQuestionCountMax(map.numOfSong),
+        }));
         setErrorMessage(null);
     };
 
@@ -323,8 +368,29 @@ export function LobbyCreate() {
     ) => {
         event.stopPropagation();
         setSelectedMap(null);
+        setFormState((currentFormState) => ({
+            ...currentFormState,
+            questionCount: CREATE_LOBBY_POLICY.DEFAULT_QUESTION_COUNT,
+        }));
         setErrorMessage(null);
     };
+
+    const questionCountMax = getLobbyQuestionCountMax(
+        selectedMap?.numOfSong,
+    );
+    const isQuestionCountDisabled =
+        isSubmitting ||
+        Boolean(
+            selectedMap &&
+            !hasValidLobbyMapSongCount(selectedMap.numOfSong),
+        );
+    const questionCountGuide = selectedMap
+        ? selectedMap.numOfSong > questionCountMax
+            ? `이 맵은 최대 ${selectedMap.numOfSong}곡이지만, 로비는 최대 ${questionCountMax}라운드까지 설정할 수 있습니다.`
+            : hasValidLobbyMapSongCount(selectedMap.numOfSong)
+                ? `이 맵은 최대 ${questionCountMax}라운드까지 진행할 수 있습니다.`
+                : '등록된 곡이 없어 라운드 수를 설정할 수 없습니다.'
+        : `맵을 선택하지 않으면 기본 ${CREATE_LOBBY_POLICY.DEFAULT_QUESTION_COUNT}라운드, 최대 ${CREATE_LOBBY_POLICY.MAX_QUESTION_COUNT}라운드로 설정됩니다.`;
 
     const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
@@ -504,8 +570,8 @@ export function LobbyCreate() {
                                 label="라운드 수"
                                 value={formState.questionCount}
                                 min={CREATE_LOBBY_POLICY.MIN_QUESTION_COUNT}
-                                max={CREATE_LOBBY_POLICY.MAX_QUESTION_COUNT}
-                                disabled={isSubmitting}
+                                max={questionCountMax}
+                                disabled={isQuestionCountDisabled}
                                 onChange={(value) =>
                                     updateFormState('questionCount', value)
                                 }
@@ -529,7 +595,11 @@ export function LobbyCreate() {
                             />
                         </div>
 
-                        <p className="mt-[29px] h-5 text-base leading-5 text-[var(--monomat-text-muted)]">
+                        <p className="mt-3 min-h-5 break-keep text-xs font-medium leading-5 text-[var(--monomat-text-muted)]">
+                            {questionCountGuide}
+                        </p>
+
+                        <p className="mt-3 h-5 text-base leading-5 text-[var(--monomat-text-muted)]">
                             공개 설정
                         </p>
 

--- a/src/pages/LobbyRoom.tsx
+++ b/src/pages/LobbyRoom.tsx
@@ -30,6 +30,10 @@ import { useLobbySocket } from '../hooks/useLobbySocket';
 import { useAuthStore } from '../store/useAuthStore';
 import type { MapSummary } from '../types/map';
 import type { UpdateLobbySettingsRequest } from '../types/lobby';
+import {
+    clampLobbyQuestionCount,
+    hasValidLobbyMapSongCount,
+} from '../utils/lobbyQuestionCount';
 
 interface LobbyActionMessage {
     inviteCode: string;
@@ -421,7 +425,20 @@ export function LobbyRoom() {
             return;
         }
 
-        settingsMutation.mutate(request);
+        if (
+            lobbyDetail.mapNumOfSong !== null &&
+            !hasValidLobbyMapSongCount(lobbyDetail.mapNumOfSong)
+        ) {
+            return;
+        }
+
+        settingsMutation.mutate({
+            ...request,
+            questionCount: clampLobbyQuestionCount(
+                request.questionCount,
+                lobbyDetail.mapNumOfSong,
+            ),
+        });
     };
 
     if (!inviteCode) {
@@ -554,9 +571,11 @@ export function LobbyRoom() {
                                     lobbyDetail.maxPlayers,
                                     lobbyDetail.questionCount,
                                     lobbyDetail.timeLimitSeconds,
+                                    lobbyDetail.mapNumOfSong,
                                 ].join(':')}
                                 maxPlayers={lobbyDetail.maxPlayers}
                                 questionCount={lobbyDetail.questionCount}
+                                mapNumOfSong={lobbyDetail.mapNumOfSong}
                                 timeLimitSeconds={
                                     lobbyDetail.timeLimitSeconds
                                 }
@@ -570,6 +589,7 @@ export function LobbyRoom() {
                         ) : (
                             <LobbyMapInfoCard
                                 questionCount={lobbyDetail.questionCount}
+                                mapNumOfSong={lobbyDetail.mapNumOfSong}
                                 timeLimitSeconds={
                                     lobbyDetail.timeLimitSeconds
                                 }

--- a/src/schemas/lobbySchema.ts
+++ b/src/schemas/lobbySchema.ts
@@ -72,6 +72,7 @@ export const lobbyDetailResponseSchema = z.object({
     mapId: z.number().int().positive().nullable(),
     mapTitle: z.string().min(1).nullable(),
     mapCategory: lobbyCategorySchema.nullable(),
+    mapNumOfSong: z.number().int().nonnegative().nullable(),
     questionCount: z.number().int().positive(),
     timeLimitSeconds: z.number().int().positive(),
     players: z.array(lobbyPlayerResponseSchema),

--- a/src/types/lobby.ts
+++ b/src/types/lobby.ts
@@ -87,6 +87,7 @@ export interface LobbyDetailResponse {
     mapId: number | null;
     mapTitle: string | null;
     mapCategory: LobbyCategory | null;
+    mapNumOfSong: number | null;
     questionCount: number;
     timeLimitSeconds: number;
     players: LobbyPlayerResponse[];

--- a/src/utils/lobbyQuestionCount.ts
+++ b/src/utils/lobbyQuestionCount.ts
@@ -1,0 +1,33 @@
+import { CREATE_LOBBY_POLICY } from '../constants/lobby';
+
+export function hasValidLobbyMapSongCount(
+    mapNumOfSong?: number | null,
+): mapNumOfSong is number {
+    return typeof mapNumOfSong === 'number' && mapNumOfSong > 0;
+}
+
+export function getLobbyQuestionCountMax(
+    mapNumOfSong?: number | null,
+): number {
+    if (!hasValidLobbyMapSongCount(mapNumOfSong)) {
+        return CREATE_LOBBY_POLICY.MAX_QUESTION_COUNT;
+    }
+
+    return Math.min(
+        mapNumOfSong,
+        CREATE_LOBBY_POLICY.MAX_QUESTION_COUNT,
+    );
+}
+
+export function clampLobbyQuestionCount(
+    questionCount: number,
+    mapNumOfSong?: number | null,
+): number {
+    return Math.min(
+        Math.max(
+            questionCount,
+            CREATE_LOBBY_POLICY.MIN_QUESTION_COUNT,
+        ),
+        getLobbyQuestionCountMax(mapNumOfSong),
+    );
+}


### PR DESCRIPTION
## 📣 Related Issue

- #124

## 📝 Summary

- 로비 상세 응답 타입과 Zod schema에 `mapNumOfSong`을 추가했습니다.
- 라운드 수 최대값을 `min(mapNumOfSong, 50)`으로 계산하는 공통 helper를 추가했습니다.
- 로비 생성 시 맵 선택 및 변경에 따라 라운드 수를 자동 설정하고 입력 범위를 제한했습니다.
- 로비 생성 및 설정 요청 직전에 `questionCount`를 허용 범위로 보정했습니다.
- 대기실 설정 UI와 참가자용 설정 정보에 맵 기준 라운드 범위를 반영했습니다.
- 맵 변경 후 상세 재조회 결과의 `mapNumOfSong`과 `questionCount`가 설정 UI에 반영되도록 처리했습니다.
- MSW 로비 응답과 맵 변경 동작을 변경된 BE 계약에 맞췄습니다.

## 🙏PR point

- BE의 현재 라운드 수 상한이 50이므로 맵에 50곡을 초과하여 등록했더라도 최대 50라운드까지만 설정됩니다.
- `mapNumOfSong`이 `null` 또는 0 이하이면 대기실 라운드 수 조작을 비활성화합니다.
- 맵 미선택 상태에서는 기존 기본값 10, 최대값 50 정책을 유지합니다.
- Figma 기준 프레임이 없어 기존 레이아웃과 스타일을 유지했습니다.
- `npm run lint`: 오류 없음, 기존 `mockServiceWorker.js` 경고 1건
- `npm run build`: 성공, 기존 청크 크기 경고 존재

## 📬 Reference

- Monomat-BE #208
- `GET /api/lobbies/{inviteCode}`의 `mapNumOfSong` 응답 계약