### PR TITLE
[Fix/#147] 인게임 서버 시간 기준 타이머 보정

### DIFF
--- a/src/hooks/useGameSocket.ts
+++ b/src/hooks/useGameSocket.ts
@@ -305,6 +305,7 @@ export function useGameSocket(inviteCode: string | undefined) {
             try {
                 const status =
                     await getCurrentGameRoundStatus(normalizedInviteCode);
+                const clientReceivedAtMs = Date.now();
 
                 if (
                     isCancelled ||
@@ -314,7 +315,9 @@ export function useGameSocket(inviteCode: string | undefined) {
                     return;
                 }
 
-                useGameStore.getState().applyCurrentRoundStatus(status);
+                useGameStore
+                    .getState()
+                    .applyCurrentRoundStatus(status, clientReceivedAtMs);
             } catch (error: unknown) {
                 if (isCancelled) {
                     return;
@@ -436,6 +439,7 @@ export function useGameSocket(inviteCode: string | undefined) {
             const answersDestination = SOCKET_SUBSCRIBE.GAME_ANSWERS;
 
             subscribe(roundDestination, (message) => {
+                const clientReceivedAtMs = Date.now();
                 const event = parseMessage(
                     message,
                     gameRoundEventSchema,
@@ -443,7 +447,9 @@ export function useGameSocket(inviteCode: string | undefined) {
                 );
 
                 if (event) {
-                    useGameStore.getState().applyRoundEvent(event);
+                    useGameStore
+                        .getState()
+                        .applyRoundEvent(event, clientReceivedAtMs);
                 }
             });
 

--- a/src/pages/InGamePage.tsx
+++ b/src/pages/InGamePage.tsx
@@ -24,6 +24,7 @@ import {
     normalizeInviteCode,
     validateInviteCode,
 } from '../utils/inviteCode';
+import { getSyncedNowMs } from '../utils/serverTime';
 
 import type {
     GameChatDisplayMessage,
@@ -120,6 +121,12 @@ export function InGamePage() {
     const currentRoundStatus = useGameStore(
         (state) => state.currentRoundStatus,
     );
+    const serverTimeOffsetMs = useGameStore(
+        (state) => state.serverTimeOffsetMs,
+    );
+    const serverTimeOffsetRoundNo = useGameStore(
+        (state) => state.serverTimeOffsetRoundNo,
+    );
 
     const {
         connectionStatus,
@@ -173,7 +180,13 @@ export function InGamePage() {
         shouldPlay && playbackStarted
             ? playbackStarted.serverStartedAt
             : null;
-    const [countdownNow, setCountdownNow] = useState(() => Date.now());
+    const activeServerTimeOffsetMs =
+        serverTimeOffsetRoundNo === currentRoundNo
+            ? serverTimeOffsetMs
+            : null;
+    const [countdownClientNow, setCountdownClientNow] = useState(
+        () => Date.now(),
+    );
 
     useEffect(() => {
         if (playbackStartedAt == null) {
@@ -181,7 +194,7 @@ export function InGamePage() {
         }
 
         const timer = window.setInterval(() => {
-            setCountdownNow(Date.now());
+            setCountdownClientNow(Date.now());
         }, 250);
 
         return () => {
@@ -207,7 +220,12 @@ export function InGamePage() {
 
         const elapsedSeconds = Math.max(
             0,
-            (countdownNow - playbackStartedAt) / 1000,
+            (getSyncedNowMs(
+                countdownClientNow,
+                activeServerTimeOffsetMs,
+            ) -
+                playbackStartedAt) /
+                1000,
         );
 
         return Math.max(

--- a/src/store/useGameStore.ts
+++ b/src/store/useGameStore.ts
@@ -1,5 +1,10 @@
 import { create } from 'zustand';
 
+import {
+    calculatePlaybackEventTimeOffsetMs,
+    calculateRecoveryTimeOffsetMs,
+} from '../utils/serverTime';
+
 import type {
     CurrentGameRoundStatus,
     GameChatMessage,
@@ -39,14 +44,23 @@ interface GameState {
     isSubmittingGameInput: boolean;
     lastSubmittedContent: string | null;
     gameInputErrorMessage: string | null;
+    serverTimeOffsetMs: number | null;
+    serverTimeOffsetRoundNo: number | null;
+    serverTimeSyncSource: 'playback-event' | 'round-recovery' | null;
     initializeGame: (inviteCode: string) => void;
     setSubscriptionStatus: (status: GameSubscriptionStatus) => void;
     setError: (message: string | null) => void;
-    applyRoundEvent: (event: GameRoundEvent) => void;
+    applyRoundEvent: (
+        event: GameRoundEvent,
+        clientReceivedAtMs: number,
+    ) => void;
     applyRoundEnd: (event: GameRoundEndEvent) => void;
     appendChatMessage: (message: GameChatMessage) => void;
     applyCorrectAnswer: (event: GameRoundCorrectEvent) => void;
-    applyCurrentRoundStatus: (status: CurrentGameRoundStatus) => void;
+    applyCurrentRoundStatus: (
+        status: CurrentGameRoundStatus,
+        clientReceivedAtMs: number,
+    ) => void;
     markPlayerReady: (roundNo: number, videoId: string) => void;
     markPlayerBuffering: (roundNo: number, videoId: string) => void;
     markPlayerPlaying: (roundNo: number, videoId: string) => void;
@@ -96,6 +110,9 @@ function createEmptyGameState() {
         isSubmittingGameInput: false,
         lastSubmittedContent: null,
         gameInputErrorMessage: null,
+        serverTimeOffsetMs: null,
+        serverTimeOffsetRoundNo: null,
+        serverTimeSyncSource: null,
     };
 }
 
@@ -128,11 +145,18 @@ export const useGameStore = create<GameState>((set, get) => ({
         set({ errorMessage });
     },
 
-    applyRoundEvent: (event) => {
+    applyRoundEvent: (event, clientReceivedAtMs) => {
         const receivedState = createReceivedState();
         const currentState = get();
         const hasRoundChanged =
             currentState.currentRoundNo !== event.roundNo;
+        const resetServerTimeState = hasRoundChanged
+            ? {
+                serverTimeOffsetMs: null,
+                serverTimeOffsetRoundNo: null,
+                serverTimeSyncSource: null,
+            }
+            : {};
         const resetSubmissionState = hasRoundChanged
             ? {
                 isSubmittingGameInput: false,
@@ -147,6 +171,7 @@ export const useGameStore = create<GameState>((set, get) => ({
                 set({
                     ...receivedState,
                     ...resetSubmissionState,
+                    ...resetServerTimeState,
                     currentRoundNo: event.roundNo,
                     roundReady: event,
                     playbackStarted:
@@ -163,7 +188,17 @@ export const useGameStore = create<GameState>((set, get) => ({
                     playerRoundNo: event.roundNo,
                 });
                 break;
-            case 'ROUND_PLAYBACK_STARTED':
+            case 'ROUND_PLAYBACK_STARTED': {
+                const playbackEventOffsetMs =
+                    calculatePlaybackEventTimeOffsetMs(
+                        event.serverStartedAt,
+                        clientReceivedAtMs,
+                    );
+                const hasRecoveryOffsetForRound =
+                    currentState.serverTimeOffsetRoundNo === event.roundNo &&
+                    currentState.serverTimeSyncSource === 'round-recovery' &&
+                    currentState.serverTimeOffsetMs != null;
+
                 set({
                     ...receivedState,
                     ...resetSubmissionState,
@@ -172,12 +207,23 @@ export const useGameStore = create<GameState>((set, get) => ({
                         : {}),
                     currentRoundNo: event.roundNo,
                     playbackStarted: event,
+                    ...(!hasRecoveryOffsetForRound &&
+                    playbackEventOffsetMs != null
+                        ? {
+                            serverTimeOffsetMs: playbackEventOffsetMs,
+                            serverTimeOffsetRoundNo: event.roundNo,
+                            serverTimeSyncSource:
+                                'playback-event' as const,
+                        }
+                        : resetServerTimeState),
                 });
                 break;
+            }
             case 'ROUND_SKIP_VOTE':
                 set({
                     ...receivedState,
                     ...resetSubmissionState,
+                    ...resetServerTimeState,
                     currentRoundNo: event.roundNo,
                     skipVote: event,
                 });
@@ -186,6 +232,7 @@ export const useGameStore = create<GameState>((set, get) => ({
                 set({
                     ...receivedState,
                     ...resetSubmissionState,
+                    ...resetServerTimeState,
                     ...createEmptyPlayerState(),
                     currentRoundNo: event.roundNo,
                     roundSkipped: event,
@@ -227,10 +274,21 @@ export const useGameStore = create<GameState>((set, get) => ({
         });
     },
 
-    applyCurrentRoundStatus: (status) => {
+    applyCurrentRoundStatus: (status, clientReceivedAtMs) => {
         set((state) => {
             const hasRoundChanged =
                 state.currentRoundNo !== status.roundNo;
+            const recoveryOffsetMs =
+                status.roundPhase === 'PLAYING' &&
+                status.serverStartedAt != null &&
+                status.remainingSeconds != null
+                    ? calculateRecoveryTimeOffsetMs({
+                        serverStartedAtMs: status.serverStartedAt,
+                        timeLimitSeconds: status.timeLimitSeconds,
+                        remainingSeconds: status.remainingSeconds,
+                        clientReceivedAtMs,
+                    })
+                    : null;
             let restoredRoundReady: GameRoundReadyEvent | null = null;
 
             if (
@@ -292,6 +350,20 @@ export const useGameStore = create<GameState>((set, get) => ({
                         correctAnswer: null,
                     }
                     : {}),
+                ...(recoveryOffsetMs != null
+                    ? {
+                        serverTimeOffsetMs: recoveryOffsetMs,
+                        serverTimeOffsetRoundNo: status.roundNo,
+                        serverTimeSyncSource:
+                            'round-recovery' as const,
+                    }
+                    : hasRoundChanged
+                        ? {
+                            serverTimeOffsetMs: null,
+                            serverTimeOffsetRoundNo: null,
+                            serverTimeSyncSource: null,
+                        }
+                        : {}),
             };
         });
     },

--- a/src/utils/serverTime.ts
+++ b/src/utils/serverTime.ts
@@ -1,0 +1,69 @@
+interface RecoveryTimeOffsetParams {
+    serverStartedAtMs: number;
+    timeLimitSeconds: number;
+    remainingSeconds: number;
+    clientReceivedAtMs: number;
+}
+
+function areFiniteNumbers(values: readonly number[]) {
+    return values.every(Number.isFinite);
+}
+
+export function calculatePlaybackEventTimeOffsetMs(
+    serverStartedAtMs: number,
+    clientReceivedAtMs: number,
+) {
+    if (
+        !areFiniteNumbers([serverStartedAtMs, clientReceivedAtMs]) ||
+        serverStartedAtMs < 0 ||
+        clientReceivedAtMs < 0
+    ) {
+        return null;
+    }
+
+    return serverStartedAtMs - clientReceivedAtMs;
+}
+
+export function calculateRecoveryTimeOffsetMs({
+    serverStartedAtMs,
+    timeLimitSeconds,
+    remainingSeconds,
+    clientReceivedAtMs,
+}: RecoveryTimeOffsetParams) {
+    if (
+        !areFiniteNumbers([
+            serverStartedAtMs,
+            timeLimitSeconds,
+            remainingSeconds,
+            clientReceivedAtMs,
+        ]) ||
+        serverStartedAtMs < 0 ||
+        timeLimitSeconds <= 0 ||
+        remainingSeconds < 0 ||
+        remainingSeconds > timeLimitSeconds ||
+        clientReceivedAtMs < 0
+    ) {
+        return null;
+    }
+
+    const estimatedServerNowMs =
+        serverStartedAtMs +
+        (timeLimitSeconds - remainingSeconds) * 1000;
+
+    return estimatedServerNowMs - clientReceivedAtMs;
+}
+
+export function getSyncedNowMs(
+    clientNowMs: number,
+    serverTimeOffsetMs: number | null,
+) {
+    if (
+        !Number.isFinite(clientNowMs) ||
+        serverTimeOffsetMs == null ||
+        !Number.isFinite(serverTimeOffsetMs)
+    ) {
+        return clientNowMs;
+    }
+
+    return clientNowMs + serverTimeOffsetMs;
+}


### PR DESCRIPTION
## 📣 Related Issue

- #147

## 📝 Summary

- 인게임 남은 시간을 서버 기준으로 근사 보정하는 로직을 추가했습니다.
- `ROUND_PLAYBACK_STARTED` 수신 시 서버 재생 시작 시각과 클라이언트 수신 시각으로 offset을 계산합니다.
- 현재 라운드 복구 응답의 `serverStartedAt`, `timeLimitSeconds`, `remainingSeconds`를 이용해 offset을 재계산합니다.
- 복구 응답 기반 보정값이 STOMP 이벤트 기반 보정값보다 우선하도록 처리했습니다.
- 라운드 번호가 변경될 때만 이전 라운드의 offset을 무효화합니다.
- 같은 라운드의 `ROUND_READY` 이벤트에서는 기존 offset을 유지합니다.
- 유효한 보정값이 없으면 기존 클라이언트 `Date.now()` 기준으로 fallback합니다.
- 시간 계산 로직을 `serverTime` 유틸의 순수 함수로 분리했습니다.
- 기존 인게임 디자인, YouTube IFrame 제어, 정답 및 채팅 흐름은 유지했습니다.

## 🙏PR point

- BE 응답에 `serverNow`가 없어 완전한 NTP 방식이 아닌 근사 보정입니다.
- 현재 라운드 복구 응답은 `remainingSeconds`를 초 단위로 올림 처리하므로 약 1초 내외의 오차가 발생할 수 있습니다.
- STOMP 이벤트 기반 보정은 메시지 전송 지연만큼 타이머가 늦을 수 있습니다.
- 복구 응답에서 계산한 offset이 있으면 뒤늦게 수신한 STOMP 이벤트가 이를 덮어쓰지 않습니다.
- `types/game.ts`, `gameSchema.ts`는 BE 필드 변경이 없어 수정하지 않았습니다.
- `npm run lint` 통과
  - 기존 `public/mockServiceWorker.js` 경고 1건, 오류 없음
- `npm run build` 통과
  - 기존 번들 청크 크기 경고만 발생

## 📬 Reference
