### PR TITLE
[Feat/#133] 게임 시작 이벤트 기반 인게임 이동 구현

### DIFF
--- a/src/pages/LobbyRoom.tsx
+++ b/src/pages/LobbyRoom.tsx
@@ -1,7 +1,9 @@
 import {
     type ReactNode,
+    useCallback,
     useEffect,
     useMemo,
+    useRef,
     useState,
 } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -163,21 +165,60 @@ export function LobbyRoom() {
         inviteCode,
         lobbyChat.handleLobbyMessageBody,
     );
+    const navigatedInviteCodeRef = useRef<string | null>(null);
+    const initialStatusCheckedInviteCodeRef = useRef<string | null>(null);
+
+    const navigateToGame = useCallback(
+        (targetInviteCode: string) => {
+            if (navigatedInviteCodeRef.current === targetInviteCode) {
+                return;
+            }
+
+            navigatedInviteCodeRef.current = targetInviteCode;
+            navigate(GAME_ROUTES.PLAY(targetInviteCode), {
+                replace: true,
+            });
+        },
+        [navigate],
+    );
+
+    useEffect(() => {
+        navigatedInviteCodeRef.current = null;
+        initialStatusCheckedInviteCodeRef.current = null;
+    }, [inviteCode]);
 
     useEffect(() => {
         if (!inviteCode || gameStatus !== 'started') {
             return;
         }
 
-        navigate(GAME_ROUTES.PLAY(inviteCode), { replace: true });
-    }, [gameStatus, inviteCode, navigate]);
+        navigateToGame(inviteCode);
+    }, [gameStatus, inviteCode, navigateToGame]);
 
     const {
         data: lobbyDetail,
         isLoading,
+        isFetching,
         isError,
         error,
     } = useLobbyDetail(inviteCode);
+
+    useEffect(() => {
+        if (
+            !inviteCode ||
+            !lobbyDetail ||
+            isFetching ||
+            initialStatusCheckedInviteCodeRef.current === inviteCode
+        ) {
+            return;
+        }
+
+        initialStatusCheckedInviteCodeRef.current = inviteCode;
+
+        if (lobbyDetail.status === 'PLAYING') {
+            navigateToGame(inviteCode);
+        }
+    }, [inviteCode, isFetching, lobbyDetail, navigateToGame]);
 
     const [actionMessage, setActionMessage] =
         useState<LobbyActionMessage | null>(null);


### PR DESCRIPTION
## 📣 Related Issue

- #133

## 📝 Summary

- 로비 WebSocket `GAME_STARTED` 이벤트 수신 시 `/game/{inviteCode}`로 이동
- 방장과 참가자 모두 서버 이벤트를 기준으로 동일하게 인게임 진입
- `useRef`를 사용해 중복 이벤트, 재렌더링, Strict Mode 환경의 중복 이동 방지
- 최초 상세 조회 상태가 `PLAYING`인 경우 새로고침 및 뒤로가기 복구 이동 지원
- 방장의 게임 시작 mutation 성공 시에는 기존 안내 및 상세 재조회 흐름 유지

## 🙏PR point

- 인게임 이동의 주 기준은 `/topic/lobby/{inviteCode}/game`의 `GAME_STARTED` 이벤트입니다.
- `startLobbyGame` mutation 성공만으로는 이동하지 않습니다.
- `PLAYING` 상태 기반 이동은 페이지 최초 상세 조회 시 이미 게임이 진행 중인 경우에만 동작합니다.
- 동일 inviteCode에 대한 navigate는 한 번만 실행됩니다.
- `npm run lint` 통과: 기존 `mockServiceWorker.js` 경고 1건
- `npm run build` 통과: 기존 번들 크기 경고 존재
- 이번 이슈는 UI 변경이 없어 Figma 기준 프레임을 사용하지 않았습니다.

## 📬 Reference

