### PR TITLE
[Fix/#143] 로그인 force 요청 및 중복 로그인 처리 추가

### DIFF
--- a/src/components/home/AuthEntryForm.tsx
+++ b/src/components/home/AuthEntryForm.tsx
@@ -5,6 +5,7 @@ import { useMemberLoginSession } from '../../hooks/useMemberLoginSession';
 import { useRegisterSession } from '../../hooks/useRegisterSession';
 import { AUTH_LABELS, AUTH_MESSAGES } from '../../constants/auth';
 import { AuthGlobalErrorMessage } from './AuthErrorMessage';
+import { ConcurrentLoginConfirmModal } from './ConcurrentLoginConfirmModal';
 import { GuestForm } from './GuestForm';
 import { LoginForm } from './LoginForm';
 import { RegisterForm } from './RegisterForm';
@@ -80,8 +81,11 @@ export function AuthEntryForm({
     const activeGlobalErrorMessage = activeErrorField
         ? null
         : activeErrorMessage;
-    const isActiveSubmitting = isMemberMode
-        ? memberSession.isSubmitting
+    const isMemberInteractionLocked =
+        memberSession.isSubmitting ||
+        memberSession.isConcurrentLoginConfirmOpen;
+    const isActiveInteractionLocked = isMemberMode
+        ? isMemberInteractionLocked
         : guestSession.isSubmitting;
     const hasTopFeedback = Boolean(activeGlobalErrorMessage || successMessage);
 
@@ -95,6 +99,7 @@ export function AuthEntryForm({
     const handleModeChange = (nextMode: AuthMode) => {
         if (
             memberSession.isSubmitting ||
+            memberSession.isConcurrentLoginConfirmOpen ||
             guestSession.isSubmitting ||
             registerSession.isSubmitting ||
             nextMode === mode
@@ -203,7 +208,7 @@ export function AuthEntryForm({
                             type="button"
                             role="tab"
                             aria-selected={isSelected}
-                            disabled={isActiveSubmitting}
+                            disabled={isActiveInteractionLocked}
                             onClick={() => handleModeChange(authMode)}
                             className={`min-h-9 min-w-0 rounded-lg px-2 text-sm leading-5 transition disabled:cursor-not-allowed ${
                                 isSelected
@@ -228,7 +233,7 @@ export function AuthEntryForm({
                     loginId={loginId}
                     password={memberPassword}
                     autoLogin={autoLogin}
-                    isSubmitting={memberSession.isSubmitting}
+                    isSubmitting={isMemberInteractionLocked}
                     errorMessage={memberSession.errorMessage}
                     errorField={memberSession.errorField}
                     onLoginIdChange={(value) => {
@@ -265,7 +270,7 @@ export function AuthEntryForm({
 
             <button
                 type="button"
-                disabled={isActiveSubmitting}
+                disabled={isActiveInteractionLocked}
                 onClick={() => handleModeChange(isMemberMode ? 'guest' : 'member')}
                 className="min-h-12 w-full min-w-0 rounded-lg border border-[color:var(--monomat-border-input)] bg-white px-3 text-[15px] font-bold leading-5 text-[var(--monomat-text-strong)] transition hover:bg-[var(--monomat-page-bg)] disabled:cursor-not-allowed disabled:opacity-60"
             >
@@ -281,13 +286,26 @@ export function AuthEntryForm({
 
                 <button
                     type="button"
-                    disabled={isActiveSubmitting}
+                    disabled={isActiveInteractionLocked}
                     onClick={() => handleModeChange('register')}
                     className="font-semibold text-[var(--monomat-primary)] transition hover:text-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:opacity-60"
                 >
                     {AUTH_LABELS.SIGNUP}
                 </button>
             </footer>
+
+            {memberSession.isConcurrentLoginConfirmOpen ? (
+                <ConcurrentLoginConfirmModal
+                    isSubmitting={memberSession.isSubmitting}
+                    onCancel={memberSession.cancelConcurrentLogin}
+                    onConfirm={() => {
+                        void memberSession.forceLoginWithAccount(
+                            loginId,
+                            memberPassword,
+                        );
+                    }}
+                />
+            ) : null}
         </div>
     );
 }

--- a/src/components/home/ConcurrentLoginConfirmModal.tsx
+++ b/src/components/home/ConcurrentLoginConfirmModal.tsx
@@ -1,0 +1,109 @@
+import {
+    type MouseEvent,
+    useEffect,
+} from 'react';
+import { X } from 'lucide-react';
+
+import { CONCURRENT_LOGIN_CONFIRM_COPY } from '../../constants/auth';
+
+interface ConcurrentLoginConfirmModalProps {
+    isSubmitting: boolean;
+    onCancel: () => void;
+    onConfirm: () => void;
+}
+
+export function ConcurrentLoginConfirmModal({
+    isSubmitting,
+    onCancel,
+    onConfirm,
+}: ConcurrentLoginConfirmModalProps) {
+    useEffect(() => {
+        const previousOverflow = document.body.style.overflow;
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape' && !isSubmitting) {
+                onCancel();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        document.body.style.overflow = 'hidden';
+
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+            document.body.style.overflow = previousOverflow;
+        };
+    }, [isSubmitting, onCancel]);
+
+    const handleOverlayMouseDown = () => {
+        if (!isSubmitting) {
+            onCancel();
+        }
+    };
+
+    const handleContentMouseDown = (event: MouseEvent<HTMLDivElement>) => {
+        event.stopPropagation();
+    };
+
+    return (
+        <div
+            role="presentation"
+            onMouseDown={handleOverlayMouseDown}
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/45 px-4 py-8"
+        >
+            <div
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="concurrent-login-confirm-title"
+                aria-describedby="concurrent-login-confirm-description"
+                onMouseDown={handleContentMouseDown}
+                className="relative w-full max-w-[445px] overflow-hidden rounded-lg bg-white px-7 pb-6 pt-8 text-center shadow-[0_18px_48px_rgba(15,23,42,0.22)]"
+            >
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    disabled={isSubmitting}
+                    aria-label={CONCURRENT_LOGIN_CONFIRM_COPY.CLOSE_ARIA_LABEL}
+                    className="absolute right-3 top-3 flex h-8 w-8 items-center justify-center rounded-lg text-[var(--monomat-text-muted)] transition hover:bg-[var(--monomat-page-bg)] hover:text-black disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                    <X size={20} strokeWidth={1.8} aria-hidden="true" />
+                </button>
+
+                <h2
+                    id="concurrent-login-confirm-title"
+                    className="!m-0 !text-lg !font-bold !leading-7 !text-black"
+                >
+                    {CONCURRENT_LOGIN_CONFIRM_COPY.TITLE}
+                </h2>
+
+                <p
+                    id="concurrent-login-confirm-description"
+                    className="mx-auto mt-3 max-w-[360px] break-keep text-sm font-medium leading-5 text-[var(--monomat-text-muted)]"
+                >
+                    {CONCURRENT_LOGIN_CONFIRM_COPY.DESCRIPTION}
+                </p>
+
+                <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                    <button
+                        type="button"
+                        onClick={onCancel}
+                        disabled={isSubmitting}
+                        className="min-h-11 rounded-lg border border-[color:var(--monomat-border-input)] bg-white px-4 text-sm font-bold text-[var(--monomat-text-muted)] transition hover:bg-[var(--monomat-page-bg)] disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                        {CONCURRENT_LOGIN_CONFIRM_COPY.CANCEL}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onConfirm}
+                        disabled={isSubmitting}
+                        className="min-h-11 rounded-lg bg-[var(--monomat-primary)] px-4 text-sm font-bold text-white transition hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:bg-[var(--monomat-primary-disabled)]"
+                    >
+                        {isSubmitting
+                            ? CONCURRENT_LOGIN_CONFIRM_COPY.SUBMITTING
+                            : CONCURRENT_LOGIN_CONFIRM_COPY.CONFIRM}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -48,10 +48,21 @@ export const AUTH_MESSAGES = {
 } as const;
 
 export const AUTH_ERROR_CODES = {
+    CONCURRENT_LOGIN_REJECTED: 'AUTH_CONCURRENT_LOGIN_REJECTED',
     INVALID_REFRESH_TOKEN: 'AUTH_INVALID_REFRESH_TOKEN',
     SESSION_EXPIRED: 'AUTH_SESSION_EXPIRED',
     UNAUTHENTICATED: 'AUTH_UNAUTHENTICATED',
     INVALID_AUTHORIZATION: 'AUTH_INVALID_AUTHORIZATION',
+} as const;
+
+export const CONCURRENT_LOGIN_CONFIRM_COPY = {
+    TITLE: '이미 로그인된 계정입니다',
+    DESCRIPTION:
+        '다른 기기 또는 브라우저에서 로그인된 세션이 있습니다. 기존 접속을 끊고 로그인하시겠습니까?',
+    CANCEL: '취소',
+    CONFIRM: '기존 접속 끊고 로그인',
+    SUBMITTING: '로그인 중...',
+    CLOSE_ARIA_LABEL: '강제 로그인 확인 닫기',
 } as const;
 
 export const AUTH_LABELS = {

--- a/src/hooks/useMemberLoginSession.ts
+++ b/src/hooks/useMemberLoginSession.ts
@@ -1,14 +1,17 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { login } from '../api/authApi';
 import { ApiError } from '../api/apiError';
-import { AUTH_MESSAGES } from '../constants/auth';
+import { AUTH_ERROR_CODES, AUTH_MESSAGES } from '../constants/auth';
 import { useAuthStore } from '../store/useAuthStore';
 
 interface UseMemberLoginSessionReturn {
     loginWithAccount: (loginId: string, password: string) => Promise<void>;
+    forceLoginWithAccount: (loginId: string, password: string) => Promise<void>;
+    cancelConcurrentLogin: () => void;
     isSubmitting: boolean;
+    isConcurrentLoginConfirmOpen: boolean;
     errorMessage: string | null;
     errorField: string | null;
     clearErrorMessage: () => void;
@@ -27,12 +30,30 @@ export function useMemberLoginSession(): UseMemberLoginSessionReturn {
     const navigate = useNavigate();
 
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [isConcurrentLoginConfirmOpen, setIsConcurrentLoginConfirmOpen] =
+        useState(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
     const [errorField, setErrorField] = useState<string | null>(null);
+    const isRequestInFlightRef = useRef(false);
 
     const clearErrorMessage = () => {
         setErrorMessage(null);
         setErrorField(null);
+    };
+
+    const completeLogin = async (
+        loginId: string,
+        password: string,
+        force: boolean,
+    ) => {
+        const session = await login({
+            loginId,
+            password,
+            force,
+        });
+
+        setSession(session);
+        navigate('/lobbies');
     };
 
     const loginWithAccount = async (loginId: string, password: string) => {
@@ -50,33 +71,79 @@ export function useMemberLoginSession(): UseMemberLoginSessionReturn {
             return;
         }
 
-        if (isSubmitting) {
+        if (
+            isRequestInFlightRef.current ||
+            isConcurrentLoginConfirmOpen
+        ) {
             return;
         }
 
         try {
+            isRequestInFlightRef.current = true;
             setIsSubmitting(true);
             setErrorMessage(null);
             setErrorField(null);
 
-            const session = await login({
-                loginId: trimmedLoginId,
-                password,
-            });
-
-            setSession(session);
-            navigate('/lobbies');
+            await completeLogin(trimmedLoginId, password, false);
         } catch (error) {
+            if (
+                error instanceof ApiError &&
+                error.code === AUTH_ERROR_CODES.CONCURRENT_LOGIN_REJECTED
+            ) {
+                setIsConcurrentLoginConfirmOpen(true);
+                return;
+            }
+
             setErrorMessage(getErrorMessage(error));
             setErrorField(error instanceof ApiError ? error.field ?? null : null);
         } finally {
+            isRequestInFlightRef.current = false;
             setIsSubmitting(false);
         }
     };
 
+    const forceLoginWithAccount = async (
+        loginId: string,
+        password: string,
+    ) => {
+        if (
+            !isConcurrentLoginConfirmOpen ||
+            isRequestInFlightRef.current
+        ) {
+            return;
+        }
+
+        try {
+            isRequestInFlightRef.current = true;
+            setIsSubmitting(true);
+            setErrorMessage(null);
+            setErrorField(null);
+
+            await completeLogin(loginId.trim(), password, true);
+        } catch (error) {
+            setIsConcurrentLoginConfirmOpen(false);
+            setErrorMessage(getErrorMessage(error));
+            setErrorField(error instanceof ApiError ? error.field ?? null : null);
+        } finally {
+            isRequestInFlightRef.current = false;
+            setIsSubmitting(false);
+        }
+    };
+
+    const cancelConcurrentLogin = () => {
+        if (isRequestInFlightRef.current) {
+            return;
+        }
+
+        setIsConcurrentLoginConfirmOpen(false);
+    };
+
     return {
         loginWithAccount,
+        forceLoginWithAccount,
+        cancelConcurrentLogin,
         isSubmitting,
+        isConcurrentLoginConfirmOpen,
         errorMessage,
         errorField,
         clearErrorMessage,

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -9,6 +9,7 @@ export interface GuestLoginRequest {
 export interface LoginRequest {
     loginId: string;
     password: string;
+    force?: boolean;
 }
 
 export interface RegisterRequest {


### PR DESCRIPTION
## 📣 Related Issue

- #143

## 📝 Summary

- `LoginRequest` 타입에 `force` 필드를 추가했습니다.
- 일반 로그인 요청 시 `force: false`를 명시적으로 전송하도록 수정했습니다.
- `AUTH_CONCURRENT_LOGIN_REJECTED` 응답을 감지해 강제 로그인 확인 모달을 표시합니다.
- 사용자가 확인하면 기존 입력값으로 `force: true` 로그인 요청을 다시 전송합니다.
- 강제 로그인 성공 시 기존과 동일하게 세션을 저장하고 로비 목록으로 이동합니다.
- 로그인 요청 중 중복 제출과 모달 닫기, 배경 클릭, Escape 입력을 방지했습니다.

## 🙏PR point

- 비밀번호는 기존 로그인 입력 state에서만 사용하며 별도 저장소나 ref에 보관하지 않습니다.
- `useAuthStore`의 세션 저장 구조와 refresh token 처리 흐름은 변경하지 않았습니다.
- 중복 로그인 이외의 로그인 오류는 기존 에러 처리 흐름을 유지합니다.
- `npm run lint` 실행 결과 오류 없이 통과했습니다.
  - 기존 `public/mockServiceWorker.js` 경고 1건이 있습니다.
- `npm run build` 실행 결과 성공했습니다.
  - 기존 번들 크기 경고가 있습니다.
- 실제 중복 로그인 계정을 이용한 BE 연동 테스트가 필요합니다.

## 📬 Reference

- Monomat-BE `develop` 로그인 API 계약
- `AUTH_CONCURRENT_LOGIN_REJECTED`