### PR TITLE
[Fix/#128] 맵 아이템 API 계약 정합성 수정

### DIFF
--- a/src/mocks/handlers/map.ts
+++ b/src/mocks/handlers/map.ts
@@ -5,6 +5,7 @@ import {
     DEFAULT_MAP_LIST_PAGE,
     DEFAULT_MAP_LIST_SIZE,
     DEFAULT_MAP_SORT_OPTION,
+    MAP_CREATE_POLICY,
     MAP_CATEGORY_OPTIONS,
     MAP_CATEGORY_QUERY_VALUE,
     MY_MAP_LIST_PAGE_SIZE,
@@ -182,11 +183,9 @@ export const mapHandlers = [
                     ...mockMyMapItems.map((map) => map.mapId),
                 ) + 1;
             const createdAt = new Date().toISOString();
-            const totalPlayTime = payload.items.reduce(
-                (total, item) =>
-                    total + (item.endTime - item.startTime),
-                0,
-            );
+            const totalPlayTime =
+                payload.items.length *
+                MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS;
             const createdMap = {
                 id: nextMapId,
                 ownerId: 999,
@@ -209,7 +208,6 @@ export const mapHandlers = [
                 youtubeUrl: item.youtubeUrl,
                 videoId: null,
                 startTime: item.startTime,
-                endTime: item.endTime,
                 title: null,
                 artist: null,
                 thumbnailUrl: null,

--- a/src/pages/MapManage.tsx
+++ b/src/pages/MapManage.tsx
@@ -68,7 +68,8 @@ function createManageSongForm(
         videoDurationSeconds: null,
         answers: [...item.answers],
         hintTime: item.hintTime,
-        playDurationSeconds: Math.max(1, item.endTime - item.startTime),
+        playDurationSeconds:
+            MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS,
     };
 }
 

--- a/src/schemas/mapSchema.ts
+++ b/src/schemas/mapSchema.ts
@@ -57,7 +57,6 @@ export const mapItemResponseSchema = z.object({
     youtubeUrl: z.string().min(1),
     videoId: z.string().min(1).nullable(),
     startTime: z.number().int().min(0),
-    endTime: z.number().int().positive(),
     title: z.string().nullable(),
     artist: z.string().nullable(),
     thumbnailUrl: z.string().nullable(),

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -65,7 +65,6 @@ export interface ManageMapItemRequest {
     orderNum: number;
     youtubeUrl: string;
     startTime: number;
-    endTime: number;
     answers: string[];
     hint: string;
     hintTime: number | null;
@@ -80,7 +79,6 @@ export interface CreateMapItemRequest {
     orderNum: number;
     youtubeUrl: string;
     startTime: number;
-    endTime: number;
     answers: string[];
     hint: string;
     hintTime?: number | null;
@@ -121,7 +119,6 @@ export interface MapItemResponse {
     youtubeUrl: string;
     videoId: string | null;
     startTime: number;
-    endTime: number;
     title: string | null;
     artist: string | null;
     thumbnailUrl: string | null;

--- a/src/utils/mapCreateTiming.ts
+++ b/src/utils/mapCreateTiming.ts
@@ -1,24 +1,16 @@
 import { MAP_CREATE_POLICY } from '../constants/map';
 
-export interface MapCreateTiming {
-    startTime: number;
-    endTime: number;
-}
-
-export function getMapCreateTiming(
+export function getMapCreatePreviewEndTime(
     startTime: number,
     playDurationSeconds: number =
         MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS,
-): MapCreateTiming {
+): number {
     const normalizedPlayDuration =
         Number.isInteger(playDurationSeconds) && playDurationSeconds > 0
             ? playDurationSeconds
             : MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS;
 
-    return {
-        startTime,
-        endTime: startTime + normalizedPlayDuration,
-    };
+    return startTime + normalizedPlayDuration;
 }
 
 export function getMapCreateTimingError(
@@ -41,9 +33,12 @@ export function getMapCreateTimingError(
         return '시작 시간은 0 이상의 정수로 입력해주세요.';
     }
 
-    const timing = getMapCreateTiming(startTime, playDurationSeconds);
+    const previewEndTime = getMapCreatePreviewEndTime(
+        startTime,
+        playDurationSeconds,
+    );
 
-    if (timing.endTime <= timing.startTime) {
+    if (previewEndTime <= startTime) {
         return '종료 시간은 시작 시간보다 커야 합니다.';
     }
 
@@ -55,11 +50,11 @@ export function getMapCreateTimingError(
         return null;
     }
 
-    if (timing.startTime >= videoDurationSeconds) {
+    if (startTime >= videoDurationSeconds) {
         return `시작 시간은 영상 길이 ${Math.floor(videoDurationSeconds)}초보다 작아야 합니다.`;
     }
 
-    if (timing.endTime > videoDurationSeconds) {
+    if (previewEndTime > videoDurationSeconds) {
         const latestStartTime = Math.max(
             MAP_CREATE_POLICY.MIN_START_TIME_SECONDS,
             Math.floor(

--- a/src/utils/mapSongForm.ts
+++ b/src/utils/mapSongForm.ts
@@ -1,9 +1,6 @@
 import { MAP_CREATE_POLICY } from '../constants/map';
 import { normalizeAnswerList } from './answerNormalizer';
-import {
-    getMapCreateTiming,
-    getMapCreateTimingError,
-} from './mapCreateTiming';
+import { getMapCreateTimingError } from './mapCreateTiming';
 
 import type {
     CreateMapWithItemsItemRequest,
@@ -43,11 +40,6 @@ export function createMapItemRequestFromSong(
     song: CreateMapSongFormState,
     orderNum: number,
 ): CreateMapWithItemsItemRequest {
-    const timing = getMapCreateTiming(
-        Number(song.startTime),
-        song.playDurationSeconds ??
-            MAP_CREATE_POLICY.API_FALLBACK_PLAY_DURATION_SECONDS,
-    );
     const hintTime = song.hintTime;
     const hasValidHintTime =
         typeof hintTime === 'number' &&
@@ -58,8 +50,7 @@ export function createMapItemRequestFromSong(
     return {
         orderNum,
         youtubeUrl: song.youtubeUrl.trim(),
-        startTime: timing.startTime,
-        endTime: timing.endTime,
+        startTime: Number(song.startTime),
         answers: song.answers
             .map((answer) => answer.trim())
             .filter(Boolean),


### PR DESCRIPTION
## 📣 Related Issue

- #128

## 📝 Summary

- BE develop 기준 맵 아이템 DTO에 존재하지 않는 `endTime` 필드를 FE 타입, Zod schema, 요청 payload, MSW mock 응답에서 제거했습니다.
- 맵 생성/관리 저장 요청은 `orderNum`, `youtubeUrl`, `startTime`, `answers`, `hint`, `hintTime` 중심으로 BE 계약에 맞췄습니다.
- `playDurationSeconds`는 저장 payload가 아닌 FE 내부 YouTube duration 검증용 UI 보조 상태로 유지했습니다.
- 맵 관리 화면에서 기존 응답으로 재생 길이를 복원할 수 없는 경우 정책 상수값으로 fallback 처리하도록 수정했습니다.

## 🙏PR point

- 이번 PR은 BE 수정 없이 FE 계약을 BE develop 기준에 맞추는 작업입니다.
- `endTime` 제거 후 `rg -n "endTime" src` 결과가 없는 것을 확인했습니다.
- `npm run lint`는 통과했으며, 기존 `public/mockServiceWorker.js` unused eslint-disable warning 1건이 남아 있습니다.
- `npm run build`는 통과했으며, 기존 Vite chunk size warning이 표시됩니다.

## 📬 Reference

- Monomat-BE develop 기준 `MapItemResponse`
- Monomat-BE develop 기준 `CreateMapItemRequest`
- Monomat-BE develop 기준 `ManageMapItemRequest`