### PR TITLE
[Feat/#130] 인게임 페이지 라우팅 및 기본 레이아웃 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,11 +9,13 @@ import { useSocket } from './hooks/useSocket';
 import { ProtectedRoute } from './components/common/ProtectedRoute';
 import { AppLayout } from './components/common/AppLayout';
 import { ViewportGuard } from './components/common/ViewportGuard';
+import { GAME_ROUTES } from './constants/game';
 import { LOBBY_ROUTES } from './constants/lobby';
 import { MAP_ROUTES } from './constants/map';
 
 // 페이지 컴포넌트
 import { Home } from './pages/Home';
+import { InGamePage } from './pages/InGamePage';
 import { Lobbies } from './pages/Lobbies';
 import { LobbyCreate } from './pages/LobbyCreate';
 import { LobbyRoom } from './pages/LobbyRoom';
@@ -121,6 +123,17 @@ function AppRoutes() {
                         <AppLayout>
                             <ProtectedRoute>
                                 <LobbyRoom />
+                            </ProtectedRoute>
+                        </AppLayout>
+                    }
+                />
+
+                <Route
+                    path={GAME_ROUTES.PLAY_PATTERN}
+                    element={
+                        <AppLayout>
+                            <ProtectedRoute>
+                                <InGamePage />
                             </ProtectedRoute>
                         </AppLayout>
                     }

--- a/src/components/game/GameAnswerInput.tsx
+++ b/src/components/game/GameAnswerInput.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { Send } from 'lucide-react';
+
+import { GAME_COPY } from '../../constants/game';
+
+export function GameAnswerInput() {
+    const [answer, setAnswer] = useState('');
+
+    return (
+        <section className="flex h-[52px] gap-[8px]">
+            <label className="sr-only" htmlFor="game-answer-input">
+                {GAME_COPY.ANSWER_PLACEHOLDER}
+            </label>
+            <input
+                id="game-answer-input"
+                type="text"
+                value={answer}
+                onChange={(event) => setAnswer(event.target.value)}
+                placeholder={GAME_COPY.ANSWER_PLACEHOLDER}
+                className="h-[52px] min-w-0 flex-1 rounded-xl border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-[14px] text-sm text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[var(--monomat-primary)]"
+            />
+            <button
+                type="button"
+                disabled
+                aria-label={GAME_COPY.ANSWER_ACTION_ARIA_LABEL}
+                title={GAME_COPY.ANSWER_ACTION_ARIA_LABEL}
+                className="flex h-[52px] w-[52px] shrink-0 cursor-not-allowed items-center justify-center rounded-xl bg-[var(--monomat-primary)] text-white"
+            >
+                <Send
+                    size={25}
+                    strokeWidth={2}
+                    className="-rotate-12"
+                    aria-hidden="true"
+                />
+            </button>
+        </section>
+    );
+}

--- a/src/components/game/GameChatPanel.tsx
+++ b/src/components/game/GameChatPanel.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { Send } from 'lucide-react';
+
+import { GAME_COPY } from '../../constants/game';
+
+import type { GameChatPreviewMessage } from '../../types/game';
+
+interface GameChatPanelProps {
+    messages: readonly GameChatPreviewMessage[];
+}
+
+export function GameChatPanel({ messages }: GameChatPanelProps) {
+    const [message, setMessage] = useState('');
+
+    return (
+        <section className="flex min-h-[420px] flex-col overflow-hidden rounded-2xl border border-[color:var(--monomat-border-default)] bg-white text-left shadow-[0_4px_8px_rgba(0,0,0,0.10)] min-[1280px]:h-[690px]">
+            <header className="flex h-[55px] shrink-0 items-center border-b border-[color:var(--monomat-border-default)] px-5">
+                <h2 className="!m-0 !text-base !font-semibold !leading-none !text-black">
+                    {GAME_COPY.CHAT_TITLE}
+                </h2>
+            </header>
+
+            <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+                <ul className="space-y-[18px]">
+                    {messages.map((chatMessage, index) => (
+                        <li
+                            key={`${chatMessage.nickname}-${chatMessage.time}-${index}`}
+                            className="min-w-0"
+                        >
+                            <div className="flex min-w-0 items-baseline gap-2">
+                                <span className="min-w-0 truncate text-base font-semibold leading-[19px] text-[var(--monomat-primary)]">
+                                    {chatMessage.nickname}
+                                </span>
+                                <time className="shrink-0 text-xs leading-[19px] text-[#73788A]">
+                                    {chatMessage.time}
+                                </time>
+                            </div>
+                            <p className="mt-[9px] whitespace-pre-wrap break-words text-[15px] leading-[26px] text-black [overflow-wrap:anywhere]">
+                                {chatMessage.content}
+                            </p>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+
+            <footer className="h-[70px] shrink-0 border-t border-[color:var(--monomat-border-default)] px-3 py-2">
+                <div className="flex h-[52px] gap-[8px]">
+                    <label className="sr-only" htmlFor="game-chat-input">
+                        {GAME_COPY.CHAT_PLACEHOLDER}
+                    </label>
+                    <input
+                        id="game-chat-input"
+                        type="text"
+                        value={message}
+                        onChange={(event) => setMessage(event.target.value)}
+                        placeholder={GAME_COPY.CHAT_PLACEHOLDER}
+                        className="h-[52px] min-w-0 flex-1 rounded-xl border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-[14px] text-sm text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[var(--monomat-primary)]"
+                    />
+                    <button
+                        type="button"
+                        disabled
+                        aria-label={GAME_COPY.CHAT_ACTION_ARIA_LABEL}
+                        title={GAME_COPY.CHAT_ACTION_ARIA_LABEL}
+                        className="flex h-[52px] w-[52px] shrink-0 cursor-not-allowed items-center justify-center rounded-xl bg-[var(--monomat-primary)] text-white"
+                    >
+                        <Send
+                            size={24}
+                            strokeWidth={2}
+                            className="-rotate-12"
+                            aria-hidden="true"
+                        />
+                    </button>
+                </div>
+            </footer>
+        </section>
+    );
+}

--- a/src/components/game/GameHeader.tsx
+++ b/src/components/game/GameHeader.tsx
@@ -1,0 +1,28 @@
+import { X } from 'lucide-react';
+
+import { GAME_COPY } from '../../constants/game';
+import { MonomatLogo } from '../common/MonomatLogo';
+
+interface GameHeaderProps {
+    onLeave: () => void;
+}
+
+export function GameHeader({ onLeave }: GameHeaderProps) {
+    return (
+        <header className="h-[75px] shrink-0 border border-[color:var(--monomat-border-default)] bg-white">
+            <div className="mx-auto flex h-full w-full max-w-[1440px] items-center justify-between px-4 sm:px-6 lg:px-8 min-[1280px]:px-[40px]">
+                <MonomatLogo />
+
+                <button
+                    type="button"
+                    onClick={onLeave}
+                    aria-label={GAME_COPY.LEAVE_ARIA_LABEL}
+                    className="flex h-10 items-center gap-1 text-lg font-medium text-[var(--monomat-text-muted)] transition hover:text-[var(--monomat-text-strong)]"
+                >
+                    <X size={22} strokeWidth={2} aria-hidden="true" />
+                    <span>{GAME_COPY.LEAVE}</span>
+                </button>
+            </div>
+        </header>
+    );
+}

--- a/src/components/game/GamePlayerPanel.tsx
+++ b/src/components/game/GamePlayerPanel.tsx
@@ -1,0 +1,40 @@
+import { Music2 } from 'lucide-react';
+
+import { GAME_COPY } from '../../constants/game';
+
+interface GamePlayerPanelProps {
+    currentRound: number;
+    totalRounds: number;
+}
+
+export function GamePlayerPanel({
+    currentRound,
+    totalRounds,
+}: GamePlayerPanelProps) {
+    return (
+        <section className="flex h-[440px] flex-col items-center overflow-hidden rounded-2xl bg-white px-6 text-center shadow-[0_4px_16px_rgba(0,0,0,0.18)]">
+            <div
+                role="img"
+                aria-label={GAME_COPY.PLAYER_PLACEHOLDER_ARIA_LABEL}
+                className="mt-[57px] flex h-[200px] w-[200px] shrink-0 items-center justify-center rounded-full bg-[var(--monomat-primary)]"
+            >
+                <Music2
+                    size={52}
+                    strokeWidth={2.2}
+                    className="text-white"
+                    aria-hidden="true"
+                />
+            </div>
+
+            <p className="mt-11 text-[15px] font-bold leading-[17px] text-[var(--monomat-text-muted)]">
+                {GAME_COPY.NOW_PLAYING}
+            </p>
+            <h1 className="!m-0 mt-[13px] !text-xl !font-bold !leading-6 !text-[var(--monomat-text-strong)]">
+                {GAME_COPY.PLAYER_GUIDE}
+            </h1>
+            <p className="mt-3 text-sm leading-[17px] text-[var(--monomat-text-muted)] tabular-nums">
+                {currentRound}/{totalRounds}
+            </p>
+        </section>
+    );
+}

--- a/src/components/game/GameRankingCard.tsx
+++ b/src/components/game/GameRankingCard.tsx
@@ -1,0 +1,58 @@
+import { GAME_COPY } from '../../constants/game';
+
+import type { GameRankingEntry } from '../../types/game';
+
+interface GameRankingCardProps {
+    entries: readonly GameRankingEntry[];
+}
+
+export function GameRankingCard({ entries }: GameRankingCardProps) {
+    return (
+        <section className="h-[440px] overflow-hidden rounded-2xl bg-white px-[13px] py-[18px] text-left">
+            <h2 className="!m-0 !text-base !font-bold !leading-[23px] !text-[var(--monomat-text-strong)]">
+                {GAME_COPY.RANKING_TITLE}
+            </h2>
+
+            <ol className="mt-2 space-y-[7px]">
+                {entries.map((entry) => (
+                    <li
+                        key={`${entry.rank}-${entry.nickname}`}
+                        className={`grid h-[40px] grid-cols-[20px_minmax(0,1fr)_48px] items-center gap-[3px] rounded-xl px-[7px] ${
+                            entry.isCurrentUser
+                                ? 'bg-[#EBEDFF]'
+                                : 'bg-[#F1F2F5]'
+                        }`}
+                    >
+                        <span
+                            className={`text-center text-xs font-semibold ${
+                                entry.isCurrentUser
+                                    ? 'text-[#FF9400]'
+                                    : 'text-[#7B808D]'
+                            }`}
+                        >
+                            {entry.rank}
+                        </span>
+                        <span
+                            className={`truncate text-base font-semibold ${
+                                entry.isCurrentUser
+                                    ? 'text-[#5542BC]'
+                                    : 'text-[#303540]'
+                            }`}
+                        >
+                            {entry.nickname}
+                        </span>
+                        <span
+                            className={`text-right text-sm font-semibold tabular-nums ${
+                                entry.isCurrentUser
+                                    ? 'text-[#4D38B7]'
+                                    : 'text-black'
+                            }`}
+                        >
+                            {entry.score}
+                        </span>
+                    </li>
+                ))}
+            </ol>
+        </section>
+    );
+}

--- a/src/components/game/GameRoundStatusBar.tsx
+++ b/src/components/game/GameRoundStatusBar.tsx
@@ -1,0 +1,33 @@
+import { GAME_COPY } from '../../constants/game';
+
+interface GameRoundStatusBarProps {
+    remainingSeconds: number;
+    progressPercent: number;
+}
+
+export function GameRoundStatusBar({
+    remainingSeconds,
+    progressPercent,
+}: GameRoundStatusBarProps) {
+    const normalizedProgress = Math.min(Math.max(progressPercent, 0), 100);
+
+    return (
+        <section className="h-20 rounded-2xl bg-white px-[27px] pt-[19px] shadow-[0_4px_16px_rgba(0,0,0,0.18)]">
+            <div className="flex items-center justify-between">
+                <span className="text-sm font-semibold text-[var(--monomat-text-muted)]">
+                    {GAME_COPY.REMAINING_TIME}
+                </span>
+                <span className="text-base font-bold leading-none text-[var(--monomat-primary)] tabular-nums">
+                    {remainingSeconds}s
+                </span>
+            </div>
+
+            <div className="mt-[9px] h-2 overflow-hidden rounded-full bg-[#F1F2F5]">
+                <div
+                    className="h-full rounded-full bg-[var(--monomat-primary)]"
+                    style={{ width: `${normalizedProgress}%` }}
+                />
+            </div>
+        </section>
+    );
+}

--- a/src/components/game/InGameLayout.tsx
+++ b/src/components/game/InGameLayout.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from 'react';
+
+interface InGameLayoutProps {
+    ranking: ReactNode;
+    roundStatus: ReactNode;
+    player: ReactNode;
+    answerInput: ReactNode;
+    chat: ReactNode;
+}
+
+export function InGameLayout({
+    ranking,
+    roundStatus,
+    player,
+    answerInput,
+    chat,
+}: InGameLayoutProps) {
+    return (
+        <div className="mx-auto grid w-full max-w-[1360px] grid-cols-[220px_minmax(0,1fr)] gap-[16px] min-[1280px]:grid-cols-[250px_minmax(0,700px)_minmax(320px,377px)]">
+            <aside className="min-w-0">{ranking}</aside>
+
+            <div className="flex min-w-0 flex-col gap-[15px]">
+                {roundStatus}
+                {player}
+                {answerInput}
+            </div>
+
+            <aside className="col-span-2 min-w-0 min-[1280px]:col-span-1">
+                {chat}
+            </aside>
+        </div>
+    );
+}

--- a/src/constants/game.ts
+++ b/src/constants/game.ts
@@ -1,0 +1,65 @@
+import type {
+    GameChatPreviewMessage,
+    GameRankingEntry,
+} from '../types/game';
+
+export const GAME_ROUTES = {
+    PLAY_PATTERN: '/game/:inviteCode',
+    PLAY: (inviteCode: string) => `/game/${inviteCode}`,
+} as const;
+
+export const GAME_COPY = {
+    LEAVE: '나가기',
+    LEAVE_ARIA_LABEL: '게임에서 나가 로비 목록으로 이동',
+    INVALID_ACCESS_TITLE: '잘못된 게임 접근입니다.',
+    INVALID_ACCESS_DESCRIPTION:
+        '초대 코드가 포함된 게임 주소로 다시 접속해주세요.',
+    GO_TO_LOBBY_LIST: '로비 목록으로 이동',
+    RANKING_TITLE: '🏆 실시간 순위',
+    REMAINING_TIME: '남은 시간',
+    NOW_PLAYING: '지금 재생 중',
+    PLAYER_GUIDE: '제목을 맞춰보세요',
+    PLAYER_PLACEHOLDER_ARIA_LABEL: '음악 플레이어 준비 영역',
+    ANSWER_PLACEHOLDER: '정답을 입력하세요',
+    ANSWER_ACTION_ARIA_LABEL: '정답 제출 기능은 준비 중입니다.',
+    CHAT_TITLE: '게임 채팅',
+    CHAT_PLACEHOLDER: '메시지를 입력하세요',
+    CHAT_ACTION_ARIA_LABEL: '게임 채팅 전송 기능은 준비 중입니다.',
+} as const;
+
+export const GAME_PREVIEW = {
+    remainingSeconds: 13,
+    timeProgressPercent: 50,
+    currentRound: 3,
+    totalRounds: 10,
+} as const;
+
+export const GAME_RANKING_PREVIEW: readonly GameRankingEntry[] = [
+    { rank: 1, nickname: '나', score: 320, isCurrentUser: true },
+    { rank: 2, nickname: '유키', score: 300 },
+    { rank: 3, nickname: '벨', score: 240 },
+    { rank: 4, nickname: 'Nut', score: 230 },
+    { rank: 5, nickname: '민지', score: 180 },
+    { rank: 6, nickname: '제이', score: 150 },
+    { rank: 7, nickname: '도현', score: 140 },
+    { rank: 8, nickname: '하루', score: 90 },
+] as const;
+
+export const GAME_CHAT_PREVIEW: readonly GameChatPreviewMessage[] = [
+    {
+        nickname: '노래왕',
+        time: '20:43',
+        content: '이번 노래는 알 것 같아요!',
+    },
+    {
+        nickname: '심야괴담회X서프라이즈',
+        time: '20:45',
+        content:
+            '게임 채팅 UI 확인용 메시지입니다. 내용이 길어지면 말줄임표 없이 다음 줄로 자연스럽게 표시됩니다.',
+    },
+    {
+        nickname: '유키',
+        time: '20:46',
+        content: '다음 문제도 파이팅!',
+    },
+] as const;

--- a/src/constants/lobby.ts
+++ b/src/constants/lobby.ts
@@ -189,8 +189,6 @@ export const LOBBY_ROOM_COPY = {
     READY_SYNCED: '준비 상태는 서버 이벤트로 다시 동기화됩니다.',
     READY_WAIT_PLAYER: '참여자 정보 동기화 후 준비할 수 있습니다.',
     START_REQUESTED: '게임 시작 요청을 보냈습니다.',
-    GAME_STARTED_PENDING_ROUTE:
-        '게임이 시작되었습니다. 게임 화면 전환은 추후 연결됩니다.',
     MAP_CHANGE_FAILED: '로비 맵 변경에 실패했습니다.',
     READY_CHANGE_FAILED: '준비 상태 변경에 실패했습니다.',
     START_FAILED: '게임 시작에 실패했습니다.',

--- a/src/pages/InGamePage.tsx
+++ b/src/pages/InGamePage.tsx
@@ -1,0 +1,100 @@
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { GameAnswerInput } from '../components/game/GameAnswerInput';
+import { GameChatPanel } from '../components/game/GameChatPanel';
+import { GameHeader } from '../components/game/GameHeader';
+import { GamePlayerPanel } from '../components/game/GamePlayerPanel';
+import { GameRankingCard } from '../components/game/GameRankingCard';
+import { GameRoundStatusBar } from '../components/game/GameRoundStatusBar';
+import { InGameLayout } from '../components/game/InGameLayout';
+import { LobbyFooter } from '../components/lobby/LobbyFooter';
+import {
+    GAME_CHAT_PREVIEW,
+    GAME_COPY,
+    GAME_PREVIEW,
+    GAME_RANKING_PREVIEW,
+} from '../constants/game';
+import { LOBBY_ROUTES } from '../constants/lobby';
+import {
+    normalizeInviteCode,
+    validateInviteCode,
+} from '../utils/inviteCode';
+
+function InGameStateCard({ onBack }: { onBack: () => void }) {
+    return (
+        <main className="flex flex-1 items-center justify-center px-4 py-10">
+            <section className="w-full max-w-xl rounded-lg bg-white px-6 py-9 text-center shadow-[0_4px_16px_rgba(0,0,0,0.08)] ring-1 ring-[color:var(--monomat-border-card)] sm:px-8">
+                <h1 className="!m-0 !text-2xl !font-extrabold !text-[var(--monomat-text-strong)]">
+                    {GAME_COPY.INVALID_ACCESS_TITLE}
+                </h1>
+                <p className="mt-4 break-keep text-sm font-medium text-[var(--monomat-text-muted)]">
+                    {GAME_COPY.INVALID_ACCESS_DESCRIPTION}
+                </p>
+                <button
+                    type="button"
+                    onClick={onBack}
+                    className="mt-6 h-10 rounded-lg bg-[var(--monomat-primary)] px-5 text-sm font-bold text-white transition hover:bg-[var(--monomat-primary-hover)]"
+                >
+                    {GAME_COPY.GO_TO_LOBBY_LIST}
+                </button>
+            </section>
+        </main>
+    );
+}
+
+export function InGamePage() {
+    const { inviteCode: inviteCodeParam } = useParams<{
+        inviteCode: string;
+    }>();
+    const navigate = useNavigate();
+    const inviteCode = normalizeInviteCode(inviteCodeParam ?? '');
+    const inviteCodeError = validateInviteCode(inviteCode);
+
+    const handleLeave = () => {
+        navigate(LOBBY_ROUTES.LIST);
+    };
+
+    return (
+        <div className="flex min-h-screen flex-col bg-[var(--monomat-page-bg)]">
+            <GameHeader onLeave={handleLeave} />
+
+            {inviteCodeError ? (
+                <InGameStateCard onBack={handleLeave} />
+            ) : (
+                <main className="flex-1 px-4 pb-[64px] pt-[30px] sm:px-6 lg:px-8 min-[1280px]:px-[40px]">
+                    <InGameLayout
+                        ranking={
+                            <GameRankingCard
+                                entries={GAME_RANKING_PREVIEW}
+                            />
+                        }
+                        roundStatus={
+                            <GameRoundStatusBar
+                                remainingSeconds={
+                                    GAME_PREVIEW.remainingSeconds
+                                }
+                                progressPercent={
+                                    GAME_PREVIEW.timeProgressPercent
+                                }
+                            />
+                        }
+                        player={
+                            <GamePlayerPanel
+                                currentRound={GAME_PREVIEW.currentRound}
+                                totalRounds={GAME_PREVIEW.totalRounds}
+                            />
+                        }
+                        answerInput={<GameAnswerInput />}
+                        chat={
+                            <GameChatPanel messages={GAME_CHAT_PREVIEW} />
+                        }
+                    />
+                </main>
+            )}
+
+            <div className="shrink-0 [&>footer]:h-[41px] [&>footer>div]:h-[39px] [&>footer>div]:min-h-0 [&>footer>div]:py-0">
+                <LobbyFooter />
+            </div>
+        </div>
+    );
+}

--- a/src/pages/LobbyRoom.tsx
+++ b/src/pages/LobbyRoom.tsx
@@ -1,4 +1,9 @@
-import { type ReactNode, useMemo, useState } from 'react';
+import {
+    type ReactNode,
+    useEffect,
+    useMemo,
+    useState,
+} from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -20,6 +25,7 @@ import { LobbyRoomLayout } from '../components/lobby/LobbyRoomLayout';
 import { LobbyRoomTopControls } from '../components/lobby/LobbyRoomTopControls';
 import { LobbySettingsEditor } from '../components/lobby/LobbySettingsEditor';
 import { MapSelectModal } from '../components/lobby/MapSelectModal';
+import { GAME_ROUTES } from '../constants/game';
 import { LOBBY_ROOM_COPY, LOBBY_ROUTES } from '../constants/lobby';
 import {
     lobbyDetailQueryKey,
@@ -157,6 +163,15 @@ export function LobbyRoom() {
         inviteCode,
         lobbyChat.handleLobbyMessageBody,
     );
+
+    useEffect(() => {
+        if (!inviteCode || gameStatus !== 'started') {
+            return;
+        }
+
+        navigate(GAME_ROUTES.PLAY(inviteCode), { replace: true });
+    }, [gameStatus, inviteCode, navigate]);
+
     const {
         data: lobbyDetail,
         isLoading,
@@ -519,8 +534,7 @@ export function LobbyRoom() {
                     }
                     feedbackSlot={
                         (currentActionErrorMessage ||
-                            currentActionMessage ||
-                            gameStatus === 'started') && (
+                            currentActionMessage) && (
                             <section
                                 role={
                                     currentActionErrorMessage
@@ -534,9 +548,7 @@ export function LobbyRoom() {
                                 }`}
                             >
                                 {currentActionErrorMessage ??
-                                    (gameStatus === 'started'
-                                        ? LOBBY_ROOM_COPY.GAME_STARTED_PENDING_ROUTE
-                                        : currentActionMessage)}
+                                    currentActionMessage}
                             </section>
                         )
                     }

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -1,0 +1,12 @@
+export interface GameRankingEntry {
+    rank: number;
+    nickname: string;
+    score: number;
+    isCurrentUser?: boolean;
+}
+
+export interface GameChatPreviewMessage {
+    nickname: string;
+    time: string;
+    content: string;
+}


### PR DESCRIPTION
## 📣 Related Issue

- #130

## 📝 Summary

- `/game/:inviteCode` 보호 라우트와 `InGamePage`를 추가했습니다.
- Figma의 `인게임 | 라운드 진행 중` 화면을 기준으로 좌측 랭킹, 중앙 게임 플레이, 우측 채팅 영역의 3컬럼 레이아웃을 구현했습니다.
- 랭킹, 라운드 상태바, 플레이어 placeholder, 정답 입력, 게임 채팅, 헤더를 게임 전용 컴포넌트로 분리했습니다.
- 잘못된 초대 코드로 접근하면 안내 화면을 표시하고 로비 목록으로 이동할 수 있도록 처리했습니다.
- 기존 `GAME_STARTED` WebSocket 이벤트 수신 시 `/game/:inviteCode`로 자동 이동하도록 연결했습니다.
- 나가기 버튼은 별도의 서버 이벤트 없이 `/lobbies`로 이동하도록 구현했습니다.
- 1440px 데스크톱 화면을 우선 적용하고, 1024px 환경에서는 채팅 영역을 다음 행으로 배치했습니다.
- `npm run lint`와 `npm run build`를 실행했습니다.

## 🙏PR point

- 현재 랭킹, 채팅, 남은 시간, 라운드 정보는 화면 확인을 위한 static mock 데이터입니다.
- 실제 YouTube Player, 게임 WebSocket 이벤트, 정답 제출, 채팅 전송, 실시간 랭킹 반영은 포함하지 않았습니다.
- 정답과 채팅 입력은 로컬 상태만 관리하며 제출 동작은 비활성화되어 있습니다.
- `src/types/game.ts`에는 UI 렌더링에 필요한 최소 타입만 정의했습니다.
- lint는 오류 없이 통과했으며 기존 `public/mockServiceWorker.js` 경고 1건이 남아 있습니다.
- build는 성공했으며 기존 번들 크기 경고가 발생합니다.

## 📬 Reference

