### PR TITLE
[Feat/#135] 인게임 WebSocket 상태 및 채팅 연동

### DIFF
--- a/src/api/gameApi.ts
+++ b/src/api/gameApi.ts
@@ -1,0 +1,37 @@
+import { fetchWithAuth } from './apiClient';
+import { createApiError } from './apiError';
+import { API_ENDPOINTS } from '../constants/endpoints';
+import { currentGameRoundStatusSchema } from '../schemas/gameSchema';
+
+import type { CurrentGameRoundStatus } from '../types/game';
+
+const DEFAULT_FETCH_CURRENT_ROUND_ERROR_MESSAGE =
+    '현재 게임 라운드 정보를 불러오는 데 실패했습니다.';
+
+export async function getCurrentGameRoundStatus(
+    inviteCode: string,
+): Promise<CurrentGameRoundStatus> {
+    const response = await fetchWithAuth(
+        API_ENDPOINTS.GAME.CURRENT_ROUND(inviteCode),
+    );
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            DEFAULT_FETCH_CURRENT_ROUND_ERROR_MESSAGE,
+        );
+    }
+
+    const payload = await response.json() as unknown;
+    const parsed = currentGameRoundStatusSchema.safeParse(payload);
+
+    if (!parsed.success) {
+        console.warn(
+            '[gameApi] 현재 라운드 응답 검증 실패:',
+            parsed.error,
+        );
+        throw new Error('현재 게임 라운드 응답 형식이 올바르지 않습니다.');
+    }
+
+    return parsed.data;
+}

--- a/src/components/game/GameAnswerInput.tsx
+++ b/src/components/game/GameAnswerInput.tsx
@@ -3,11 +3,34 @@ import { Send } from 'lucide-react';
 
 import { GAME_COPY } from '../../constants/game';
 
