### PR TITLE
[Fix/#142] 초대코드 입력 모달 색상 수정

### DIFF
--- a/src/components/common/NavigationBar.tsx
+++ b/src/components/common/NavigationBar.tsx
@@ -82,7 +82,7 @@ export function NavigationBar() {
                                 size={18}
                                 strokeWidth={2.2}
                             />
-                            <span className="ml-[18px] min-w-0 truncate text-[var(--monomat-border-input)]">
+                            <span className="ml-[18px] min-w-0 truncate text-[var(--monomat-text-strong)]">
                                 {LOBBY_NAVIGATION_LABELS.INVITE_CODE}
                             </span>
                             <span className="ml-auto mr-[9px] flex h-[22px] w-9 shrink-0 items-center justify-center rounded-full bg-[var(--monomat-page-bg)] text-[11px] text-[var(--monomat-text-muted)]">

--- a/src/components/lobby/InviteCodeJoinModal.tsx
+++ b/src/components/lobby/InviteCodeJoinModal.tsx
@@ -145,7 +145,7 @@ export function InviteCodeJoinModal({
 
                 <h2
                     id="invite-code-join-modal-title"
-                    className="mb-3 text-center text-2xl font-bold text-[var(--monomat-text-strong)]"
+                    className="mb-3 text-center text-2xl font-bold !text-[var(--monomat-text-strong)]"
                 >
                     초대 코드로 입장
                 </h2>

--- a/src/components/lobby/InviteCodeJoinModal.tsx
+++ b/src/components/lobby/InviteCodeJoinModal.tsx
@@ -132,12 +132,12 @@ export function InviteCodeJoinModal({
             aria-modal="true"
             aria-labelledby="invite-code-join-modal-title"
         >
-            <div className="relative w-[460px] rounded-2xl bg-white px-9 py-8 text-[#333338] shadow-xl">
+            <div className="relative w-[460px] rounded-2xl bg-white px-9 py-8 text-[var(--monomat-text-strong)] shadow-xl">
                 <button
                     type="button"
                     onClick={handleClose}
                     disabled={isSubmitting}
-                    className="absolute right-6 top-6 text-3xl leading-none text-[#808085] hover:text-[#333338] disabled:cursor-not-allowed disabled:opacity-40"
+                    className="absolute right-6 top-6 text-3xl leading-none text-[var(--monomat-text-muted)] hover:text-[var(--monomat-text-strong)] disabled:cursor-not-allowed disabled:opacity-40"
                     aria-label="초대 코드 입장 모달 닫기"
                 >
                     ×
@@ -145,19 +145,19 @@ export function InviteCodeJoinModal({
 
                 <h2
                     id="invite-code-join-modal-title"
-                    className="mb-3 text-center text-2xl font-bold text-[#333338]"
+                    className="mb-3 text-center text-2xl font-bold text-[var(--monomat-text-strong)]"
                 >
                     초대 코드로 입장
                 </h2>
 
-                <p className="mb-8 text-center text-sm text-[#808085]">
+                <p className="mb-8 text-center text-sm text-[var(--monomat-text-secondary)]">
                     전달받은 6자리 초대 코드를 입력해주세요.
                 </p>
 
                 <section className="mb-5">
                     <label
                         htmlFor="invite-code-input"
-                        className="mb-3 block text-sm font-bold text-[#333338]"
+                        className="mb-3 block text-sm font-bold text-[var(--monomat-text-strong)]"
                     >
                         초대 코드
                     </label>
@@ -172,10 +172,10 @@ export function InviteCodeJoinModal({
                         onChange={handleInputChange}
                         onEnter={handleJoinCheck}
                         placeholder="ABC123"
-                        className="h-13 w-full rounded-lg border border-[#CCCCD1] bg-[#F5F5F7] px-4 text-center font-mono text-2xl font-bold tracking-[0.35em] text-[#333338] outline-none transition placeholder:text-[#B5B5BA] focus:border-[#3873E6] disabled:cursor-not-allowed disabled:opacity-60"
+                        className="h-13 w-full rounded-lg border border-[color:var(--monomat-border-input)] bg-[var(--monomat-page-bg)] px-4 text-center font-mono text-2xl font-bold tracking-[0.35em] text-[var(--monomat-text-strong)] outline-none transition placeholder:text-[var(--monomat-text-muted)] focus:border-[var(--monomat-primary)] disabled:cursor-not-allowed disabled:opacity-60"
                     />
 
-                    <p className="mt-2 text-xs text-[#808085]">
+                    <p className="mt-2 text-xs text-[var(--monomat-text-muted)]">
                         영문 대문자와 숫자 조합 6자리만 입력할 수 있습니다.
                     </p>
                 </section>
@@ -190,22 +190,22 @@ export function InviteCodeJoinModal({
                 )}
 
                 {joinedLobby && (
-                    <section className="mb-5 rounded-xl bg-[#F5F5F7] px-4 py-4">
-                        <p className="mb-2 text-sm font-bold text-[#333338]">
+                    <section className="mb-5 rounded-xl bg-[var(--monomat-page-bg)] px-4 py-4">
+                        <p className="mb-2 text-sm font-bold text-[var(--monomat-text-strong)]">
                             입장 가능한 로비입니다.
                         </p>
 
                         <dl className="space-y-2 text-sm">
                             <div className="flex justify-between gap-4">
-                                <dt className="text-[#808085]">로비 이름</dt>
-                                <dd className="max-w-[240px] truncate font-semibold text-[#333338]">
+                                <dt className="text-[var(--monomat-text-muted)]">로비 이름</dt>
+                                <dd className="max-w-[240px] truncate font-semibold text-[var(--monomat-text-strong)]">
                                     {joinedLobby.title}
                                 </dd>
                             </div>
 
                             <div className="flex justify-between gap-4">
-                                <dt className="text-[#808085]">현재 인원</dt>
-                                <dd className="font-semibold text-[#333338]">
+                                <dt className="text-[var(--monomat-text-muted)]">현재 인원</dt>
+                                <dd className="font-semibold text-[var(--monomat-text-strong)]">
                                     {joinedLobby.currentPlayers}/
                                     {joinedLobby.maxPlayers}명
                                 </dd>
@@ -219,7 +219,7 @@ export function InviteCodeJoinModal({
                         type="button"
                         onClick={handleClose}
                         disabled={isSubmitting}
-                        className="h-12 flex-1 rounded-lg border border-[#CCCCD1] font-bold text-[#333338] hover:bg-[#F5F5F7] disabled:cursor-not-allowed disabled:opacity-50"
+                        className="h-12 flex-1 rounded-lg border border-[color:var(--monomat-border-input)] font-bold text-[var(--monomat-text-strong)] hover:bg-[var(--monomat-page-bg)] disabled:cursor-not-allowed disabled:opacity-50"
                     >
                         취소
                     </button>
@@ -228,7 +228,7 @@ export function InviteCodeJoinModal({
                         <button
                             type="button"
                             onClick={handleConfirmEnter}
-                            className="h-12 flex-1 rounded-lg bg-[#3873E6] font-bold text-white hover:bg-blue-600"
+                            className="h-12 flex-1 rounded-lg bg-[var(--monomat-primary)] font-bold text-white hover:bg-[var(--monomat-primary-hover)]"
                         >
                             입장하기
                         </button>
@@ -237,7 +237,7 @@ export function InviteCodeJoinModal({
                             type="button"
                             onClick={() => handleJoinCheck(inviteCodeInput)}
                             disabled={isSubmitting}
-                            className="h-12 flex-1 rounded-lg bg-[#3873E6] font-bold text-white hover:bg-blue-600 disabled:cursor-not-allowed disabled:bg-blue-300"
+                            className="h-12 flex-1 rounded-lg bg-[var(--monomat-primary)] font-bold text-white hover:bg-[var(--monomat-primary-hover)] disabled:cursor-not-allowed disabled:bg-[var(--monomat-primary-disabled)]"
                         >
                             {isSubmitting ? '확인 중...' : '입장 확인'}
                         </button>


### PR DESCRIPTION
## 📣 Related Issue

- #142

## 📝 Summary

- 초대코드 입력 모달의 제목과 안내 문구 색상 대비를 개선했습니다.
- 로비 상단의 “초대 코드” 텍스트를 강조 색상 토큰으로 변경했습니다.
- 모달의 관련 하드코딩 색상을 기존 디자인 토큰으로 교체했습니다.
- 전역 `h2` 스타일과 다크 모드 설정이 제목 색상을 덮어쓰지 않도록 우선순위를 조정했습니다.
- 초대코드 입력, 제출, 닫기 및 에러 처리 로직은 변경하지 않았습니다.

## 🙏 PR point

- `src/index.css`와 인증·API 관련 코드는 변경하지 않았습니다.
- `npm run lint` 통과
  - 기존 `mockServiceWorker.js` 경고 1건이 있습니다.
- `npm run build` 통과
  - 기존 번들 크기 경고가 있습니다.
- 로그인 API의 `400 Bad Request`는 이번 이슈와 별도이며, 필요 시 Network 탭의 request payload와 response 확인이 필요합니다.

## 📬 Reference

- 프로젝트 기존 CSS 변수 및 디자인 토큰을 재사용했습니다.