### PR TITLE
[Fix/#131] 로비 퇴장 시 leave 메시지 발행

### DIFF
--- a/src/constants/socketEvents.ts
+++ b/src/constants/socketEvents.ts
@@ -21,6 +21,10 @@ export const SOCKET_PUBLISH = {
     // 인게임 중앙 입력에서 정답 또는 일반 채팅을 보낼 때 사용한다.
     // BE 경로명은 chat이지만 FE에서는 통합 입력 역할을 명시한다.
     GAME_INPUT: (code: string) => `/app/game/${code}/chat`,
+
+    // 로비에서 명시적으로 퇴장할 때 사용한다. (BE: payload 없음)
+    // 이 메시지를 보내지 않으면 BE는 연결이 끊길 때까지 참여자를 유지한다.
+    LOBBY_LEAVE: (code: string) => `/app/lobby/${code}/leave`,
 } as const;
 
 // 구독 경로 (서버 → 클라이언트)

--- a/src/hooks/useLobbySocket.ts
+++ b/src/hooks/useLobbySocket.ts
@@ -1,7 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
-import { SOCKET_MESSAGES, SOCKET_SUBSCRIBE } from '../constants/socketEvents';
+import {
+    SOCKET_MESSAGES,
+    SOCKET_PUBLISH,
+    SOCKET_SUBSCRIBE,
+} from '../constants/socketEvents';
 import { useSocketStore } from '../store/useSocketStore';
 import { lobbyDetailQueryKey } from './useLobbyDetail';
 
@@ -101,11 +105,34 @@ export function useLobbySocket(
         onLobbyMessageBody,
     ]);
 
+    // 로비에서 나갈 때 BE에 명시적 퇴장을 알린다.
+    // 구독 해제만으로는 BE가 연결 종료(새로고침/종료) 전까지 참여자를 유지하므로,
+    // 다른 참여자 화면에서 즉시 빠지려면 leave 메시지를 보내야 한다.
+    const leaveLobby = useCallback(() => {
+        if (
+            !stompClient ||
+            connectionStatus !== 'connected' ||
+            !normalizedInviteCode
+        ) {
+            return;
+        }
+
+        try {
+            stompClient.publish({
+                destination: SOCKET_PUBLISH.LOBBY_LEAVE(normalizedInviteCode),
+            });
+        } catch (error) {
+            // 발행 실패가 화면 이동을 막지 않도록 경고만 남긴다.
+            console.warn('[useLobbySocket] 로비 퇴장 메시지 전송 실패:', error);
+        }
+    }, [connectionStatus, normalizedInviteCode, stompClient]);
+
     const gameStatus: LobbyGameStatus =
         gameStartedInviteCode === normalizedInviteCode ? 'started' : 'idle';
 
     return {
         connectionStatus,
         gameStatus,
+        leaveLobby,
     };
 }

--- a/src/pages/LobbyRoom.tsx
+++ b/src/pages/LobbyRoom.tsx
@@ -161,7 +161,7 @@ export function LobbyRoom() {
     const userId = useAuthStore((state) => state.userId);
     const userIdentifier = useAuthStore((state) => state.userIdentifier);
     const lobbyChat = useLobbyChat(inviteCode);
-    const { gameStatus } = useLobbySocket(
+    const { gameStatus, leaveLobby } = useLobbySocket(
         inviteCode,
         lobbyChat.handleLobbyMessageBody,
     );
@@ -275,6 +275,9 @@ export function LobbyRoom() {
     }, [lobbyDetail]);
 
     const handleNavigateLobbyList = () => {
+        // navigate 전에 leave를 보내 다른 참여자 화면에서 즉시 빠지도록 한다.
+        // (언마운트 시 구독 해제보다 먼저, 연결이 살아 있을 때 발행)
+        leaveLobby();
         navigate(LOBBY_ROUTES.LIST);
     };
 


### PR DESCRIPTION
## 📣 Related Issue

- #131

## 📝 Summary

- 로비 방에서 "로비 목록으로 이동" 버튼으로 나가도 다른 참여자 화면에 나간 사람이 계속 남아 있던 문제를 수정했습니다.
- 기존에는 로비를 떠날 때 STOMP 구독만 해제하고 BE 계약상 명시적 퇴장 경로(`/app/lobby/{code}/leave`)를 발행하지 않아, BE가 연결 종료(새로고침/종료) 전까지 참여자를 유지했습니다.
- `SOCKET_PUBLISH`에 `LOBBY_LEAVE` 경로 상수를 추가했습니다.
- `useLobbySocket`에 `leaveLobby()`를 추가해, 연결·inviteCode 가드를 통과하면 leave를 발행하도록 구현했습니다. (발행 실패가 화면 이동을 막지 않도록 경고 로그만 남깁니다.)
- `LobbyRoom`의 "로비 목록으로 이동" 핸들러에서 `navigate` 전에 `leaveLobby()`를 호출하도록 연결했습니다.

## 🙏PR point

- BE의 `/app/lobby/{code}/leave` 핸들러는 이미 동작하므로 이번 작업은 FE 연동만 수행했습니다. (payload 없음 → body 생략)
- 게임 시작으로 인게임에 진입하는 경로(`navigateToGame`)에는 leave를 발행하지 않습니다. 인게임 진입은 퇴장이 아니므로 로비 잔류가 정상입니다.
- 브라우저 뒤로가기/탭 종료 등 버튼을 거치지 않는 이탈 경로는 이번 범위에서 제외했습니다. 필요 시 후속 이슈에서 unmount/`beforeunload` 처리를 검토하겠습니다.
- MSW는 STOMP를 목하지 않으므로, 실제 검증은 `VITE_ENABLE_MSW=false`(실 BE 연동) + 계정 2개로 진행해야 합니다.

## 📬 Reference
