### PR TITLE
[Feat/#126] 맵 곡 수 기반 라운드 수 입력 정책 반영

### DIFF
--- a/src/components/lobby/LobbySettingsEditor.tsx
+++ b/src/components/lobby/LobbySettingsEditor.tsx
@@ -14,6 +14,7 @@ import {
     clampLobbyQuestionCount,
     getLobbyQuestionCountMax,
     hasValidLobbyMapSongCount,
+    normalizeLobbyQuestionCountInput,
 } from '../../utils/lobbyQuestionCount';
 
 interface LobbySettingsEditorProps extends UpdateLobbySettingsRequest {
@@ -33,6 +34,8 @@ interface LobbySettingsRangeProps {
     max: number;
     disabled: boolean;
     onChange: (value: number) => void;
+    showNumberInput?: boolean;
+    numberInputAriaLabel?: string;
 }
 
 function getRangeBackground(value: number, min: number, max: number) {
@@ -54,20 +57,84 @@ function LobbySettingsRange({
     max,
     disabled,
     onChange,
+    showNumberInput = false,
+    numberInputAriaLabel,
 }: LobbySettingsRangeProps) {
+    const [numberInputValue, setNumberInputValue] = useState<string | null>(
+        null,
+    );
+    const displayedNumberInputValue = numberInputValue ?? String(value);
+
     const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
         onChange(Number(event.target.value));
     };
 
+    const handleNumberInputChange = (
+        event: ChangeEvent<HTMLInputElement>,
+    ) => {
+        const nextValue = event.target.value;
+        const parsedValue = Number(nextValue);
+
+        setNumberInputValue(nextValue);
+
+        if (
+            nextValue.trim() === '' ||
+            !Number.isFinite(parsedValue)
+        ) {
+            return;
+        }
+
+        onChange(
+            normalizeLobbyQuestionCountInput(
+                nextValue,
+                max,
+                value,
+            ),
+        );
+    };
+
+    const handleNumberInputBlur = () => {
+        const normalizedValue = normalizeLobbyQuestionCountInput(
+            displayedNumberInputValue,
+            max,
+            value,
+        );
+
+        setNumberInputValue(null);
+        onChange(normalizedValue);
+    };
+
     return (
-        <label htmlFor={id} className="block min-w-0">
-            <span className="mb-[9px] block text-base leading-5 text-[var(--monomat-text-muted)]">
-                {label} :{' '}
-                <strong className="font-semibold text-[var(--monomat-text-strong)]">
-                    {value}
-                    {unit}
-                </strong>
-            </span>
+        <div className="block min-w-0">
+            <div className="mb-[9px] flex min-h-8 items-center justify-between gap-3">
+                <label
+                    htmlFor={id}
+                    className="min-w-0 text-base leading-5 text-[var(--monomat-text-muted)]"
+                >
+                    {label} :{' '}
+                    <strong className="font-semibold text-[var(--monomat-text-strong)]">
+                        {value}
+                        {unit}
+                    </strong>
+                </label>
+
+                {showNumberInput && (
+                    <input
+                        type="number"
+                        inputMode="numeric"
+                        min={min}
+                        max={max}
+                        step={1}
+                        value={displayedNumberInputValue}
+                        disabled={disabled}
+                        aria-label={numberInputAriaLabel ?? label}
+                        onFocus={() => setNumberInputValue(String(value))}
+                        onChange={handleNumberInputChange}
+                        onBlur={handleNumberInputBlur}
+                        className="h-8 w-[72px] shrink-0 rounded-lg border border-[var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-2 text-right text-sm font-semibold text-[var(--monomat-text-strong)] outline-none transition focus:border-[var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-50"
+                    />
+                )}
+            </div>
 
             <input
                 id={id}
@@ -82,7 +149,7 @@ function LobbySettingsRange({
                 }}
                 className="block h-[7px] w-full cursor-pointer appearance-none rounded-[3px] border border-[var(--monomat-border-input)] outline-none transition disabled:cursor-not-allowed disabled:opacity-50 [&::-moz-range-thumb]:h-3 [&::-moz-range-thumb]:w-3 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-[var(--monomat-primary)] [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[var(--monomat-primary)]"
             />
-        </label>
+        </div>
     );
 }
 
@@ -220,6 +287,8 @@ export function LobbySettingsEditor({
                     onChange={(value) =>
                         updateFormState('questionCount', value)
                     }
+                    showNumberInput
+                    numberInputAriaLabel="라운드 수 직접 입력"
                 />
                 <LobbySettingsRange
                     id="lobby-settings-time-limit"
@@ -237,9 +306,7 @@ export function LobbySettingsEditor({
 
             <p className="mt-3 break-keep text-xs font-medium leading-5 text-[var(--monomat-text-muted)]">
                 {hasValidMapSongCount
-                    ? mapNumOfSong > questionCountMax
-                        ? `이 맵은 최대 ${mapNumOfSong}곡이지만, 로비는 최대 ${questionCountMax}라운드까지 설정할 수 있습니다.`
-                        : `이 맵은 최대 ${questionCountMax}라운드까지 진행할 수 있습니다.`
+                    ? `이 맵은 최대 ${questionCountMax}라운드까지 진행할 수 있습니다.`
                     : hasEmptySelectedMap
                         ? LOBBY_ROOM_COPY.SETTINGS_QUESTION_COUNT_EMPTY_MAP
                         : LOBBY_ROOM_COPY.SETTINGS_QUESTION_COUNT_MAP_REQUIRED}

--- a/src/mocks/data/maps.ts
+++ b/src/mocks/data/maps.ts
@@ -79,6 +79,19 @@ export const mockPublicMapItems: MapSummary[] = [
         ownerId: 106,
         ownerNickname: 'OST콜렉터',
     },
+    {
+        mapId: 7,
+        title: '70곡 라운드 정책 검증 맵',
+        description: '기본 상한을 넘는 라운드 설정을 확인하기 위한 mock 맵입니다.',
+        category: 'POP',
+        numOfSong: 70,
+        totalPlayTime: 12_600,
+        playCount: 12,
+        isPublic: true,
+        pendingPublic: false,
+        ownerId: 107,
+        ownerNickname: 'MockTester',
+    },
 ];
 
 export const mockMyMapItems: MapSummary[] = [

--- a/src/pages/LobbyCreate.tsx
+++ b/src/pages/LobbyCreate.tsx
@@ -36,6 +36,7 @@ import {
     clampLobbyQuestionCount,
     getLobbyQuestionCountMax,
     hasValidLobbyMapSongCount,
+    normalizeLobbyQuestionCountInput,
 } from '../utils/lobbyQuestionCount';
 
 interface LobbyCreateFormState {
@@ -55,6 +56,8 @@ interface LobbyRangeControlProps {
     max: number;
     disabled: boolean;
     onChange: (value: number) => void;
+    showNumberInput?: boolean;
+    numberInputAriaLabel?: string;
 }
 
 interface VisibilityOptionProps {
@@ -200,20 +203,84 @@ function LobbyRangeControl({
     max,
     disabled,
     onChange,
+    showNumberInput = false,
+    numberInputAriaLabel,
 }: LobbyRangeControlProps) {
+    const [numberInputValue, setNumberInputValue] = useState<string | null>(
+        null,
+    );
+    const displayedNumberInputValue = numberInputValue ?? String(value);
+
     const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
         onChange(Number(event.target.value));
     };
 
+    const handleNumberInputChange = (
+        event: ChangeEvent<HTMLInputElement>,
+    ) => {
+        const nextValue = event.target.value;
+        const parsedValue = Number(nextValue);
+
+        setNumberInputValue(nextValue);
+
+        if (
+            nextValue.trim() === '' ||
+            !Number.isFinite(parsedValue)
+        ) {
+            return;
+        }
+
+        onChange(
+            normalizeLobbyQuestionCountInput(
+                nextValue,
+                max,
+                value,
+            ),
+        );
+    };
+
+    const handleNumberInputBlur = () => {
+        const normalizedValue = normalizeLobbyQuestionCountInput(
+            displayedNumberInputValue,
+            max,
+            value,
+        );
+
+        setNumberInputValue(null);
+        onChange(normalizedValue);
+    };
+
     return (
-        <label htmlFor={id} className="block min-w-0">
-            <span className="mb-[9px] block h-5 text-base leading-5 text-[var(--monomat-text-muted)]">
-                {label} :{' '}
-                <strong className="font-semibold text-black">
-                    {value}
-                    {unit}
-                </strong>
-            </span>
+        <div className="block min-w-0">
+            <div className="mb-[9px] flex min-h-8 items-center justify-between gap-3">
+                <label
+                    htmlFor={id}
+                    className="min-w-0 text-base leading-5 text-[var(--monomat-text-muted)]"
+                >
+                    {label} :{' '}
+                    <strong className="font-semibold text-black">
+                        {value}
+                        {unit}
+                    </strong>
+                </label>
+
+                {showNumberInput && (
+                    <input
+                        type="number"
+                        inputMode="numeric"
+                        min={min}
+                        max={max}
+                        step={1}
+                        value={displayedNumberInputValue}
+                        disabled={disabled}
+                        aria-label={numberInputAriaLabel ?? label}
+                        onFocus={() => setNumberInputValue(String(value))}
+                        onChange={handleNumberInputChange}
+                        onBlur={handleNumberInputBlur}
+                        className="h-8 w-[72px] shrink-0 rounded-lg border border-[var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-2 text-right text-sm font-semibold text-[var(--monomat-text-strong)] outline-none transition focus:border-[var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
+                    />
+                )}
+            </div>
 
             <input
                 id={id}
@@ -228,7 +295,7 @@ function LobbyRangeControl({
                 }}
                 className="block h-[7px] w-full cursor-pointer appearance-none rounded-[3px] border border-[var(--monomat-border-input)] outline-none transition disabled:cursor-not-allowed disabled:opacity-60 [&::-moz-range-thumb]:h-3 [&::-moz-range-thumb]:w-3 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:bg-[var(--monomat-primary)] [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[var(--monomat-primary)]"
             />
-        </label>
+        </div>
     );
 }
 
@@ -385,11 +452,9 @@ export function LobbyCreate() {
             !hasValidLobbyMapSongCount(selectedMap.numOfSong),
         );
     const questionCountGuide = selectedMap
-        ? selectedMap.numOfSong > questionCountMax
-            ? `이 맵은 최대 ${selectedMap.numOfSong}곡이지만, 로비는 최대 ${questionCountMax}라운드까지 설정할 수 있습니다.`
-            : hasValidLobbyMapSongCount(selectedMap.numOfSong)
-                ? `이 맵은 최대 ${questionCountMax}라운드까지 진행할 수 있습니다.`
-                : '등록된 곡이 없어 라운드 수를 설정할 수 없습니다.'
+        ? hasValidLobbyMapSongCount(selectedMap.numOfSong)
+            ? `이 맵은 최대 ${questionCountMax}라운드까지 진행할 수 있습니다.`
+            : '등록된 곡이 없어 라운드 수를 설정할 수 없습니다.'
         : `맵을 선택하지 않으면 기본 ${CREATE_LOBBY_POLICY.DEFAULT_QUESTION_COUNT}라운드, 최대 ${CREATE_LOBBY_POLICY.MAX_QUESTION_COUNT}라운드로 설정됩니다.`;
 
     const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -575,6 +640,8 @@ export function LobbyCreate() {
                                 onChange={(value) =>
                                     updateFormState('questionCount', value)
                                 }
+                                showNumberInput
+                                numberInputAriaLabel="라운드 수 직접 입력"
                             />
 
                             <LobbyRangeControl

--- a/src/schemas/lobbySchema.ts
+++ b/src/schemas/lobbySchema.ts
@@ -85,8 +85,7 @@ export const updateLobbySettingsRequestSchema: z.ZodType<UpdateLobbySettingsRequ
             .min(CREATE_LOBBY_POLICY.MIN_PLAYERS)
             .max(CREATE_LOBBY_POLICY.MAX_PLAYERS),
         questionCount: z.number().int()
-            .min(CREATE_LOBBY_POLICY.MIN_QUESTION_COUNT)
-            .max(CREATE_LOBBY_POLICY.MAX_QUESTION_COUNT),
+            .min(CREATE_LOBBY_POLICY.MIN_QUESTION_COUNT),
         timeLimitSeconds: z.number().int()
             .min(CREATE_LOBBY_POLICY.MIN_TIME_LIMIT_SECONDS)
             .max(CREATE_LOBBY_POLICY.MAX_TIME_LIMIT_SECONDS),

--- a/src/utils/lobbyQuestionCount.ts
+++ b/src/utils/lobbyQuestionCount.ts
@@ -13,10 +13,7 @@ export function getLobbyQuestionCountMax(
         return CREATE_LOBBY_POLICY.MAX_QUESTION_COUNT;
     }
 
-    return Math.min(
-        mapNumOfSong,
-        CREATE_LOBBY_POLICY.MAX_QUESTION_COUNT,
-    );
+    return mapNumOfSong;
 }
 
 export function clampLobbyQuestionCount(
@@ -29,5 +26,25 @@ export function clampLobbyQuestionCount(
             CREATE_LOBBY_POLICY.MIN_QUESTION_COUNT,
         ),
         getLobbyQuestionCountMax(mapNumOfSong),
+    );
+}
+
+export function normalizeLobbyQuestionCountInput(
+    inputValue: string,
+    mapNumOfSong?: number | null,
+    fallbackQuestionCount: number = CREATE_LOBBY_POLICY.MIN_QUESTION_COUNT,
+): number {
+    const parsedValue = Number(inputValue);
+
+    if (!Number.isFinite(parsedValue)) {
+        return clampLobbyQuestionCount(
+            fallbackQuestionCount,
+            mapNumOfSong,
+        );
+    }
+
+    return clampLobbyQuestionCount(
+        Math.trunc(parsedValue),
+        mapNumOfSong,
     );
 }


### PR DESCRIPTION
## 📣 Related Issue

- #126

## 📝 Summary

- 선택된 맵이 있는 경우 라운드 수 최대값을 `mapNumOfSong` / `selectedMap.numOfSong` 기준으로 반영했습니다.
- 로비 생성 화면과 대기실 방장 설정 UI에 라운드 수 숫자 입력칸을 추가했습니다.
- 빈 값, 소수, 음수, 최대값 초과 입력은 현재 허용 범위 안으로 보정되도록 처리했습니다.
- `updateLobbySettingsRequestSchema.questionCount`의 정적 `max(50)` 제한을 제거했습니다.
- 70곡 mock 맵을 추가해 50라운드 초과 입력 정책을 확인할 수 있도록 했습니다.

## 🙏PR point

- 현재 Monomat-BE `develop`에는 `questionCount @Max(50)` 검증이 남아 있어, 실제 서버에서는 51 이상 요청이 실패할 수 있습니다.
- FE 정책 반영 후 정상 동작하려면 BE 검증 정책 수정이 필요합니다.
- mock 맵은 라운드 수 정책 검증에 필요한 최소 데이터만 추가했고, 실제 map item 70개는 생성하지 않았습니다.
- `npm run lint` 통과: 기존 `public/mockServiceWorker.js` warning 1건만 출력
- `npm run build` 통과: Vite chunk size warning 1건만 출력

## 📬 Reference

- GitHub Issue #126
- Monomat-BE develop 로비 생성/설정 변경 정책