### PR TITLE
[Feat/#146] 자동 로그인 세션 유지 기능 구현

### DIFF
--- a/src/components/home/AuthEntryForm.tsx
+++ b/src/components/home/AuthEntryForm.tsx
@@ -113,7 +113,11 @@ export function AuthEntryForm({
 
     const handleMemberSubmit = () => {
         setSuccessMessage(null);
-        void memberSession.loginWithAccount(loginId, memberPassword);
+        void memberSession.loginWithAccount(
+            loginId,
+            memberPassword,
+            autoLogin,
+        );
     };
 
     const handleGuestSubmit = () => {
@@ -302,6 +306,7 @@ export function AuthEntryForm({
                         void memberSession.forceLoginWithAccount(
                             loginId,
                             memberPassword,
+                            autoLogin,
                         );
                     }}
                 />

--- a/src/hooks/useGuestSession.ts
+++ b/src/hooks/useGuestSession.ts
@@ -59,7 +59,9 @@ export function useGuestSession(): UseGuestSessionReturn {
                 nickname: trimmedNickname,
             });
 
-            setSession(session);
+            setSession(session, {
+                storageStrategy: 'local',
+            });
             navigate('/lobbies');
         } catch (error) {
             setErrorMessage(getErrorMessage(error));

--- a/src/hooks/useMemberLoginSession.ts
+++ b/src/hooks/useMemberLoginSession.ts
@@ -7,8 +7,16 @@ import { AUTH_ERROR_CODES, AUTH_MESSAGES } from '../constants/auth';
 import { useAuthStore } from '../store/useAuthStore';
 
 interface UseMemberLoginSessionReturn {
-    loginWithAccount: (loginId: string, password: string) => Promise<void>;
-    forceLoginWithAccount: (loginId: string, password: string) => Promise<void>;
+    loginWithAccount: (
+        loginId: string,
+        password: string,
+        autoLogin: boolean,
+    ) => Promise<void>;
+    forceLoginWithAccount: (
+        loginId: string,
+        password: string,
+        autoLogin: boolean,
+    ) => Promise<void>;
     cancelConcurrentLogin: () => void;
     isSubmitting: boolean;
     isConcurrentLoginConfirmOpen: boolean;
@@ -45,6 +53,7 @@ export function useMemberLoginSession(): UseMemberLoginSessionReturn {
         loginId: string,
         password: string,
         force: boolean,
+        autoLogin: boolean,
     ) => {
         const session = await login({
             loginId,
@@ -52,11 +61,17 @@ export function useMemberLoginSession(): UseMemberLoginSessionReturn {
             force,
         });
 
-        setSession(session);
+        setSession(session, {
+            storageStrategy: autoLogin ? 'local' : 'session',
+        });
         navigate('/lobbies');
     };
 
-    const loginWithAccount = async (loginId: string, password: string) => {
+    const loginWithAccount = async (
+        loginId: string,
+        password: string,
+        autoLogin: boolean,
+    ) => {
         const trimmedLoginId = loginId.trim();
 
         if (!trimmedLoginId) {
@@ -84,7 +99,7 @@ export function useMemberLoginSession(): UseMemberLoginSessionReturn {
             setErrorMessage(null);
             setErrorField(null);
 
-            await completeLogin(trimmedLoginId, password, false);
+            await completeLogin(trimmedLoginId, password, false, autoLogin);
         } catch (error) {
             if (
                 error instanceof ApiError &&
@@ -105,6 +120,7 @@ export function useMemberLoginSession(): UseMemberLoginSessionReturn {
     const forceLoginWithAccount = async (
         loginId: string,
         password: string,
+        autoLogin: boolean,
     ) => {
         if (
             !isConcurrentLoginConfirmOpen ||
@@ -119,7 +135,7 @@ export function useMemberLoginSession(): UseMemberLoginSessionReturn {
             setErrorMessage(null);
             setErrorField(null);
 
-            await completeLogin(loginId.trim(), password, true);
+            await completeLogin(loginId.trim(), password, true, autoLogin);
         } catch (error) {
             setIsConcurrentLoginConfirmOpen(false);
             setErrorMessage(getErrorMessage(error));

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -6,6 +6,8 @@ import { authSessionSchema } from '../schemas/authSchema';
 
 import type {
     AuthSession,
+    AuthStorageStrategy,
+    SetSessionOptions,
     UserType,
 } from '../types/auth';
 
@@ -20,11 +22,13 @@ interface AuthState {
     refreshTokenExpiresAt: string | null;
     isGuest: boolean;
     isHydrated: boolean;
-    setSession: (session: AuthSession) => void;
+    setSession: (session: AuthSession, options?: SetSessionOptions) => void;
     clearSession: () => void;
     initializeSession: () => void;
     updateNickname: (nickname: string) => void;
 }
+
+const DEFAULT_STORAGE_STRATEGY: AuthStorageStrategy = 'local';
 
 function createSessionState(session: AuthSession) {
     return {
@@ -56,6 +60,74 @@ function createEmptyAuthState() {
     };
 }
 
+function getStorage(strategy: AuthStorageStrategy): Storage | null {
+    if (typeof window === 'undefined') {
+        return null;
+    }
+
+    return strategy === 'local'
+        ? window.localStorage
+        : window.sessionStorage;
+}
+
+function getOppositeStorageStrategy(
+    strategy: AuthStorageStrategy,
+): AuthStorageStrategy {
+    return strategy === 'local' ? 'session' : 'local';
+}
+
+function removeStoredSession(strategy: AuthStorageStrategy) {
+    try {
+        getStorage(strategy)?.removeItem(STORAGE_KEYS.GUEST_SESSION);
+    } catch (error) {
+        console.error(
+            `[useAuthStore] ${strategy}Storage 인증 세션 삭제 실패:`,
+            error,
+        );
+    }
+}
+
+function readStoredSession(
+    strategy: AuthStorageStrategy,
+): AuthSession | null {
+    try {
+        const storage = getStorage(strategy);
+
+        if (!storage) {
+            return null;
+        }
+
+        const storedData = storage.getItem(STORAGE_KEYS.GUEST_SESSION);
+
+        if (!storedData) {
+            return null;
+        }
+
+        const parsedData = JSON.parse(storedData) as unknown;
+        const result = authSessionSchema.safeParse(parsedData);
+
+        if (!result.success) {
+            console.warn(
+                `[useAuthStore] ${AUTH_MESSAGES.SESSION_RESTORE_FAILED}`,
+                result.error,
+            );
+            removeStoredSession(strategy);
+            return null;
+        }
+
+        return result.data;
+    } catch (error) {
+        console.error(
+            `[useAuthStore] ${strategy}Storage 세션 복구 중 오류 발생:`,
+            error,
+        );
+        removeStoredSession(strategy);
+        return null;
+    }
+}
+
+let currentStorageStrategy: AuthStorageStrategy | null = null;
+
 export const useAuthStore = create<AuthState>((set, get) => ({
     userId: null,
     userIdentifier: null,
@@ -68,56 +140,57 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     isGuest: false,
     isHydrated: false,
 
-    setSession: (session) => {
+    setSession: (session, options) => {
+        const storageStrategy =
+            options?.storageStrategy ??
+            currentStorageStrategy ??
+            DEFAULT_STORAGE_STRATEGY;
+
+        currentStorageStrategy = storageStrategy;
+
         try {
-            localStorage.setItem(
+            getStorage(storageStrategy)?.setItem(
                 STORAGE_KEYS.GUEST_SESSION,
                 JSON.stringify(session),
             );
         } catch (error) {
-            // localStorage 저장 실패가 즉시 플레이를 막지는 않도록 메모리 상태는 유지한다.
+            // 브라우저 저장소 저장 실패가 즉시 플레이를 막지는 않도록 메모리 상태는 유지한다.
             // 단, 새로고침 시 세션 복구는 실패할 수 있으므로 로그를 남긴다.
             console.error('[useAuthStore] 인증 세션 저장 실패:', error);
+        } finally {
+            removeStoredSession(getOppositeStorageStrategy(storageStrategy));
         }
 
         set(createSessionState(session));
     },
 
     clearSession: () => {
-        localStorage.removeItem(STORAGE_KEYS.GUEST_SESSION);
+        removeStoredSession('local');
+        removeStoredSession('session');
+        currentStorageStrategy = null;
         set(createEmptyAuthState());
     },
 
     initializeSession: () => {
-        try {
-            const storedData = localStorage.getItem(STORAGE_KEYS.GUEST_SESSION);
+        const localSession = readStoredSession('local');
 
-            if (!storedData) {
-                set({ isHydrated: true });
-                return;
-            }
-
-            const parsedData = JSON.parse(storedData) as unknown;
-            const result = authSessionSchema.safeParse(parsedData);
-
-            if (!result.success) {
-                console.warn(
-                    `[useAuthStore] ${AUTH_MESSAGES.SESSION_RESTORE_FAILED}`,
-                    result.error,
-                );
-
-                localStorage.removeItem(STORAGE_KEYS.GUEST_SESSION);
-                set(createEmptyAuthState());
-                return;
-            }
-
-            set(createSessionState(result.data));
-        } catch (error) {
-            console.error('[useAuthStore] 세션 복구 중 오류 발생:', error);
-
-            localStorage.removeItem(STORAGE_KEYS.GUEST_SESSION);
-            set(createEmptyAuthState());
+        if (localSession) {
+            removeStoredSession('session');
+            currentStorageStrategy = 'local';
+            set(createSessionState(localSession));
+            return;
         }
+
+        const sessionSession = readStoredSession('session');
+
+        if (sessionSession) {
+            currentStorageStrategy = 'session';
+            set(createSessionState(sessionSession));
+            return;
+        }
+
+        currentStorageStrategy = null;
+        set(createEmptyAuthState());
     },
 
     updateNickname: (nickname) => {
@@ -156,17 +229,6 @@ export const useAuthStore = create<AuthState>((set, get) => ({
             refreshTokenExpiresAt,
         };
 
-        try {
-            localStorage.setItem(
-                STORAGE_KEYS.GUEST_SESSION,
-                JSON.stringify(nextSession),
-            );
-        } catch (error) {
-            console.error('[useAuthStore] 닉네임 변경 저장 실패:', error);
-        }
-
-        set({
-            nickname: trimmedNickname,
-        });
+        get().setSession(nextSession);
     },
 }));

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -32,6 +32,12 @@ export interface AuthSession extends AuthTokenSet {
     userIdentifier: string;
 }
 
+export type AuthStorageStrategy = 'local' | 'session';
+
+export interface SetSessionOptions {
+    storageStrategy?: AuthStorageStrategy;
+}
+
 export interface RefreshSessionResponse extends AuthTokenSet {
     userId: number;
     userType: UserType;


### PR DESCRIPTION
## 📣 Related Issue

- #146

## 📝 Summary

- 자동 로그인 체크 시 인증 세션을 `localStorage`에 저장하도록 구현했습니다.
- 자동 로그인 미체크 시 인증 세션을 `sessionStorage`에 저장하도록 구현했습니다.
- 세션 복구 시 `localStorage`를 우선 확인하고, 복구할 수 없으면 `sessionStorage`를 확인합니다.
- 손상된 세션 데이터는 해당 저장소에서만 제거한 뒤 다음 저장소 복구를 시도합니다.
- 세션 저장 시 반대쪽 저장소를 정리하고, 로그아웃 시 양쪽 저장소를 모두 정리합니다.
- refresh token 재발급과 닉네임 변경 시 기존 세션 저장 전략을 유지합니다.
- 일반 로그인과 중복 로그인 강제 요청에 동일한 자동 로그인 선택값을 반영합니다.
- 게스트 로그인은 기존과 동일하게 `localStorage` 정책을 유지합니다.

## 🙏PR point

- 자동 로그인 여부를 별도 값으로 저장하지 않고 인증 세션의 저장 위치로 구분합니다.
- `setSession(session, options?)` 형태로 기존 API를 확장했습니다.
- 비밀번호는 브라우저 저장소나 전역 상태에 저장하지 않습니다.
- `npm run lint` 실행 결과 오류 없이 기존 MSW 파일 경고 1건만 확인했습니다.
- `npm run build`가 성공했습니다.
- 브라우저 완전 종료 후 세션 유지 여부와 실제 refresh 연동은 수동 확인이 필요합니다.

## 📬 Reference