-export function GameAnswerInput() {
+interface GameAnswerInputProps {
+    disabled: boolean;
+    onSubmit: (content: string) => boolean;
+}
+
+export function GameAnswerInput({
+    disabled,
+    onSubmit,
+}: GameAnswerInputProps) {
     const [answer, setAnswer] = useState('');
+    const trimmedAnswer = answer.trim();
+    const isSubmitDisabled = disabled || !trimmedAnswer;
+
+    const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        if (isSubmitDisabled || !onSubmit(trimmedAnswer)) {
+            return;
+        }
+
+        setAnswer('');
+    };
 
     return (
-        <section className="flex h-[52px] gap-[8px]">
+        <form
+            onSubmit={handleSubmit}
+            className="flex h-[52px] gap-[8px]"
+        >
             <label className="sr-only" htmlFor="game-answer-input">
                 {GAME_COPY.ANSWER_PLACEHOLDER}
             </label>
@@ -20,11 +43,11 @@ export function GameAnswerInput() {
                 className="h-[52px] min-w-0 flex-1 rounded-xl border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-[14px] text-sm text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[var(--monomat-primary)]"
             />
             <button
-                type="button"
-                disabled
+                type="submit"
+                disabled={isSubmitDisabled}
                 aria-label={GAME_COPY.ANSWER_ACTION_ARIA_LABEL}
                 title={GAME_COPY.ANSWER_ACTION_ARIA_LABEL}
-                className="flex h-[52px] w-[52px] shrink-0 cursor-not-allowed items-center justify-center rounded-xl bg-[var(--monomat-primary)] text-white"
+                className="flex h-[52px] w-[52px] shrink-0 items-center justify-center rounded-xl bg-[var(--monomat-primary)] text-white transition hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:opacity-50"
             >
                 <Send
                     size={25}
@@ -33,6 +56,6 @@ export function GameAnswerInput() {
                     aria-hidden="true"
                 />
             </button>
-        </section>
+        </form>
     );
 }

--- a/src/components/game/GameChatPanel.tsx
+++ b/src/components/game/GameChatPanel.tsx
@@ -1,19 +1,14 @@
-import { useState } from 'react';
-import { Send } from 'lucide-react';
-
 import { GAME_COPY } from '../../constants/game';
 
-import type { GameChatPreviewMessage } from '../../types/game';
+import type { GameChatDisplayMessage } from '../../types/game';
 
 interface GameChatPanelProps {
-    messages: readonly GameChatPreviewMessage[];
+    messages: readonly GameChatDisplayMessage[];
 }
 
 export function GameChatPanel({ messages }: GameChatPanelProps) {
-    const [message, setMessage] = useState('');
-
     return (
-        <section className="flex min-h-[420px] flex-col overflow-hidden rounded-2xl border border-[color:var(--monomat-border-default)] bg-white text-left shadow-[0_4px_8px_rgba(0,0,0,0.10)] min-[1280px]:h-[690px]">
+        <section className="flex min-h-[420px] flex-col overflow-hidden rounded-2xl border border-[color:var(--monomat-border-default)] bg-white text-left shadow-[0_4px_8px_rgba(0,0,0,0.10)] min-[1280px]:h-[602px]">
             <header className="flex h-[55px] shrink-0 items-center border-b border-[color:var(--monomat-border-default)] px-5">
                 <h2 className="!m-0 !text-base !font-semibold !leading-none !text-black">
                     {GAME_COPY.CHAT_TITLE}
@@ -21,57 +16,33 @@ export function GameChatPanel({ messages }: GameChatPanelProps) {
             </header>
 
             <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
-                <ul className="space-y-[18px]">
-                    {messages.map((chatMessage, index) => (
-                        <li
-                            key={`${chatMessage.nickname}-${chatMessage.time}-${index}`}
-                            className="min-w-0"
-                        >
-                            <div className="flex min-w-0 items-baseline gap-2">
-                                <span className="min-w-0 truncate text-base font-semibold leading-[19px] text-[var(--monomat-primary)]">
-                                    {chatMessage.nickname}
-                                </span>
-                                <time className="shrink-0 text-xs leading-[19px] text-[#73788A]">
-                                    {chatMessage.time}
-                                </time>
-                            </div>
-                            <p className="mt-[9px] whitespace-pre-wrap break-words text-[15px] leading-[26px] text-black [overflow-wrap:anywhere]">
-                                {chatMessage.content}
-                            </p>
-                        </li>
-                    ))}
-                </ul>
+                {messages.length === 0 ? (
+                    <p className="mt-8 text-center text-sm font-medium text-[var(--monomat-text-muted)]">
+                        {GAME_COPY.CHAT_EMPTY}
+                    </p>
+                ) : (
+                    <ul className="space-y-[18px]">
+                        {messages.map((chatMessage, index) => (
+                            <li
+                                key={`${chatMessage.nickname}-${chatMessage.time}-${index}`}
+                                className="min-w-0"
+                            >
+                                <div className="flex min-w-0 items-baseline gap-2">
+                                    <span className="min-w-0 truncate text-base font-semibold leading-[19px] text-[var(--monomat-primary)]">
+                                        {chatMessage.nickname}
+                                    </span>
+                                    <time className="shrink-0 text-xs leading-[19px] text-[#73788A]">
+                                        {chatMessage.time}
+                                    </time>
+                                </div>
+                                <p className="mt-[9px] whitespace-pre-wrap break-words text-[15px] leading-[26px] text-black [overflow-wrap:anywhere]">
+                                    {chatMessage.content}
+                                </p>
+                            </li>
+                        ))}
+                    </ul>
+                )}
             </div>
-
-            <footer className="h-[70px] shrink-0 border-t border-[color:var(--monomat-border-default)] px-3 py-2">
-                <div className="flex h-[52px] gap-[8px]">
-                    <label className="sr-only" htmlFor="game-chat-input">
-                        {GAME_COPY.CHAT_PLACEHOLDER}
-                    </label>
-                    <input
-                        id="game-chat-input"
-                        type="text"
-                        value={message}
-                        onChange={(event) => setMessage(event.target.value)}
-                        placeholder={GAME_COPY.CHAT_PLACEHOLDER}
-                        className="h-[52px] min-w-0 flex-1 rounded-xl border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-[14px] text-sm text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-border-input)] focus:border-[var(--monomat-primary)]"
-                    />
-                    <button
-                        type="button"
-                        disabled
-                        aria-label={GAME_COPY.CHAT_ACTION_ARIA_LABEL}
-                        title={GAME_COPY.CHAT_ACTION_ARIA_LABEL}
-                        className="flex h-[52px] w-[52px] shrink-0 cursor-not-allowed items-center justify-center rounded-xl bg-[var(--monomat-primary)] text-white"
-                    >
-                        <Send
-                            size={24}
-                            strokeWidth={2}
-                            className="-rotate-12"
-                            aria-hidden="true"
-                        />
-                    </button>
-                </div>
-            </footer>
         </section>
     );
 }

--- a/src/components/game/GamePlayerPanel.tsx
+++ b/src/components/game/GamePlayerPanel.tsx
@@ -3,13 +3,11 @@ import { Music2 } from 'lucide-react';
 import { GAME_COPY } from '../../constants/game';
 
 interface GamePlayerPanelProps {
-    currentRound: number;
-    totalRounds: number;
+    currentRound: number | null;
 }
 
 export function GamePlayerPanel({
     currentRound,
-    totalRounds,
 }: GamePlayerPanelProps) {
     return (
         <section className="flex h-[440px] flex-col items-center overflow-hidden rounded-2xl bg-white px-6 text-center shadow-[0_4px_16px_rgba(0,0,0,0.18)]">
@@ -26,14 +24,16 @@ export function GamePlayerPanel({
                 />
             </div>
 
-            <p className="mt-11 text-[15px] font-bold leading-[17px] text-[var(--monomat-text-muted)]">
+            <p className="mt-[58px] text-[15px] font-bold leading-[17px] text-[var(--monomat-text-muted)]">
                 {GAME_COPY.NOW_PLAYING}
             </p>
-            <h1 className="!m-0 mt-[13px] !text-xl !font-bold !leading-6 !text-[var(--monomat-text-strong)]">
+            <h1 className="!m-0 mt-5 !text-xl !font-bold !leading-6 !text-[var(--monomat-text-strong)]">
                 {GAME_COPY.PLAYER_GUIDE}
             </h1>
-            <p className="mt-3 text-sm leading-[17px] text-[var(--monomat-text-muted)] tabular-nums">
-                {currentRound}/{totalRounds}
+            <p className="mt-5 text-sm leading-[17px] text-[var(--monomat-text-muted)] tabular-nums">
+                {currentRound == null
+                    ? GAME_COPY.ROUND_WAITING
+                    : `${currentRound}번째 문제`}
             </p>
         </section>
     );

--- a/src/components/game/GameRankingCard.tsx
+++ b/src/components/game/GameRankingCard.tsx
@@ -13,46 +13,52 @@ export function GameRankingCard({ entries }: GameRankingCardProps) {
                 {GAME_COPY.RANKING_TITLE}
             </h2>
 
-            <ol className="mt-2 space-y-[7px]">
-                {entries.map((entry) => (
-                    <li
-                        key={`${entry.rank}-${entry.nickname}`}
-                        className={`grid h-[40px] grid-cols-[20px_minmax(0,1fr)_48px] items-center gap-[3px] rounded-xl px-[7px] ${
-                            entry.isCurrentUser
-                                ? 'bg-[#EBEDFF]'
-                                : 'bg-[#F1F2F5]'
-                        }`}
-                    >
-                        <span
-                            className={`text-center text-xs font-semibold ${
+            {entries.length === 0 ? (
+                <p className="mt-8 text-center text-sm font-medium text-[var(--monomat-text-muted)]">
+                    {GAME_COPY.RANKING_EMPTY}
+                </p>
+            ) : (
+                <ol className="mt-2 space-y-[7px]">
+                    {entries.map((entry) => (
+                        <li
+                            key={`${entry.rank}-${entry.nickname}`}
+                            className={`grid h-[40px] grid-cols-[20px_minmax(0,1fr)_48px] items-center gap-[3px] rounded-xl px-[7px] ${
                                 entry.isCurrentUser
-                                    ? 'text-[#FF9400]'
-                                    : 'text-[#7B808D]'
+                                    ? 'bg-[#EBEDFF]'
+                                    : 'bg-[#F1F2F5]'
                             }`}
                         >
-                            {entry.rank}
-                        </span>
-                        <span
-                            className={`truncate text-base font-semibold ${
-                                entry.isCurrentUser
-                                    ? 'text-[#5542BC]'
-                                    : 'text-[#303540]'
-                            }`}
-                        >
-                            {entry.nickname}
-                        </span>
-                        <span
-                            className={`text-right text-sm font-semibold tabular-nums ${
-                                entry.isCurrentUser
-                                    ? 'text-[#4D38B7]'
-                                    : 'text-black'
-                            }`}
-                        >
-                            {entry.score}
-                        </span>
-                    </li>
-                ))}
-            </ol>
+                            <span
+                                className={`text-center text-xs font-semibold ${
+                                    entry.isCurrentUser
+                                        ? 'text-[#FF9400]'
+                                        : 'text-[#7B808D]'
+                                }`}
+                            >
+                                {entry.rank}
+                            </span>
+                            <span
+                                className={`truncate text-base font-semibold ${
+                                    entry.isCurrentUser
+                                        ? 'text-[#5542BC]'
+                                        : 'text-[#303540]'
+                                }`}
+                            >
+                                {entry.nickname}
+                            </span>
+                            <span
+                                className={`text-right text-sm font-semibold tabular-nums ${
+                                    entry.isCurrentUser
+                                        ? 'text-[#4D38B7]'
+                                        : 'text-black'
+                                }`}
+                            >
+                                {entry.score}
+                            </span>
+                        </li>
+                    ))}
+                </ol>
+            )}
         </section>
     );
 }

--- a/src/components/game/GameRoundStatusBar.tsx
+++ b/src/components/game/GameRoundStatusBar.tsx
@@ -1,15 +1,18 @@
 import { GAME_COPY } from '../../constants/game';
 
 interface GameRoundStatusBarProps {
-    remainingSeconds: number;
-    progressPercent: number;
+    remainingSeconds: number | null;
+    progressPercent: number | null;
 }
 
 export function GameRoundStatusBar({
     remainingSeconds,
     progressPercent,
 }: GameRoundStatusBarProps) {
-    const normalizedProgress = Math.min(Math.max(progressPercent, 0), 100);
+    const normalizedProgress =
+        progressPercent == null
+            ? 0
+            : Math.min(Math.max(progressPercent, 0), 100);
 
     return (
         <section className="h-20 rounded-2xl bg-white px-[27px] pt-[19px] shadow-[0_4px_16px_rgba(0,0,0,0.18)]">
@@ -18,7 +21,9 @@ export function GameRoundStatusBar({
                     {GAME_COPY.REMAINING_TIME}
                 </span>
                 <span className="text-base font-bold leading-none text-[var(--monomat-primary)] tabular-nums">
-                    {remainingSeconds}s
+                    {remainingSeconds == null
+                        ? GAME_COPY.ROUND_WAITING
+                        : `${remainingSeconds}s`}
                 </span>
             </div>
 

--- a/src/constants/endpoints.ts
+++ b/src/constants/endpoints.ts
@@ -53,6 +53,11 @@ export const API_ENDPOINTS = {
             createApiEndpoint(`/api/lobbies/${code}/chats/recent`),
     },
 
+    GAME: {
+        CURRENT_ROUND: (code: string) =>
+            createApiEndpoint(`/api/game/${code}/round/current`),
+    },
+
     MAP: {
         LIST: createApiEndpoint('/api/maps'),
         CREATE: createApiEndpoint('/api/maps'),

--- a/src/constants/game.ts
+++ b/src/constants/game.ts
@@ -1,8 +1,3 @@
-import type {
-    GameChatPreviewMessage,
-    GameRankingEntry,
-} from '../types/game';
-
 export const GAME_ROUTES = {
     PLAY_PATTERN: '/game/:inviteCode',
     PLAY: (inviteCode: string) => `/game/${inviteCode}`,
@@ -16,50 +11,18 @@ export const GAME_COPY = {
         '초대 코드가 포함된 게임 주소로 다시 접속해주세요.',
     GO_TO_LOBBY_LIST: '로비 목록으로 이동',
     RANKING_TITLE: '🏆 실시간 순위',
+    RANKING_EMPTY: '랭킹 정보가 아직 없습니다.',
     REMAINING_TIME: '남은 시간',
+    ROUND_WAITING: '라운드 대기 중',
     NOW_PLAYING: '지금 재생 중',
     PLAYER_GUIDE: '제목을 맞춰보세요',
     PLAYER_PLACEHOLDER_ARIA_LABEL: '음악 플레이어 준비 영역',
-    ANSWER_PLACEHOLDER: '정답을 입력하세요',
-    ANSWER_ACTION_ARIA_LABEL: '정답 제출 기능은 준비 중입니다.',
+    ANSWER_PLACEHOLDER: '정답 또는 메시지를 입력하세요',
+    ANSWER_ACTION_ARIA_LABEL: '정답 또는 채팅 메시지 보내기',
     CHAT_TITLE: '게임 채팅',
-    CHAT_PLACEHOLDER: '메시지를 입력하세요',
-    CHAT_ACTION_ARIA_LABEL: '게임 채팅 전송 기능은 준비 중입니다.',
+    CHAT_EMPTY: '아직 채팅 메시지가 없습니다.',
 } as const;
 
-export const GAME_PREVIEW = {
-    remainingSeconds: 13,
-    timeProgressPercent: 50,
-    currentRound: 3,
-    totalRounds: 10,
+export const GAME_CHAT_POLICY = {
+    MAX_MESSAGE_LENGTH: 500,
 } as const;
-
-export const GAME_RANKING_PREVIEW: readonly GameRankingEntry[] = [
-    { rank: 1, nickname: '나', score: 320, isCurrentUser: true },
-    { rank: 2, nickname: '유키', score: 300 },
-    { rank: 3, nickname: '벨', score: 240 },
-    { rank: 4, nickname: 'Nut', score: 230 },
-    { rank: 5, nickname: '민지', score: 180 },
-    { rank: 6, nickname: '제이', score: 150 },
-    { rank: 7, nickname: '도현', score: 140 },
-    { rank: 8, nickname: '하루', score: 90 },
-] as const;
-
-export const GAME_CHAT_PREVIEW: readonly GameChatPreviewMessage[] = [
-    {
-        nickname: '노래왕',
-        time: '20:43',
-        content: '이번 노래는 알 것 같아요!',
-    },
-    {
-        nickname: '심야괴담회X서프라이즈',
-        time: '20:45',
-        content:
-            '게임 채팅 UI 확인용 메시지입니다. 내용이 길어지면 말줄임표 없이 다음 줄로 자연스럽게 표시됩니다.',
-    },
-    {
-        nickname: '유키',
-        time: '20:46',
-        content: '다음 문제도 파이팅!',
-    },
-] as const;

--- a/src/constants/socketEvents.ts
+++ b/src/constants/socketEvents.ts
@@ -17,6 +17,9 @@ export const SOCKET_PUBLISH = {
     // code는 로비의 6자리 초대 코드이다.
     // 예 : SOCKET_PUBLISH.CHAT_LOBBY('ABC123') → '/app/chat/lobby/ABC123'
     CHAT_LOBBY: (code: string) => `/app/chat/lobby/${code}`,
+
+    // 인게임 중앙 입력에서 정답 또는 일반 채팅을 보낼 때 사용한다.
+    GAME_CHAT: (code: string) => `/app/game/${code}/chat`,
 } as const;
 
 // 구독 경로 (서버 → 클라이언트)
@@ -36,6 +39,18 @@ export const SOCKET_SUBSCRIBE = {
 
     // 특정 로비의 게임 시작 이벤트를 수신한다.
     LOBBY_GAME: (code: string) => `/topic/lobby/${code}/game`,
+
+    // 특정 게임의 라운드 준비/재생/스킵 이벤트를 수신한다.
+    GAME_ROUND: (code: string) => `/topic/game/${code}/round`,
+
+    // 특정 게임의 라운드 종료 메타데이터와 랭킹을 수신한다.
+    GAME_ROUND_END: (code: string) => `/topic/game/${code}/round-end`,
+
+    // 특정 게임의 일반/시스템 채팅 메시지를 수신한다.
+    GAME_CHAT: (code: string) => `/topic/game/${code}/chat`,
+
+    // 현재 사용자의 인게임 정답 알림을 수신한다.
+    GAME_ANSWERS: '/user/queue/game/answers',
 } as const;
 
 export const SOCKET_MESSAGES = {

--- a/src/hooks/useGameSocket.ts
+++ b/src/hooks/useGameSocket.ts
@@ -1,0 +1,403 @@
+import { useCallback, useEffect } from 'react';
+
+import { getCurrentGameRoundStatus } from '../api/gameApi';
+import { GAME_CHAT_POLICY } from '../constants/game';
+import {
+    SOCKET_PUBLISH,
+    SOCKET_SUBSCRIBE,
+} from '../constants/socketEvents';
+import {
+    gameChatMessageSchema,
+    gameRoundCorrectEventSchema,
+    gameRoundEndEventSchema,
+    gameRoundEventSchema,
+} from '../schemas/gameSchema';
+import { useGameStore } from '../store/useGameStore';
+import { useSocketStore } from '../store/useSocketStore';
+
+import type { Client, IMessage, StompSubscription } from '@stomp/stompjs';
+import type { ZodType } from 'zod';
+
+type MessageListener = (message: IMessage) => void;
+
+interface SharedSubscription {
+    subscription: StompSubscription;
+    listeners: Set<MessageListener>;
+}
+
+const MAX_TRACKED_MESSAGE_IDS = 500;
+
+const subscriptionsByClient = new WeakMap<
+    Client,
+    Map<string, SharedSubscription>
+>();
+
+function addSharedSubscription(
+    client: Client,
+    destination: string,
+    listener: MessageListener,
+) {
+    let clientSubscriptions = subscriptionsByClient.get(client);
+
+    if (!clientSubscriptions) {
+        clientSubscriptions = new Map();
+        subscriptionsByClient.set(client, clientSubscriptions);
+    }
+
+    let sharedSubscription = clientSubscriptions.get(destination);
+
+    if (!sharedSubscription) {
+        const listeners = new Set<MessageListener>();
+        const subscription = client.subscribe(destination, (message) => {
+            for (const activeListener of listeners) {
+                activeListener(message);
+            }
+        });
+
+        sharedSubscription = {
+            subscription,
+            listeners,
+        };
+        clientSubscriptions.set(destination, sharedSubscription);
+    }
+
+    sharedSubscription.listeners.add(listener);
+
+    return () => {
+        sharedSubscription.listeners.delete(listener);
+
+        if (sharedSubscription.listeners.size > 0) {
+            return;
+        }
+
+        sharedSubscription.subscription.unsubscribe();
+        clientSubscriptions.delete(destination);
+
+        if (clientSubscriptions.size === 0) {
+            subscriptionsByClient.delete(client);
+        }
+    };
+}
+
+function getMessageId(message: IMessage) {
+    const messageId = message.headers['message-id'];
+
+    return typeof messageId === 'string' && messageId
+        ? messageId
+        : null;
+}
+
+function parseMessage<T>(
+    message: IMessage,
+    schema: ZodType<T>,
+    destination: string,
+): T | null {
+    let payload: unknown;
+
+    try {
+        payload = JSON.parse(message.body) as unknown;
+    } catch (error) {
+        const errorMessage = `${destination} 메시지의 JSON 파싱에 실패했습니다.`;
+
+        useGameStore.getState().setError(errorMessage);
+        console.warn(`[useGameSocket] ${errorMessage}`, error);
+        return null;
+    }
+
+    const result = schema.safeParse(payload);
+
+    if (!result.success) {
+        const errorMessage = `${destination} 메시지 검증에 실패했습니다.`;
+
+        useGameStore.getState().setError(errorMessage);
+        console.warn(`[useGameSocket] ${errorMessage}`, result.error);
+        return null;
+    }
+
+    return result.data;
+}
+
+export function useGameSocket(inviteCode: string | undefined) {
+    const normalizedInviteCode = inviteCode?.trim() ?? '';
+    const stompClient = useSocketStore((state) => state.stompClient);
+    const connectionStatus = useSocketStore((state) => state.connectionStatus);
+    const subscriptionStatus = useGameStore(
+        (state) => state.subscriptionStatus,
+    );
+    const currentRoundNo = useGameStore((state) => state.currentRoundNo);
+
+    useEffect(() => {
+        const gameStore = useGameStore.getState();
+
+        if (!normalizedInviteCode) {
+            gameStore.reset();
+            return;
+        }
+
+        gameStore.initializeGame(normalizedInviteCode);
+
+        return () => {
+            const currentStore = useGameStore.getState();
+
+            if (currentStore.inviteCode === normalizedInviteCode) {
+                currentStore.reset();
+            }
+        };
+    }, [normalizedInviteCode]);
+
+    useEffect(() => {
+        if (!normalizedInviteCode) {
+            return;
+        }
+
+        let isCancelled = false;
+
+        void getCurrentGameRoundStatus(normalizedInviteCode)
+            .then((status) => {
+                if (
+                    isCancelled ||
+                    useGameStore.getState().inviteCode !==
+                        normalizedInviteCode
+                ) {
+                    return;
+                }
+
+                useGameStore.getState().applyCurrentRoundStatus(status);
+            })
+            .catch((error: unknown) => {
+                if (isCancelled) {
+                    return;
+                }
+
+                const errorMessage =
+                    '현재 라운드 정보를 불러오지 못했습니다.';
+
+                useGameStore.getState().setError(errorMessage);
+                console.warn(`[useGameSocket] ${errorMessage}`, error);
+            });
+
+        return () => {
+            isCancelled = true;
+        };
+    }, [normalizedInviteCode]);
+
+    useEffect(() => {
+        if (!normalizedInviteCode) {
+            return;
+        }
+
+        const gameStore = useGameStore.getState();
+
+        if (!stompClient || connectionStatus !== 'connected') {
+            gameStore.setSubscriptionStatus('idle');
+            return;
+        }
+
+        let isActive = true;
+        const seenMessageIds = new Set<string>();
+        const trackedMessageIds: string[] = [];
+        const unsubscribeCallbacks: Array<() => void> = [];
+
+        const handleMessage = (
+            destination: string,
+            message: IMessage,
+            applyMessage: (receivedMessage: IMessage) => void,
+        ) => {
+            if (!isActive) {
+                return;
+            }
+
+            const messageId = getMessageId(message);
+
+            if (messageId && seenMessageIds.has(messageId)) {
+                return;
+            }
+
+            if (messageId) {
+                seenMessageIds.add(messageId);
+                trackedMessageIds.push(messageId);
+
+                if (trackedMessageIds.length > MAX_TRACKED_MESSAGE_IDS) {
+                    const oldestMessageId = trackedMessageIds.shift();
+
+                    if (oldestMessageId) {
+                        seenMessageIds.delete(oldestMessageId);
+                    }
+                }
+            }
+
+            try {
+                applyMessage(message);
+            } catch (error) {
+                const errorMessage = `${destination} 구독 메시지 처리에 실패했습니다.`;
+
+                useGameStore.getState().setError(errorMessage);
+                console.warn(`[useGameSocket] ${errorMessage}`, error);
+            }
+        };
+
+        const subscribe = (
+            destination: string,
+            applyMessage: (message: IMessage) => void,
+        ) => {
+            const unsubscribe = addSharedSubscription(
+                stompClient,
+                destination,
+                (message) => {
+                    handleMessage(destination, message, applyMessage);
+                },
+            );
+
+            unsubscribeCallbacks.push(unsubscribe);
+        };
+
+        const unsubscribeAll = () => {
+            for (const unsubscribe of unsubscribeCallbacks.splice(0)) {
+                unsubscribe();
+            }
+        };
+
+        gameStore.setSubscriptionStatus('subscribing');
+        gameStore.setError(null);
+
+        try {
+            const roundDestination =
+                SOCKET_SUBSCRIBE.GAME_ROUND(normalizedInviteCode);
+            const roundEndDestination =
+                SOCKET_SUBSCRIBE.GAME_ROUND_END(normalizedInviteCode);
+            const chatDestination =
+                SOCKET_SUBSCRIBE.GAME_CHAT(normalizedInviteCode);
+            const answersDestination = SOCKET_SUBSCRIBE.GAME_ANSWERS;
+
+            subscribe(roundDestination, (message) => {
+                const event = parseMessage(
+                    message,
+                    gameRoundEventSchema,
+                    roundDestination,
+                );
+
+                if (event) {
+                    useGameStore.getState().applyRoundEvent(event);
+                }
+            });
+
+            subscribe(roundEndDestination, (message) => {
+                const event = parseMessage(
+                    message,
+                    gameRoundEndEventSchema,
+                    roundEndDestination,
+                );
+
+                if (event) {
+                    useGameStore.getState().applyRoundEnd(event);
+                }
+            });
+
+            subscribe(chatDestination, (message) => {
+                const chatMessage = parseMessage(
+                    message,
+                    gameChatMessageSchema,
+                    chatDestination,
+                );
+
+                if (
+                    chatMessage &&
+                    chatMessage.roomId === normalizedInviteCode
+                ) {
+                    useGameStore.getState().appendChatMessage(chatMessage);
+                }
+            });
+
+            subscribe(answersDestination, (message) => {
+                const event = parseMessage(
+                    message,
+                    gameRoundCorrectEventSchema,
+                    answersDestination,
+                );
+
+                if (event) {
+                    useGameStore.getState().applyCorrectAnswer(event);
+                }
+            });
+
+            useGameStore.getState().setSubscriptionStatus('subscribed');
+        } catch (error) {
+            const errorMessage = '인게임 WebSocket 구독에 실패했습니다.';
+
+            unsubscribeAll();
+            useGameStore.getState().setSubscriptionStatus('error');
+            useGameStore.getState().setError(errorMessage);
+            console.warn(`[useGameSocket] ${errorMessage}`, error);
+        }
+
+        return () => {
+            isActive = false;
+            unsubscribeAll();
+        };
+    }, [connectionStatus, normalizedInviteCode, stompClient]);
+
+    const sendMessage = useCallback(
+        (content: string) => {
+            const trimmedContent = content.trim();
+
+            if (
+                !normalizedInviteCode ||
+                !stompClient ||
+                connectionStatus !== 'connected' ||
+                subscriptionStatus !== 'subscribed' ||
+                currentRoundNo == null
+            ) {
+                useGameStore.getState().setError(
+                    '게임 채팅을 보낼 수 없는 연결 상태입니다.',
+                );
+                return false;
+            }
+
+            if (
+                !trimmedContent ||
+                trimmedContent.length > GAME_CHAT_POLICY.MAX_MESSAGE_LENGTH
+            ) {
+                useGameStore.getState().setError(
+                    `게임 채팅은 1자 이상 ${GAME_CHAT_POLICY.MAX_MESSAGE_LENGTH}자 이하로 입력해주세요.`,
+                );
+                return false;
+            }
+
+            try {
+                stompClient.publish({
+                    destination:
+                        SOCKET_PUBLISH.GAME_CHAT(normalizedInviteCode),
+                    body: JSON.stringify({
+                        roundNo: currentRoundNo,
+                        content: trimmedContent,
+                    }),
+                });
+                useGameStore.getState().setError(null);
+                return true;
+            } catch (error) {
+                const errorMessage = '게임 채팅 전송에 실패했습니다.';
+
+                useGameStore.getState().setError(errorMessage);
+                console.warn(`[useGameSocket] ${errorMessage}`, error);
+                return false;
+            }
+        },
+        [
+            connectionStatus,
+            currentRoundNo,
+            normalizedInviteCode,
+            stompClient,
+            subscriptionStatus,
+        ],
+    );
+
+    return {
+        connectionStatus,
+        subscriptionStatus,
+        canSendMessage:
+            connectionStatus === 'connected' &&
+            subscriptionStatus === 'subscribed' &&
+            currentRoundNo != null,
+        sendMessage,
+    };
+}

--- a/src/pages/InGamePage.tsx
+++ b/src/pages/InGamePage.tsx
@@ -8,17 +8,34 @@ import { GameRankingCard } from '../components/game/GameRankingCard';
 import { GameRoundStatusBar } from '../components/game/GameRoundStatusBar';
 import { InGameLayout } from '../components/game/InGameLayout';
 import { LobbyFooter } from '../components/lobby/LobbyFooter';
-import {
-    GAME_CHAT_PREVIEW,
-    GAME_COPY,
-    GAME_PREVIEW,
-    GAME_RANKING_PREVIEW,
-} from '../constants/game';
+import { GAME_COPY } from '../constants/game';
 import { LOBBY_ROUTES } from '../constants/lobby';
+import { useGameSocket } from '../hooks/useGameSocket';
+import { useAuthStore } from '../store/useAuthStore';
+import { useGameStore } from '../store/useGameStore';
 import {
     normalizeInviteCode,
     validateInviteCode,
 } from '../utils/inviteCode';
+
+import type {
+    GameChatDisplayMessage,
+    GameRankingEntry,
+} from '../types/game';
+
+function formatGameChatTime(timestamp: string) {
+    const date = new Date(timestamp);
+
+    if (Number.isNaN(date.getTime())) {
+        return timestamp;
+    }
+
+    return date.toLocaleTimeString('ko-KR', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+    });
+}
 
 function InGameStateCard({ onBack }: { onBack: () => void }) {
     return (
@@ -49,6 +66,35 @@ export function InGamePage() {
     const navigate = useNavigate();
     const inviteCode = normalizeInviteCode(inviteCodeParam ?? '');
     const inviteCodeError = validateInviteCode(inviteCode);
+    const validInviteCode = inviteCodeError ? undefined : inviteCode;
+    const userIdentifier = useAuthStore((state) => state.userIdentifier);
+    const gameInviteCode = useGameStore((state) => state.inviteCode);
+    const rankings = useGameStore((state) => state.rankings);
+    const chatMessages = useGameStore((state) => state.chatMessages);
+    const currentRoundNo = useGameStore((state) => state.currentRoundNo);
+
+    const { canSendMessage, sendMessage } =
+        useGameSocket(validInviteCode);
+
+    const hasCurrentGameState = gameInviteCode === validInviteCode;
+    const rankingEntries: readonly GameRankingEntry[] =
+        hasCurrentGameState && rankings
+            ? rankings.map((ranking) => ({
+                rank: ranking.rank,
+                nickname: ranking.nickname,
+                score: ranking.score,
+                isCurrentUser:
+                    ranking.userIdentifier === userIdentifier,
+            }))
+            : [];
+    const displayedChatMessages: readonly GameChatDisplayMessage[] =
+        hasCurrentGameState
+            ? chatMessages.map((message) => ({
+                nickname: message.sender,
+                time: formatGameChatTime(message.timestamp),
+                content: message.content,
+            }))
+            : [];
 
     const handleLeave = () => {
         navigate(LOBBY_ROUTES.LIST);
@@ -65,28 +111,35 @@ export function InGamePage() {
                     <InGameLayout
                         ranking={
                             <GameRankingCard
-                                entries={GAME_RANKING_PREVIEW}
+                                entries={rankingEntries}
                             />
                         }
                         roundStatus={
                             <GameRoundStatusBar
-                                remainingSeconds={
-                                    GAME_PREVIEW.remainingSeconds
-                                }
-                                progressPercent={
-                                    GAME_PREVIEW.timeProgressPercent
-                                }
+                                remainingSeconds={null}
+                                progressPercent={null}
                             />
                         }
                         player={
                             <GamePlayerPanel
-                                currentRound={GAME_PREVIEW.currentRound}
-                                totalRounds={GAME_PREVIEW.totalRounds}
+                                currentRound={
+                                    hasCurrentGameState &&
+                                    currentRoundNo != null
+                                        ? currentRoundNo
+                                        : null
+                                }
                             />
                         }
-                        answerInput={<GameAnswerInput />}
+                        answerInput={
+                            <GameAnswerInput
+                                disabled={!canSendMessage}
+                                onSubmit={sendMessage}
+                            />
+                        }
                         chat={
-                            <GameChatPanel messages={GAME_CHAT_PREVIEW} />
+                            <GameChatPanel
+                                messages={displayedChatMessages}
+                            />
                         }
                     />
                 </main>

--- a/src/schemas/gameSchema.ts
+++ b/src/schemas/gameSchema.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod';
+
+export const gameRoundEndReasonSchema = z.enum([
+    'TIMEOUT',
+    'SKIP_VOTE',
+    'HOST_SKIP',
+    'PLAYBACK_ERROR',
+]);
+
+export const gamePlayerRankingSchema = z.object({
+    userIdentifier: z.string().min(1),
+    nickname: z.string().min(1),
+    score: z.number().int(),
+    rank: z.number().int().positive(),
+    scoreAdded: z.number().int(),
+});
+
+const gameRoundReadyEventSchema = z.object({
+    type: z.literal('ROUND_READY'),
+    videoId: z.string().min(1),
+    youtubeUrl: z.string().min(1),
+    startTime: z.number().int().nonnegative(),
+    timeLimitSeconds: z.number().int().positive(),
+    roundNo: z.number().int().positive(),
+    serverStartedAt: z.number().int().nonnegative(),
+});
+
+const gameRoundPlaybackStartedEventSchema = z.object({
+    type: z.literal('ROUND_PLAYBACK_STARTED'),
+    roundNo: z.number().int().positive(),
+    serverStartedAt: z.number().int().nonnegative(),
+    durationSeconds: z.number().int().positive(),
+});
+
+const gameRoundSkipVoteEventSchema = z.object({
+    type: z.literal('ROUND_SKIP_VOTE'),
+    roundNo: z.number().int().positive(),
+    votes: z.number().int().nonnegative(),
+    requiredVotes: z.number().int().nonnegative(),
+    totalParticipants: z.number().int().nonnegative(),
+});
+
+const gameRoundSkippedEventSchema = z.object({
+    type: z.literal('ROUND_SKIPPED'),
+    roundNo: z.number().int().positive(),
+    endReason: gameRoundEndReasonSchema,
+});
+
+export const gameRoundEventSchema = z.discriminatedUnion('type', [
+    gameRoundReadyEventSchema,
+    gameRoundPlaybackStartedEventSchema,
+    gameRoundSkipVoteEventSchema,
+    gameRoundSkippedEventSchema,
+]);
+
+export const gameRoundEndEventSchema = z.object({
+    type: z.literal('ROUND_END'),
+    title: z.string(),
+    artist: z.string(),
+    answer: z.string(),
+    thumbnailUrl: z.string(),
+    rankings: z.array(gamePlayerRankingSchema),
+    waitTimeSeconds: z.number().int().nonnegative(),
+    isLastRound: z.boolean(),
+    endReason: gameRoundEndReasonSchema,
+});
+
+export const gameChatMessageSchema = z.object({
+    type: z.enum(['CHAT', 'SYSTEM']),
+    roomId: z.string().min(1),
+    sender: z.string().min(1),
+    content: z.string(),
+    timestamp: z.string().min(1),
+});
+
+export const gameRoundCorrectEventSchema = z.object({
+    type: z.literal('ROUND_CORRECT'),
+    roundNo: z.number().int().positive(),
+    isFuzzy: z.boolean(),
+    message: z.string(),
+});
+
+export const currentGameRoundStatusSchema = z.object({
+    roundNo: z.number().int().positive(),
+    status: z.string().min(1),
+    roundPhase: z.string().min(1),
+    timeLimitSeconds: z.number().int().positive(),
+    serverStartedAt: z.number().int().nonnegative().nullable(),
+    videoId: z.string().min(1).nullable(),
+    youtubeUrl: z.string().min(1).nullable(),
+    startTime: z.number().int().nonnegative().nullable(),
+    remainingSeconds: z.number().int().nonnegative().nullable(),
+    isCorrect: z.boolean(),
+});

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -1,0 +1,164 @@
+import { create } from 'zustand';
+
+import type {
+    CurrentGameRoundStatus,
+    GameChatMessage,
+    GamePlayerRanking,
+    GameRoundCorrectEvent,
+    GameRoundEndEvent,
+    GameRoundEvent,
+    GameRoundPlaybackStartedEvent,
+    GameRoundReadyEvent,
+    GameRoundSkippedEvent,
+    GameRoundSkipVoteEvent,
+    GameSubscriptionStatus,
+} from '../types/game';
+
+interface GameState {
+    inviteCode: string | null;
+    subscriptionStatus: GameSubscriptionStatus;
+    lastReceivedAt: number | null;
+    errorMessage: string | null;
+    currentRoundNo: number | null;
+    roundReady: GameRoundReadyEvent | null;
+    playbackStarted: GameRoundPlaybackStartedEvent | null;
+    skipVote: GameRoundSkipVoteEvent | null;
+    roundSkipped: GameRoundSkippedEvent | null;
+    roundEnd: GameRoundEndEvent | null;
+    rankings: GamePlayerRanking[] | null;
+    chatMessages: GameChatMessage[];
+    correctAnswer: GameRoundCorrectEvent | null;
+    currentRoundStatus: CurrentGameRoundStatus | null;
+    initializeGame: (inviteCode: string) => void;
+    setSubscriptionStatus: (status: GameSubscriptionStatus) => void;
+    setError: (message: string | null) => void;
+    applyRoundEvent: (event: GameRoundEvent) => void;
+    applyRoundEnd: (event: GameRoundEndEvent) => void;
+    appendChatMessage: (message: GameChatMessage) => void;
+    applyCorrectAnswer: (event: GameRoundCorrectEvent) => void;
+    applyCurrentRoundStatus: (status: CurrentGameRoundStatus) => void;
+    reset: () => void;
+}
+
+function createEmptyGameState() {
+    return {
+        inviteCode: null,
+        subscriptionStatus: 'idle' as const,
+        lastReceivedAt: null,
+        errorMessage: null,
+        currentRoundNo: null,
+        roundReady: null,
+        playbackStarted: null,
+        skipVote: null,
+        roundSkipped: null,
+        roundEnd: null,
+        rankings: null,
+        chatMessages: [],
+        correctAnswer: null,
+        currentRoundStatus: null,
+    };
+}
+
+function createReceivedState() {
+    return {
+        lastReceivedAt: Date.now(),
+        errorMessage: null,
+    };
+}
+
+export const useGameStore = create<GameState>((set, get) => ({
+    ...createEmptyGameState(),
+
+    initializeGame: (inviteCode) => {
+        if (get().inviteCode === inviteCode) {
+            return;
+        }
+
+        set({
+            ...createEmptyGameState(),
+            inviteCode,
+        });
+    },
+
+    setSubscriptionStatus: (subscriptionStatus) => {
+        set({ subscriptionStatus });
+    },
+
+    setError: (errorMessage) => {
+        set({ errorMessage });
+    },
+
+    applyRoundEvent: (event) => {
+        const receivedState = createReceivedState();
+
+        switch (event.type) {
+            case 'ROUND_READY':
+                set({
+                    ...receivedState,
+                    currentRoundNo: event.roundNo,
+                    roundReady: event,
+                    playbackStarted: null,
+                    skipVote: null,
+                    roundSkipped: null,
+                    roundEnd: null,
+                    correctAnswer: null,
+                });
+                break;
+            case 'ROUND_PLAYBACK_STARTED':
+                set({
+                    ...receivedState,
+                    currentRoundNo: event.roundNo,
+                    playbackStarted: event,
+                });
+                break;
+            case 'ROUND_SKIP_VOTE':
+                set({
+                    ...receivedState,
+                    currentRoundNo: event.roundNo,
+                    skipVote: event,
+                });
+                break;
+            case 'ROUND_SKIPPED':
+                set({
+                    ...receivedState,
+                    currentRoundNo: event.roundNo,
+                    roundSkipped: event,
+                });
+                break;
+        }
+    },
+
+    applyRoundEnd: (event) => {
+        set({
+            ...createReceivedState(),
+            roundEnd: event,
+            rankings: event.rankings,
+        });
+    },
+
+    appendChatMessage: (message) => {
+        set((state) => ({
+            ...createReceivedState(),
+            chatMessages: [...state.chatMessages, message],
+        }));
+    },
+
+    applyCorrectAnswer: (event) => {
+        set({
+            ...createReceivedState(),
+            currentRoundNo: event.roundNo,
+            correctAnswer: event,
+        });
+    },
+
+    applyCurrentRoundStatus: (status) => {
+        set({
+            currentRoundNo: status.roundNo,
+            currentRoundStatus: status,
+        });
+    },
+
+    reset: () => {
+        set(createEmptyGameState());
+    },
+}));

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -5,8 +5,107 @@ export interface GameRankingEntry {
     isCurrentUser?: boolean;
 }
 
-export interface GameChatPreviewMessage {
+export interface GameChatDisplayMessage {
     nickname: string;
     time: string;
     content: string;
 }
+
+export type GameRoundEndReason =
+    | 'TIMEOUT'
+    | 'SKIP_VOTE'
+    | 'HOST_SKIP'
+    | 'PLAYBACK_ERROR';
+
+export interface GamePlayerRanking {
+    userIdentifier: string;
+    nickname: string;
+    score: number;
+    rank: number;
+    scoreAdded: number;
+}
+
+export interface GameRoundReadyEvent {
+    type: 'ROUND_READY';
+    videoId: string;
+    youtubeUrl: string;
+    startTime: number;
+    timeLimitSeconds: number;
+    roundNo: number;
+    serverStartedAt: number;
+}
+
+export interface GameRoundPlaybackStartedEvent {
+    type: 'ROUND_PLAYBACK_STARTED';
+    roundNo: number;
+    serverStartedAt: number;
+    durationSeconds: number;
+}
+
+export interface GameRoundSkipVoteEvent {
+    type: 'ROUND_SKIP_VOTE';
+    roundNo: number;
+    votes: number;
+    requiredVotes: number;
+    totalParticipants: number;
+}
+
+export interface GameRoundSkippedEvent {
+    type: 'ROUND_SKIPPED';
+    roundNo: number;
+    endReason: GameRoundEndReason;
+}
+
+export type GameRoundEvent =
+    | GameRoundReadyEvent
+    | GameRoundPlaybackStartedEvent
+    | GameRoundSkipVoteEvent
+    | GameRoundSkippedEvent;
+
+export interface GameRoundEndEvent {
+    type: 'ROUND_END';
+    title: string;
+    artist: string;
+    answer: string;
+    thumbnailUrl: string;
+    rankings: GamePlayerRanking[];
+    waitTimeSeconds: number;
+    isLastRound: boolean;
+    endReason: GameRoundEndReason;
+}
+
+export type GameChatMessageType = 'CHAT' | 'SYSTEM';
+
+export interface GameChatMessage {
+    type: GameChatMessageType;
+    roomId: string;
+    sender: string;
+    content: string;
+    timestamp: string;
+}
+
+export interface GameRoundCorrectEvent {
+    type: 'ROUND_CORRECT';
+    roundNo: number;
+    isFuzzy: boolean;
+    message: string;
+}
+
+export interface CurrentGameRoundStatus {
+    roundNo: number;
+    status: string;
+    roundPhase: string;
+    timeLimitSeconds: number;
+    serverStartedAt: number | null;
+    videoId: string | null;
+    youtubeUrl: string | null;
+    startTime: number | null;
+    remainingSeconds: number | null;
+    isCorrect: boolean;
+}
+
+export type GameSubscriptionStatus =
+    | 'idle'
+    | 'subscribing'
+    | 'subscribed'
+    | 'error';


### PR DESCRIPTION
## 📣 Related Issue

- #135

## 📝 Summary

- 기존 전역 STOMP client를 재사용하는 인게임 WebSocket 구독 훅을 추가했습니다.
- 라운드, 랭킹, 게임 채팅, 개인 정답 알림 payload를 Zod로 검증합니다.
- Zustand 기반 인게임 상태 모델을 추가했습니다.
- inviteCode 변경 및 페이지 이탈 시 기존 게임 상태와 구독을 정리합니다.
- `message-id` 기반 중복 메시지 반영 방지와 Strict Mode 중복 구독 방어를 적용했습니다.
- 현재 라운드 조회 API를 연동해 직접 진입하거나 이벤트를 놓친 경우 상태를 복구합니다.
- 중앙 입력창에서 정답 또는 게임 채팅을 전송하도록 연결했습니다.
- 우측 채팅 패널의 별도 입력창을 제거하고 수신 메시지 표시 전용으로 변경했습니다.
- 기존 인게임 Mock 데이터를 제거하고 데이터 미수신 상태 UI를 적용했습니다.
- 채팅 패널 높이와 플레이어 안내 문구 간격을 조정했습니다.

## 🙏PR point

- 구독 경로
  - `/topic/game/{code}/round`
  - `/topic/game/{code}/round-end`
  - `/topic/game/{code}/chat`
  - `/user/queue/game/answers`
- 중앙 입력은 `/app/game/{code}/chat`으로 `{ roundNo, content }`를 전송합니다.
- 입력 내용은 BE에서 정답 여부를 판별하며, 오답은 일반 게임 채팅으로 브로드캐스트됩니다.
- `serverStartedAt`은 원시 상태로만 저장하며 countdown 및 서버 시간 보정은 구현하지 않았습니다.
- YouTube IFrame 제어, ready handshake, 결과 페이지는 이번 PR 범위에 포함하지 않았습니다.
- `npm run lint` 통과
  - 기존 `public/mockServiceWorker.js` 경고 1건 존재
- `npm run build` 통과
  - 기존 번들 크기 경고 존재

## 📬 Reference

- Monomat-BE develop의 게임 WebSocket 및 REST 계약
- `GameEventController`
- `GameRealtimeNotifier`
- `GameAnswerService`
- `GameSessionController`
- `StompDestinations`