### PR TITLE
[Fix/#150] STOMP 연결 인증 및 구조화된 오류 처리 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@tanstack/react-query-devtools": "^5.99.0",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -32,11 +33,64 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "jsdom": "^29.1.1",
         "msw": "^2.14.2",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.0",
-        "vite": "^8.0.4"
+        "vite": "^8.0.4",
+        "vitest": "^4.1.10"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -230,6 +284,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -276,6 +340,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -464,6 +681,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -994,6 +1229,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@stomp/stompjs": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.3.0.tgz",
@@ -1324,6 +1566,55 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1333,6 +1624,32 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1723,6 +2040,119 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1796,6 +2226,27 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1814,6 +2265,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1891,6 +2352,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1996,12 +2467,40 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2021,12 +2520,30 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2036,6 +2553,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.335",
@@ -2063,6 +2588,26 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2261,6 +2806,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2276,6 +2831,16 @@
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
       "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -2529,6 +3094,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
@@ -2618,6 +3196,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2652,6 +3237,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -3028,6 +3664,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3036,6 +3683,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -3143,6 +3797,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3213,6 +3881,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3237,6 +3918,13 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3296,6 +3984,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3332,6 +4050,14 @@
       "peerDependencies": {
         "react": "^19.2.5"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-router": {
       "version": "7.14.2",
@@ -3375,6 +4101,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3463,6 +4199,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3507,6 +4256,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
@@ -3558,6 +4314,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -3567,6 +4330,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strict-event-emitter": {
       "version": "0.5.1",
@@ -3629,6 +4399,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -3661,6 +4438,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -3675,6 +4469,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -3708,6 +4512,19 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3795,6 +4612,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -3942,6 +4769,119 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -3965,6 +4905,31 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3979,6 +4944,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {
@@ -4008,6 +4990,23 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@stomp/stompjs": "^7.3.0",
@@ -25,6 +27,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@tanstack/react-query-devtools": "^5.99.0",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -34,10 +37,12 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "jsdom": "^29.1.1",
     "msw": "^2.14.2",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.0",
-    "vite": "^8.0.4"
+    "vite": "^8.0.4",
+    "vitest": "^4.1.10"
   },
   "msw": {
     "workerDirectory": [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { useSocket } from './hooks/useSocket';
 // 공통 컴포넌트
 import { ProtectedRoute } from './components/common/ProtectedRoute';
 import { AppLayout } from './components/common/AppLayout';
+import { SocketErrorToast } from './components/common/SocketErrorToast';
 import { ViewportGuard } from './components/common/ViewportGuard';
 import { GAME_ROUTES } from './constants/game';
 import { LOBBY_ROUTES } from './constants/lobby';
@@ -59,6 +60,7 @@ function AppRoutes() {
 
     return (
         <BrowserRouter>
+            <SocketErrorToast />
             <Routes>
                 <Route path="/" element={<Home />} />
 

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,14 +1,6 @@
-import { refreshAuthSession } from './authApi';
-import { ApiError } from './apiError';
-import { AUTH_ERROR_CODES, AUTH_MESSAGES } from '../constants/auth';
+import { AUTH_ERROR_CODES } from '../constants/auth';
+import { refreshAuthSessionSingleFlight } from '../services/authSessionRefresh';
 import { useAuthStore } from '../store/useAuthStore';
-
-import type {
-    AuthSession,
-    RefreshSessionResponse,
-    RefreshTokenResponse,
-    UserType,
-} from '../types/auth';
 
 const AUTHORIZATION_HEADER = 'Authorization';
 const AUTH_ENTRY_PATH = '/';
@@ -19,22 +11,6 @@ const AUTH_REFRESHABLE_ERROR_CODES = new Set<string>([
     AUTH_ERROR_CODES.UNAUTHENTICATED,
     AUTH_ERROR_CODES.INVALID_AUTHORIZATION,
 ]);
-
-let refreshPromise: Promise<AuthSession> | null = null;
-
-interface SessionIdentityState {
-    userId: number | null;
-    nickname: string | null;
-    userType: UserType | null;
-    userIdentifier: string | null;
-}
-
-interface ValidSessionIdentityState {
-    userId: number;
-    nickname: string;
-    userType: UserType;
-    userIdentifier: string;
-}
 
 function createHeaders(
     input: RequestInfo | URL,
@@ -77,17 +53,6 @@ function redirectToAuthEntry() {
     }
 }
 
-function shouldRedirectToAuthEntry(error: unknown) {
-    if (!(error instanceof ApiError)) {
-        return true;
-    }
-
-    return (
-        error.status === 401 ||
-        (error.code != null && AUTH_REFRESHABLE_ERROR_CODES.has(error.code))
-    );
-}
-
 async function resolveErrorCode(response: Response): Promise<string | null> {
     try {
         const payload = await response.clone().json() as unknown;
@@ -118,110 +83,6 @@ async function shouldRefreshForUnauthorizedResponse(
     return AUTH_REFRESHABLE_ERROR_CODES.has(code);
 }
 
-function hasSessionIdentityFields(
-    state: SessionIdentityState,
-): state is ValidSessionIdentityState {
-    return (
-        state.userId != null &&
-        !!state.nickname &&
-        !!state.userType &&
-        !!state.userIdentifier
-    );
-}
-
-function isRefreshSessionResponse(
-    response: RefreshTokenResponse,
-): response is RefreshSessionResponse {
-    return 'userId' in response;
-}
-
-function createSessionFromRefreshResponse(
-    response: RefreshTokenResponse,
-): AuthSession | null {
-    const state = useAuthStore.getState();
-
-    if (isRefreshSessionResponse(response)) {
-        if (!state.nickname) {
-            return null;
-        }
-
-        return {
-            userId: response.userId,
-            nickname: state.nickname,
-            userType: response.userType,
-            userIdentifier: response.userIdentifier,
-            accessToken: response.accessToken,
-            accessTokenExpiresAt: response.accessTokenExpiresAt,
-            refreshToken: response.refreshToken,
-            refreshTokenExpiresAt: response.refreshTokenExpiresAt,
-        };
-    }
-
-    if (hasSessionIdentityFields(state)) {
-        return {
-            userId: state.userId,
-            nickname: state.nickname,
-            userType: state.userType,
-            userIdentifier: state.userIdentifier,
-            accessToken: response.accessToken,
-            accessTokenExpiresAt: response.accessTokenExpiresAt,
-            refreshToken: response.refreshToken,
-            refreshTokenExpiresAt: response.refreshTokenExpiresAt,
-        };
-    }
-
-    return null;
-}
-
-async function refreshSession(): Promise<AuthSession> {
-    const refreshToken = useAuthStore.getState().refreshToken;
-
-    if (!refreshToken) {
-        useAuthStore.getState().clearSession();
-        redirectToAuthEntry();
-        throw new ApiError(
-            401,
-            AUTH_MESSAGES.LOGIN_EXPIRED,
-            AUTH_ERROR_CODES.SESSION_EXPIRED,
-        );
-    }
-
-    try {
-        const refreshResponse = await refreshAuthSession({
-            refreshToken,
-        });
-        const nextSession = createSessionFromRefreshResponse(refreshResponse);
-
-        if (!nextSession) {
-            throw new ApiError(
-                401,
-                AUTH_MESSAGES.INVALID_REFRESH_RESPONSE,
-                AUTH_ERROR_CODES.SESSION_EXPIRED,
-            );
-        }
-
-        useAuthStore.getState().setSession(nextSession);
-
-        return nextSession;
-    } catch (error) {
-        useAuthStore.getState().clearSession();
-        if (shouldRedirectToAuthEntry(error)) {
-            redirectToAuthEntry();
-        }
-        throw error;
-    }
-}
-
-function getRefreshPromise() {
-    if (!refreshPromise) {
-        refreshPromise = refreshSession().finally(() => {
-            refreshPromise = null;
-        });
-    }
-
-    return refreshPromise;
-}
-
 export async function fetchWithAuth(
     input: RequestInfo | URL,
     init?: RequestInit,
@@ -244,7 +105,7 @@ export async function fetchWithAuth(
     const retryAccessToken =
         currentAccessToken && currentAccessToken !== requestAccessToken
             ? currentAccessToken
-            : (await getRefreshPromise()).accessToken;
+            : (await refreshAuthSessionSingleFlight()).accessToken;
 
     const retryResponse = await fetch(
         input,

--- a/src/components/common/SocketErrorToast.tsx
+++ b/src/components/common/SocketErrorToast.tsx
@@ -1,0 +1,33 @@
+import { X } from 'lucide-react';
+
+import { useSocketStore } from '../../store/useSocketStore';
+
+export function SocketErrorToast() {
+    const lastError = useSocketStore((state) => state.lastError);
+    const dismissError = useSocketStore((state) => state.dismissError);
+
+    if (!lastError) {
+        return null;
+    }
+
+    return (
+        <div
+            role="status"
+            aria-live="polite"
+            className="fixed right-4 bottom-4 z-50 flex max-w-[min(360px,calc(100vw-32px))] items-start gap-3 rounded-md border border-[var(--monomat-border-input)] bg-white px-4 py-3 text-sm text-[var(--monomat-text)] shadow-lg"
+        >
+            <p className="min-w-0 flex-1 leading-5 break-words">
+                {lastError.message}
+            </p>
+            <button
+                type="button"
+                aria-label="WebSocket 오류 알림 닫기"
+                className="shrink-0 rounded p-1 text-[var(--monomat-text-muted)] hover:bg-[var(--monomat-page-bg)] hover:text-[var(--monomat-text)]"
+                onClick={dismissError}
+            >
+                <X aria-hidden="true" size={16} />
+            </button>
+        </div>
+    );
+}
+

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -1,6 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useAuthStore } from '../store/useAuthStore';
 import { useSocketStore } from '../store/useSocketStore';
+
+const SOCKET_UNMOUNT_DISCONNECT_DELAY_MS = 0;
 
 // 소켓의 생명주기(연결/해제)를 관리하는 커스텀 훅입니다.
 // App.tsx처럼 인증된 사용자가 접근하는 최상위 컴포넌트에서 한 번만 호출합니다.
@@ -10,8 +12,15 @@ export function useSocket() {
     const accessToken = useAuthStore((state) => state.accessToken);
     const connect = useSocketStore((state) => state.connect);
     const disconnect = useSocketStore((state) => state.disconnect);
+    const unmountDisconnectTimerRef =
+        useRef<ReturnType<typeof setTimeout> | null>(null);
 
     useEffect(() => {
+        if (unmountDisconnectTimerRef.current) {
+            clearTimeout(unmountDisconnectTimerRef.current);
+            unmountDisconnectTimerRef.current = null;
+        }
+
         if (!isHydrated) {
             return;
         }
@@ -26,7 +35,14 @@ export function useSocket() {
 
     useEffect(() => {
         return () => {
-            void disconnect();
+            if (unmountDisconnectTimerRef.current) {
+                clearTimeout(unmountDisconnectTimerRef.current);
+            }
+
+            unmountDisconnectTimerRef.current = setTimeout(() => {
+                unmountDisconnectTimerRef.current = null;
+                void disconnect();
+            }, SOCKET_UNMOUNT_DISCONNECT_DELAY_MS);
         };
     }, [disconnect]);
 }

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -4,19 +4,29 @@ import { useSocketStore } from '../store/useSocketStore';
 
 // 소켓의 생명주기(연결/해제)를 관리하는 커스텀 훅입니다.
 // App.tsx처럼 인증된 사용자가 접근하는 최상위 컴포넌트에서 한 번만 호출합니다.
-// WebSocket 식별자는 FE가 직접 만든 UUID가 아니라 BE가 발급한 userIdentifier를 사용합니다.
+// WebSocket CONNECT 인증은 BE가 발급한 Access Token을 사용합니다.
 export function useSocket() {
-    const userIdentifier = useAuthStore((state) => state.userIdentifier);
+    const isHydrated = useAuthStore((state) => state.isHydrated);
+    const accessToken = useAuthStore((state) => state.accessToken);
     const connect = useSocketStore((state) => state.connect);
     const disconnect = useSocketStore((state) => state.disconnect);
 
     useEffect(() => {
-        if (!userIdentifier) return;
+        if (!isHydrated) {
+            return;
+        }
 
-        connect(userIdentifier);
+        if (!accessToken) {
+            void disconnect();
+            return;
+        }
 
+        void connect(accessToken);
+    }, [isHydrated, accessToken, connect, disconnect]);
+
+    useEffect(() => {
         return () => {
             void disconnect();
         };
-    }, [userIdentifier, connect, disconnect]);
+    }, [disconnect]);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,11 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import './index.css';
 import App from './App.tsx';
+import { queryClient } from './services/queryClient';
 
 const ENABLE_MSW = import.meta.env.VITE_ENABLE_MSW === 'true';
 
@@ -25,18 +26,6 @@ async function enableMocking() {
         onUnhandledRequest: 'bypass',
     });
 }
-
-// QueryClient 인스턴스 생성
-// 포커스가 바뀔 때마다 데이터를 다시 가져오면 성능에 영향을 줄 수 있어 설정을 조정
-const queryClient = new QueryClient({
-    defaultOptions: {
-        queries: {
-            staleTime: 1000 * 60 * 5,
-            refetchOnWindowFocus: false,
-            retry: 1,
-        },
-    },
-});
 
 enableMocking().then(() => {
     createRoot(document.getElementById('root')!).render(

--- a/src/schemas/stompErrorSchema.ts
+++ b/src/schemas/stompErrorSchema.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+import { STOMP_ERROR_ACTIONS } from '../types/socket';
+
+import type { StompErrorPayload } from '../types/socket';
+
+const FALLBACK_STOMP_ERROR_MESSAGE =
+    'WebSocket 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+
+export const stompErrorPayloadSchema = z.object({
+    type: z.literal('STOMP_ERROR'),
+    code: z.string().min(1),
+    message: z.string(),
+    action: z.enum(STOMP_ERROR_ACTIONS),
+    recoverable: z.boolean(),
+    timestamp: z.string().min(1),
+});
+
+export function createFallbackStompErrorPayload(): StompErrorPayload {
+    return {
+        type: 'STOMP_ERROR',
+        code: 'MALFORMED_STOMP_ERROR',
+        message: FALLBACK_STOMP_ERROR_MESSAGE,
+        action: 'RETRY_CONNECT',
+        recoverable: true,
+        timestamp: new Date().toISOString(),
+    };
+}
+
+export function parseStompErrorPayload(body: string | undefined) {
+    if (!body?.trim()) {
+        return createFallbackStompErrorPayload();
+    }
+
+    try {
+        const payload = JSON.parse(body) as unknown;
+        const parsed = stompErrorPayloadSchema.safeParse(payload);
+
+        if (!parsed.success) {
+            return createFallbackStompErrorPayload();
+        }
+
+        return parsed.data;
+    } catch {
+        return createFallbackStompErrorPayload();
+    }
+}
+

--- a/src/services/authSessionRefresh.test.ts
+++ b/src/services/authSessionRefresh.test.ts
@@ -1,0 +1,241 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    refreshAuthSessionSingleFlight,
+    resetAuthSessionRefreshForTest,
+} from './authSessionRefresh';
+import { useAuthStore } from '../store/useAuthStore';
+
+import type { AuthSession, AuthTokenSet } from '../types/auth';
+
+const fetchMock = vi.fn<typeof fetch>();
+
+function createMemoryStorage(): Storage {
+    const values = new Map<string, string>();
+
+    return {
+        get length() {
+            return values.size;
+        },
+        clear: vi.fn(() => {
+            values.clear();
+        }),
+        getItem: vi.fn((key: string) => values.get(key) ?? null),
+        key: vi.fn((index: number) => Array.from(values.keys())[index] ?? null),
+        removeItem: vi.fn((key: string) => {
+            values.delete(key);
+        }),
+        setItem: vi.fn((key: string, value: string) => {
+            values.set(key, value);
+        }),
+    };
+}
+
+function installMemoryStorage() {
+    Object.defineProperty(window, 'localStorage', {
+        value: createMemoryStorage(),
+        configurable: true,
+    });
+    Object.defineProperty(window, 'sessionStorage', {
+        value: createMemoryStorage(),
+        configurable: true,
+    });
+}
+
+function createSession(accessToken = 'access-token'): AuthSession {
+    return {
+        userId: 1,
+        nickname: 'tester',
+        userType: 'REGISTERED',
+        userIdentifier: '11111111-1111-4111-8111-111111111111',
+        accessToken,
+        accessTokenExpiresAt: '2026-07-14T00:00:00Z',
+        refreshToken: 'refresh-token',
+        refreshTokenExpiresAt: '2026-07-15T00:00:00Z',
+    };
+}
+
+function createTokenSet(accessToken: string): AuthTokenSet {
+    return {
+        accessToken,
+        accessTokenExpiresAt: '2026-07-16T00:00:00Z',
+        refreshToken: `${accessToken}-refresh-token`,
+        refreshTokenExpiresAt: '2026-07-17T00:00:00Z',
+    };
+}
+
+function createJsonResponse(payload: unknown, status = 200) {
+    return new Response(JSON.stringify(payload), {
+        status,
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    });
+}
+
+function createDeferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+
+    return {
+        promise,
+        resolve,
+        reject,
+    };
+}
+
+function resetAuthStoreState() {
+    useAuthStore.setState({
+        userId: null,
+        userIdentifier: null,
+        nickname: null,
+        userType: null,
+        accessToken: null,
+        accessTokenExpiresAt: null,
+        refreshToken: null,
+        refreshTokenExpiresAt: null,
+        isGuest: false,
+        isHydrated: true,
+    });
+}
+
+beforeEach(() => {
+    installMemoryStorage();
+    resetAuthSessionRefreshForTest();
+    resetAuthStoreState();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+    resetAuthSessionRefreshForTest();
+    resetAuthStoreState();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    fetchMock.mockReset();
+    vi.unstubAllGlobals();
+});
+
+describe('refreshAuthSessionSingleFlight', () => {
+    it('동시 호출은 같은 Promise와 하나의 Refresh API 호출을 공유한다', async () => {
+        useAuthStore.setState({
+            ...createSession(),
+            isGuest: false,
+            isHydrated: true,
+        });
+        const deferred = createDeferred<Response>();
+
+        fetchMock.mockReturnValueOnce(deferred.promise);
+
+        const firstPromise = refreshAuthSessionSingleFlight();
+        const secondPromise = refreshAuthSessionSingleFlight();
+
+        expect(firstPromise).toBe(secondPromise);
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        deferred.resolve(createJsonResponse(createTokenSet('new-access-token')));
+
+        const [firstSession, secondSession] = await Promise.all([
+            firstPromise,
+            secondPromise,
+        ]);
+
+        expect(firstSession).toBe(secondSession);
+        expect(firstSession.accessToken).toBe('new-access-token');
+        expect(useAuthStore.getState().accessToken).toBe('new-access-token');
+    });
+
+    it('완료 후에는 refreshPromise가 정리되어 다음 호출이 새 fetch를 실행한다', async () => {
+        useAuthStore.setState({
+            ...createSession(),
+            isGuest: false,
+            isHydrated: true,
+        });
+        fetchMock
+            .mockResolvedValueOnce(
+                createJsonResponse(createTokenSet('first-new-token')),
+            )
+            .mockResolvedValueOnce(
+                createJsonResponse(createTokenSet('second-new-token')),
+            );
+
+        const firstSession = await refreshAuthSessionSingleFlight();
+        const secondSession = await refreshAuthSessionSingleFlight();
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(firstSession.accessToken).toBe('first-new-token');
+        expect(secondSession.accessToken).toBe('second-new-token');
+        expect(useAuthStore.getState().accessToken).toBe('second-new-token');
+    });
+
+    it('실패 후에도 refreshPromise가 정리되어 새 세션으로 재호출할 수 있다', async () => {
+        useAuthStore.setState({
+            ...createSession(),
+            isGuest: false,
+            isHydrated: true,
+        });
+        const failedResponse = createJsonResponse(
+            {
+                code: 'SESSION_EXPIRED',
+                message: '세션이 만료되었습니다.',
+            },
+            401,
+        );
+
+        fetchMock.mockResolvedValueOnce(failedResponse);
+
+        const firstPromise = refreshAuthSessionSingleFlight();
+        const secondPromise = refreshAuthSessionSingleFlight();
+
+        expect(firstPromise).toBe(secondPromise);
+        await expect(firstPromise).rejects.toThrow();
+        await expect(secondPromise).rejects.toThrow();
+        expect(useAuthStore.getState().accessToken).toBeNull();
+
+        useAuthStore.setState({
+            ...createSession('restored-access-token'),
+            isGuest: false,
+            isHydrated: true,
+        });
+        fetchMock.mockResolvedValueOnce(
+            createJsonResponse(createTokenSet('recovered-access-token')),
+        );
+
+        const recoveredSession = await refreshAuthSessionSingleFlight();
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(recoveredSession.accessToken).toBe('recovered-access-token');
+        expect(useAuthStore.getState().accessToken).toBe(
+            'recovered-access-token',
+        );
+    });
+
+    it('REST와 STOMP가 같은 refreshAuthSessionSingleFlight import를 사용한다', () => {
+        const apiClientSource = readFileSync(
+            resolve(process.cwd(), 'src/api/apiClient.ts'),
+            'utf8',
+        );
+        const socketStoreSource = readFileSync(
+            resolve(process.cwd(), 'src/store/useSocketStore.ts'),
+            'utf8',
+        );
+
+        expect(apiClientSource).toContain(
+            "import { refreshAuthSessionSingleFlight } from '../services/authSessionRefresh';",
+        );
+        expect(socketStoreSource).toContain(
+            "import { refreshAuthSessionSingleFlight } from '../services/authSessionRefresh';",
+        );
+        expect(apiClientSource).not.toContain('refreshPromise');
+        expect(socketStoreSource).not.toContain('refreshPromise');
+    });
+});

--- a/src/services/authSessionRefresh.ts
+++ b/src/services/authSessionRefresh.ts
@@ -1,0 +1,198 @@
+import { API_ENDPOINTS } from '../constants/endpoints';
+import { AUTH_ERROR_CODES, AUTH_MESSAGES } from '../constants/auth';
+import { ApiError, createApiError } from '../api/apiError';
+import { refreshTokenResponseSchema } from '../schemas/authSchema';
+import { useAuthStore } from '../store/useAuthStore';
+
+import type {
+    AuthSession,
+    RefreshSessionResponse,
+    RefreshTokenResponse,
+    UserType,
+} from '../types/auth';
+
+const JSON_CONTENT_TYPE = 'application/json';
+const AUTH_ENTRY_PATH = '/';
+
+const AUTH_REFRESHABLE_ERROR_CODES = new Set<string>([
+    AUTH_ERROR_CODES.INVALID_REFRESH_TOKEN,
+    AUTH_ERROR_CODES.SESSION_EXPIRED,
+    AUTH_ERROR_CODES.UNAUTHENTICATED,
+    AUTH_ERROR_CODES.INVALID_AUTHORIZATION,
+]);
+
+let refreshPromise: Promise<AuthSession> | null = null;
+
+interface SessionIdentityState {
+    userId: number | null;
+    nickname: string | null;
+    userType: UserType | null;
+    userIdentifier: string | null;
+}
+
+interface ValidSessionIdentityState {
+    userId: number;
+    nickname: string;
+    userType: UserType;
+    userIdentifier: string;
+}
+
+function hasSessionIdentityFields(
+    state: SessionIdentityState,
+): state is ValidSessionIdentityState {
+    return (
+        state.userId != null &&
+        !!state.nickname &&
+        !!state.userType &&
+        !!state.userIdentifier
+    );
+}
+
+function isRefreshSessionResponse(
+    response: RefreshTokenResponse,
+): response is RefreshSessionResponse {
+    return 'userId' in response;
+}
+
+function createSessionFromRefreshResponse(
+    response: RefreshTokenResponse,
+): AuthSession | null {
+    const state = useAuthStore.getState();
+
+    if (isRefreshSessionResponse(response)) {
+        if (!state.nickname) {
+            return null;
+        }
+
+        return {
+            userId: response.userId,
+            nickname: state.nickname,
+            userType: response.userType,
+            userIdentifier: response.userIdentifier,
+            accessToken: response.accessToken,
+            accessTokenExpiresAt: response.accessTokenExpiresAt,
+            refreshToken: response.refreshToken,
+            refreshTokenExpiresAt: response.refreshTokenExpiresAt,
+        };
+    }
+
+    if (hasSessionIdentityFields(state)) {
+        return {
+            userId: state.userId,
+            nickname: state.nickname,
+            userType: state.userType,
+            userIdentifier: state.userIdentifier,
+            accessToken: response.accessToken,
+            accessTokenExpiresAt: response.accessTokenExpiresAt,
+            refreshToken: response.refreshToken,
+            refreshTokenExpiresAt: response.refreshTokenExpiresAt,
+        };
+    }
+
+    return null;
+}
+
+function redirectToAuthEntry() {
+    if (
+        typeof window !== 'undefined' &&
+        window.location.pathname !== AUTH_ENTRY_PATH
+    ) {
+        window.location.replace(AUTH_ENTRY_PATH);
+    }
+}
+
+function shouldRedirectToAuthEntry(error: unknown) {
+    if (!(error instanceof ApiError)) {
+        return true;
+    }
+
+    return (
+        error.status === 401 ||
+        (error.code != null && AUTH_REFRESHABLE_ERROR_CODES.has(error.code))
+    );
+}
+
+async function requestRefreshSession(
+    refreshToken: string,
+): Promise<RefreshTokenResponse> {
+    const response = await fetch(API_ENDPOINTS.AUTH.REFRESH, {
+        method: 'POST',
+        headers: {
+            'Content-Type': JSON_CONTENT_TYPE,
+        },
+        body: JSON.stringify({ refreshToken }),
+    });
+
+    if (!response.ok) {
+        throw await createApiError(
+            response,
+            AUTH_MESSAGES.SESSION_REFRESH_FAILED,
+        );
+    }
+
+    const payload = await response.json() as unknown;
+    const parsed = refreshTokenResponseSchema.safeParse(payload);
+
+    if (!parsed.success) {
+        console.error(
+            '[authSessionRefresh] 토큰 갱신 응답 검증 실패:',
+            parsed.error,
+        );
+
+        throw new ApiError(500, AUTH_MESSAGES.INVALID_REFRESH_RESPONSE);
+    }
+
+    return parsed.data;
+}
+
+async function refreshSession(): Promise<AuthSession> {
+    const refreshToken = useAuthStore.getState().refreshToken;
+
+    if (!refreshToken) {
+        useAuthStore.getState().clearSession();
+        redirectToAuthEntry();
+        throw new ApiError(
+            401,
+            AUTH_MESSAGES.LOGIN_EXPIRED,
+            AUTH_ERROR_CODES.SESSION_EXPIRED,
+        );
+    }
+
+    try {
+        const refreshResponse = await requestRefreshSession(refreshToken);
+        const nextSession = createSessionFromRefreshResponse(refreshResponse);
+
+        if (!nextSession) {
+            throw new ApiError(
+                401,
+                AUTH_MESSAGES.INVALID_REFRESH_RESPONSE,
+                AUTH_ERROR_CODES.SESSION_EXPIRED,
+            );
+        }
+
+        useAuthStore.getState().setSession(nextSession);
+
+        return nextSession;
+    } catch (error) {
+        useAuthStore.getState().clearSession();
+        if (shouldRedirectToAuthEntry(error)) {
+            redirectToAuthEntry();
+        }
+        throw error;
+    }
+}
+
+export function refreshAuthSessionSingleFlight(): Promise<AuthSession> {
+    if (!refreshPromise) {
+        refreshPromise = refreshSession().finally(() => {
+            refreshPromise = null;
+        });
+    }
+
+    return refreshPromise;
+}
+
+export function resetAuthSessionRefreshForTest() {
+    refreshPromise = null;
+}
+

--- a/src/services/queryClient.ts
+++ b/src/services/queryClient.ts
@@ -1,0 +1,12 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+    defaultOptions: {
+        queries: {
+            staleTime: 1000 * 60 * 5,
+            refetchOnWindowFocus: false,
+            retry: 1,
+        },
+    },
+});
+

--- a/src/store/useSocketStore.test.tsx
+++ b/src/store/useSocketStore.test.tsx
@@ -1,0 +1,365 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useSocket } from '../hooks/useSocket';
+import { useAuthStore } from './useAuthStore';
+import {
+    configureSocketStoreForTest,
+    resetSocketStoreForTest,
+    useSocketStore,
+} from './useSocketStore';
+
+import type { IFrame, StompConfig } from '@stomp/stompjs';
+import type { AuthSession } from '../types/auth';
+
+class MockStompClient {
+    active = false;
+    reconnectDelay = -1;
+    deactivate = vi.fn(async () => {
+        this.active = false;
+    });
+    activate = vi.fn(() => {
+        this.active = true;
+    });
+    publish = vi.fn();
+    subscribe = vi.fn(() => ({
+        unsubscribe: vi.fn(),
+    }));
+
+    constructor(readonly config: StompConfig) {
+        this.reconnectDelay = config.reconnectDelay ?? -1;
+    }
+}
+
+const createClientMock = vi.fn((config: StompConfig) =>
+    new MockStompClient(config) as never,
+);
+const refreshSessionMock = vi.fn<() => Promise<AuthSession>>();
+const invalidateQueriesMock = vi.fn<() => Promise<unknown>>();
+const clearSessionMock = vi.fn();
+const resetGameMock = vi.fn();
+const replaceLocationMock = vi.fn();
+
+function createSession(accessToken: string): AuthSession {
+    return {
+        userId: 1,
+        nickname: 'tester',
+        userType: 'REGISTERED',
+        userIdentifier: '11111111-1111-4111-8111-111111111111',
+        accessToken,
+        accessTokenExpiresAt: '2026-07-14T00:00:00Z',
+        refreshToken: 'refresh-token',
+        refreshTokenExpiresAt: '2026-07-15T00:00:00Z',
+    };
+}
+
+function getClient(index: number) {
+    return createClientMock.mock.results[index]?.value as MockStompClient;
+}
+
+function createErrorFrame(
+    code: string,
+    action: string,
+    recoverable: boolean,
+): IFrame {
+    return {
+        body: JSON.stringify({
+            type: 'STOMP_ERROR',
+            code,
+            message: `${code} message`,
+            action,
+            recoverable,
+            timestamp: '2026-07-14T00:00:00Z',
+        }),
+        headers: {},
+    } as IFrame;
+}
+
+async function flushAsync() {
+    for (let index = 0; index < 10; index += 1) {
+        await Promise.resolve();
+    }
+}
+
+function resetAuthStoreState() {
+    useAuthStore.setState({
+        userId: null,
+        userIdentifier: null,
+        nickname: null,
+        userType: null,
+        accessToken: null,
+        accessTokenExpiresAt: null,
+        refreshToken: null,
+        refreshTokenExpiresAt: null,
+        isGuest: false,
+        isHydrated: true,
+    });
+}
+
+function SocketHarness() {
+    useSocket();
+    return null;
+}
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    createClientMock.mockClear();
+    refreshSessionMock.mockReset();
+    invalidateQueriesMock.mockReset();
+    clearSessionMock.mockClear();
+    resetGameMock.mockClear();
+    replaceLocationMock.mockClear();
+    invalidateQueriesMock.mockResolvedValue(undefined);
+    resetSocketStoreForTest();
+    configureSocketStoreForTest({
+        createClient: createClientMock,
+        refreshSession: refreshSessionMock,
+        invalidateQueries: invalidateQueriesMock,
+        clearSession: clearSessionMock,
+        resetGame: resetGameMock,
+        replaceLocation: replaceLocationMock,
+        defer: () => Promise.resolve(),
+    });
+    useAuthStore.setState({
+        ...createSession('access-token'),
+        isGuest: false,
+        isHydrated: true,
+    });
+});
+
+afterEach(() => {
+    cleanup();
+    resetSocketStoreForTest();
+    resetAuthStoreState();
+    vi.useRealTimers();
+});
+
+describe('useSocketStore connection auth', () => {
+    it('Access Token을 Authorization Bearer CONNECT 헤더에 넣고 userIdentifier 헤더를 제거한다', async () => {
+        await useSocketStore.getState().connect('access-token');
+
+        expect(createClientMock).toHaveBeenCalledTimes(1);
+        expect(getClient(0).config.connectHeaders).toMatchObject({
+            Authorization: 'Bearer access-token',
+        });
+        expect(getClient(0).config.connectHeaders).not.toHaveProperty(
+            'userIdentifier',
+        );
+        expect(getClient(0).config.reconnectDelay).toBe(0);
+    });
+
+    it('Access Token이 없으면 Client를 생성하지 않는다', async () => {
+        await useSocketStore.getState().connect(null);
+
+        expect(createClientMock).not.toHaveBeenCalled();
+        expect(useSocketStore.getState().connectionStatus).toBe(
+            'disconnected',
+        );
+    });
+});
+
+describe('useSocketStore token changes', () => {
+    it('같은 토큰으로 connect를 반복해도 Client를 하나만 생성한다', async () => {
+        await useSocketStore.getState().connect('access-token');
+        await useSocketStore.getState().connect('access-token');
+
+        expect(createClientMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('Access Token 변경 시 기존 Client를 종료하고 새 토큰으로 Client를 생성한다', async () => {
+        await useSocketStore.getState().connect('access-token');
+        const firstClient = getClient(0);
+
+        await useSocketStore.getState().connect('next-token');
+
+        expect(firstClient.deactivate).toHaveBeenCalledTimes(1);
+        expect(createClientMock).toHaveBeenCalledTimes(2);
+        expect(getClient(1).config.connectHeaders).toMatchObject({
+            Authorization: 'Bearer next-token',
+        });
+    });
+});
+
+describe('useSocketStore disconnect', () => {
+    it('로그아웃 시 Client와 예약된 retry timer를 정리하고 이전 close callback이 재연결하지 않는다', async () => {
+        await useSocketStore.getState().connect('access-token');
+        const firstClient = getClient(0);
+
+        firstClient.config.onWebSocketClose?.({} as CloseEvent);
+        await useSocketStore.getState().disconnect();
+        firstClient.config.onWebSocketClose?.({} as CloseEvent);
+        await vi.advanceTimersByTimeAsync(10_000);
+
+        expect(firstClient.deactivate).toHaveBeenCalledTimes(1);
+        expect(createClientMock).toHaveBeenCalledTimes(1);
+        expect(useSocketStore.getState().connectionStatus).toBe(
+            'disconnected',
+        );
+    });
+});
+
+describe('useSocketStore STOMP error recovery', () => {
+    it('ACCESS_TOKEN_EXPIRED + REFRESH_TOKEN은 refresh 후 새 토큰으로 연결한다', async () => {
+        refreshSessionMock.mockResolvedValue(createSession('refreshed-token'));
+        await useSocketStore.getState().connect('access-token');
+
+        getClient(0).config.onStompError?.(
+            createErrorFrame('ACCESS_TOKEN_EXPIRED', 'REFRESH_TOKEN', true),
+        );
+        await flushAsync();
+
+        expect(refreshSessionMock).toHaveBeenCalledTimes(1);
+        expect(createClientMock).toHaveBeenCalledTimes(2);
+        expect(getClient(1).config.connectHeaders).toMatchObject({
+            Authorization: 'Bearer refreshed-token',
+        });
+    });
+
+    it('동일 REFRESH_TOKEN 오류 반복 시 refresh와 Client 교체를 한 번만 수행한다', async () => {
+        refreshSessionMock.mockResolvedValue(createSession('refreshed-token'));
+        await useSocketStore.getState().connect('access-token');
+        const frame = createErrorFrame(
+            'ACCESS_TOKEN_EXPIRED',
+            'REFRESH_TOKEN',
+            true,
+        );
+
+        getClient(0).config.onStompError?.(frame);
+        getClient(0).config.onStompError?.(frame);
+        await flushAsync();
+
+        expect(refreshSessionMock).toHaveBeenCalledTimes(1);
+        expect(createClientMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('ACCESS_TOKEN_INVALID + RELOGIN은 세션과 게임 상태를 초기화하고 /로 이동한다', async () => {
+        await useSocketStore.getState().connect('access-token');
+
+        getClient(0).config.onStompError?.(
+            createErrorFrame('ACCESS_TOKEN_INVALID', 'RELOGIN', false),
+        );
+        await flushAsync();
+
+        expect(clearSessionMock).toHaveBeenCalledTimes(1);
+        expect(resetGameMock).toHaveBeenCalledTimes(1);
+        expect(replaceLocationMock).toHaveBeenCalledWith('/');
+        expect(createClientMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('SESSION_REVOKED + RELOGIN은 세션을 초기화한다', async () => {
+        await useSocketStore.getState().connect('access-token');
+
+        getClient(0).config.onStompError?.(
+            createErrorFrame('SESSION_REVOKED', 'RELOGIN', false),
+        );
+        await flushAsync();
+
+        expect(clearSessionMock).toHaveBeenCalledTimes(1);
+        expect(resetGameMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('LOBBY_STALE_SESSION + RECONNECT는 제한된 횟수만 재연결한다', async () => {
+        await useSocketStore.getState().connect('access-token');
+
+        for (let index = 0; index < 4; index += 1) {
+            getClient(index).config.onStompError?.(
+                createErrorFrame('LOBBY_STALE_SESSION', 'RECONNECT', true),
+            );
+            await flushAsync();
+            await vi.advanceTimersByTimeAsync(5_000);
+            await flushAsync();
+        }
+
+        expect(createClientMock).toHaveBeenCalledTimes(4);
+        expect(useSocketStore.getState().connectionStatus).toBe(
+            'disconnected',
+        );
+    });
+
+    it('RETURN_TO_LOBBY_LIST는 게임 상태를 초기화하고 /lobbies로 이동한 뒤 한 번만 복구한다', async () => {
+        await useSocketStore.getState().connect('access-token');
+
+        getClient(0).config.onStompError?.(
+            createErrorFrame(
+                'LOBBY_NOT_FOUND',
+                'RETURN_TO_LOBBY_LIST',
+                false,
+            ),
+        );
+        await flushAsync();
+
+        expect(resetGameMock).toHaveBeenCalledTimes(1);
+        expect(replaceLocationMock).toHaveBeenCalledWith('/lobbies');
+        expect(createClientMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('REFRESH_AND_RETRY는 query invalidation 후 제한 재연결을 예약한다', async () => {
+        await useSocketStore.getState().connect('access-token');
+
+        getClient(0).config.onStompError?.(
+            createErrorFrame(
+                'LOBBY_INVALID_SEQUENCE',
+                'REFRESH_AND_RETRY',
+                true,
+            ),
+        );
+        await flushAsync();
+
+        expect(invalidateQueriesMock).toHaveBeenCalledTimes(1);
+        expect(createClientMock).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        await flushAsync();
+
+        expect(createClientMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('malformed ERROR body는 throw되지 않고 fallback 오류로 제한 재연결한다', async () => {
+        await useSocketStore.getState().connect('access-token');
+
+        expect(() => {
+            getClient(0).config.onStompError?.({
+                body: 'not-json',
+                headers: {},
+            } as IFrame);
+        }).not.toThrow();
+        await flushAsync();
+
+        expect(useSocketStore.getState().lastError?.code).toBe(
+            'MALFORMED_STOMP_ERROR',
+        );
+        await vi.advanceTimersByTimeAsync(1_000);
+        await flushAsync();
+        expect(createClientMock).toHaveBeenCalledTimes(2);
+    });
+});
+
+describe('React lifecycle', () => {
+    it('mount-cleanup-mount 후 최종 활성 Client는 하나만 유지된다', async () => {
+        const firstRender = render(<SocketHarness />);
+
+        await flushAsync();
+        firstRender.unmount();
+        await flushAsync();
+        render(<SocketHarness />);
+        await flushAsync();
+
+        const activeClients = createClientMock.mock.results
+            .map((result) => result.value as MockStompClient)
+            .filter((client) => client.active);
+
+        expect(createClientMock).toHaveBeenCalledTimes(2);
+        expect(activeClients).toHaveLength(1);
+    });
+
+    it('effect cleanup 이후 이전 Client callback은 현재 상태를 덮어쓰지 않는다', async () => {
+        await useSocketStore.getState().connect('access-token');
+        const firstClient = getClient(0);
+
+        await useSocketStore.getState().connect('next-token');
+        firstClient.config.onConnect?.({} as IFrame);
+
+        expect(useSocketStore.getState().stompClient).toBe(getClient(1));
+        expect(useSocketStore.getState().connectionStatus).toBe('connecting');
+    });
+});

--- a/src/store/useSocketStore.test.tsx
+++ b/src/store/useSocketStore.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react';
 import { cleanup, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -332,6 +333,63 @@ describe('useSocketStore STOMP error recovery', () => {
         await flushAsync();
         expect(createClientMock).toHaveBeenCalledTimes(2);
     });
+
+    it('WebSocket close 이후 재연결에 성공하면 복구된 오류 Toast를 정리한다', async () => {
+        await useSocketStore.getState().connect('access-token');
+
+        getClient(0).config.onWebSocketClose?.({} as CloseEvent);
+
+        expect(useSocketStore.getState().lastError?.code).toBe(
+            'WEBSOCKET_CLOSED',
+        );
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        await flushAsync();
+
+        expect(createClientMock).toHaveBeenCalledTimes(2);
+
+        getClient(1).config.onConnect?.({} as IFrame);
+
+        expect(useSocketStore.getState().lastError).toBeNull();
+        expect(useSocketStore.getState().connectionStatus).toBe('connected');
+    });
+
+    it('NONE + recoverable=true 이후 close callback은 자동 재연결을 예약하지 않는다', async () => {
+        await useSocketStore.getState().connect('access-token');
+
+        getClient(0).config.onStompError?.(
+            createErrorFrame('NO_RECOVERY_REQUIRED', 'NONE', true),
+        );
+        await flushAsync();
+
+        const lastError = useSocketStore.getState().lastError;
+
+        getClient(0).config.onWebSocketClose?.({} as CloseEvent);
+        await vi.advanceTimersByTimeAsync(10_000);
+        await flushAsync();
+
+        expect(createClientMock).toHaveBeenCalledTimes(1);
+        expect(useSocketStore.getState().connectionStatus).toBe(
+            'disconnected',
+        );
+        expect(useSocketStore.getState().lastError).toBe(lastError);
+    });
+
+    it('RETRY_CONNECT action은 기존 제한 backoff 정책으로 새 Client를 생성한다', async () => {
+        await useSocketStore.getState().connect('access-token');
+
+        getClient(0).config.onStompError?.(
+            createErrorFrame('CONNECT_WS_SESSION_ID_MISSING', 'RETRY_CONNECT', true),
+        );
+        await flushAsync();
+
+        expect(createClientMock).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        await flushAsync();
+
+        expect(createClientMock).toHaveBeenCalledTimes(2);
+    });
 });
 
 describe('React lifecycle', () => {
@@ -348,8 +406,39 @@ describe('React lifecycle', () => {
             .map((result) => result.value as MockStompClient)
             .filter((client) => client.active);
 
-        expect(createClientMock).toHaveBeenCalledTimes(2);
+        expect(createClientMock).toHaveBeenCalled();
+        expect(createClientMock).toHaveBeenCalledTimes(activeClients.length);
         expect(activeClients).toHaveLength(1);
+    });
+
+    it('StrictMode effect 재실행 후 최종 활성 Client는 하나만 유지된다', async () => {
+        render(
+            <StrictMode>
+                <SocketHarness />
+            </StrictMode>,
+        );
+
+        await flushAsync();
+
+        const clients = createClientMock.mock.results.map(
+            (result) => result.value as MockStompClient,
+        );
+        const activeClients = clients.filter((client) => client.active);
+        const lastClient = clients.at(-1);
+
+        expect(clients.length).toBeGreaterThan(0);
+        expect(clients.length).toBeLessThanOrEqual(2);
+        expect(activeClients).toHaveLength(1);
+        expect(activeClients[0]).toBe(lastClient);
+
+        for (const endedClient of clients.slice(0, -1)) {
+            expect(endedClient.active).toBe(false);
+            endedClient.config.onConnect?.({} as IFrame);
+        }
+
+        if (lastClient) {
+            expect(useSocketStore.getState().stompClient).toBe(lastClient);
+        }
     });
 
     it('effect cleanup 이후 이전 Client callback은 현재 상태를 덮어쓰지 않는다', async () => {

--- a/src/store/useSocketStore.ts
+++ b/src/store/useSocketStore.ts
@@ -3,145 +3,547 @@ import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
 
 import { WS_ENDPOINT } from '../constants/endpoints';
+import { LOBBY_ROUTES } from '../constants/lobby';
+import { parseStompErrorPayload } from '../schemas/stompErrorSchema';
+import { refreshAuthSessionSingleFlight } from '../services/authSessionRefresh';
+import { queryClient } from '../services/queryClient';
+import { useAuthStore } from './useAuthStore';
+import { useGameStore } from './useGameStore';
+
+import type { IFrame, StompConfig } from '@stomp/stompjs';
+import type { SocketErrorNotice, StompErrorPayload } from '../types/socket';
 
 type ConnectionStatus = 'disconnected' | 'connecting' | 'connected';
 
 interface SocketState {
     stompClient: Client | null;
     connectionStatus: ConnectionStatus;
-    shouldReconnect: boolean;
-    connect: (uuid: string) => void;
+    lastError: SocketErrorNotice | null;
+    connect: (accessToken: string | null) => Promise<void>;
     disconnect: () => Promise<void>;
+    dismissError: () => void;
 }
 
-const RECONNECT_DELAY_MS = 5000;
+interface SocketRuntimeDependencies {
+    createClient: (config: StompConfig) => Client;
+    refreshSession: typeof refreshAuthSessionSingleFlight;
+    invalidateQueries: () => Promise<unknown>;
+    clearSession: () => void;
+    resetGame: () => void;
+    replaceLocation: (path: string) => void;
+    defer: () => Promise<void>;
+}
+
+interface DeactivateOptions {
+    clearState?: boolean;
+    preserveToken?: boolean;
+    intentional?: boolean;
+}
+
+interface ReplaceClientOptions {
+    preserveRetryAttempt?: boolean;
+}
+
+const SOCKET_RETRY_DELAYS_MS = [1_000, 3_000, 5_000] as const;
+const SOCKET_ERROR_DEDUPE_WINDOW_MS = 2_000;
+const AUTHORIZATION_HEADER = 'Authorization';
+const AUTH_HEADER_PREFIX = 'Bearer';
+const AUTH_ENTRY_PATH = '/';
+const SOCKET_GENERIC_RETRY_MESSAGE =
+    'WebSocket 연결이 끊어졌습니다. 다시 연결을 시도합니다.';
+const SOCKET_RETRY_EXHAUSTED_MESSAGE =
+    'WebSocket 연결을 복구하지 못했습니다. 잠시 후 다시 시도해주세요.';
+
+function createDefaultClient(config: StompConfig) {
+    return new Client(config);
+}
+
+function replaceLocation(path: string) {
+    if (typeof window === 'undefined') {
+        return;
+    }
+
+    if (window.location.pathname === path) {
+        return;
+    }
+
+    window.history.replaceState(null, '', path);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+}
+
+const defaultDependencies: SocketRuntimeDependencies = {
+    createClient: createDefaultClient,
+    refreshSession: refreshAuthSessionSingleFlight,
+    invalidateQueries: () => queryClient.invalidateQueries(),
+    clearSession: () => useAuthStore.getState().clearSession(),
+    resetGame: () => useGameStore.getState().reset(),
+    replaceLocation,
+    defer: () => new Promise((resolve) => setTimeout(resolve, 0)),
+};
+
+let dependencies: SocketRuntimeDependencies = defaultDependencies;
+let currentClient: Client | null = null;
+let currentAccessToken: string | null = null;
+let currentGeneration = 0;
+let intentionalDisconnect = true;
+let retryAttempt = 0;
+let retryTimer: ReturnType<typeof setTimeout> | null = null;
+let lifecyclePromise: Promise<void> = Promise.resolve();
+let recoveryPromise: Promise<void> | null = null;
+let lastHandledError:
+    | {
+        signature: string;
+        handledAt: number;
+    }
+    | null = null;
+
+function enqueueLifecycle(task: () => Promise<void>) {
+    const nextPromise = lifecyclePromise
+        .catch(() => undefined)
+        .then(task);
+
+    lifecyclePromise = nextPromise.catch(() => undefined);
+
+    return nextPromise;
+}
+
+function isCurrentGeneration(generation: number, client: Client) {
+    return currentGeneration === generation && currentClient === client;
+}
+
+function clearRetryTimer() {
+    if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+    }
+}
+
+function createSocketErrorNotice(
+    payload: StompErrorPayload,
+    signature: string,
+): SocketErrorNotice {
+    return {
+        ...payload,
+        signature,
+    };
+}
+
+function setSocketError(payload: StompErrorPayload, signature: string) {
+    useSocketStore.setState({
+        lastError: createSocketErrorNotice(payload, signature),
+    });
+}
+
+function createRetryExhaustedPayload(): StompErrorPayload {
+    return {
+        type: 'STOMP_ERROR',
+        code: 'SOCKET_RETRY_EXHAUSTED',
+        message: SOCKET_RETRY_EXHAUSTED_MESSAGE,
+        action: 'NONE',
+        recoverable: false,
+        timestamp: new Date().toISOString(),
+    };
+}
+
+async function deactivateCurrentClient(options: DeactivateOptions = {}) {
+    const {
+        clearState = true,
+        preserveToken = false,
+        intentional = true,
+    } = options;
+    const clientToDeactivate = currentClient;
+
+    clearRetryTimer();
+    intentionalDisconnect = intentional;
+    currentGeneration += 1;
+    currentClient = null;
+
+    if (!preserveToken) {
+        currentAccessToken = null;
+    }
+
+    useSocketStore.setState({
+        stompClient: null,
+        connectionStatus: clearState ? 'disconnected' : 'connecting',
+    });
+
+    if (clientToDeactivate) {
+        clientToDeactivate.reconnectDelay = 0;
+
+        try {
+            await clientToDeactivate.deactivate();
+        } catch (error) {
+            console.warn('[Socket] STOMP Client 종료 실패:', error);
+        }
+    }
+
+    if (clearState) {
+        useSocketStore.setState({
+            connectionStatus: 'disconnected',
+        });
+    }
+}
+
+function scheduleRetryWithCurrentToken(reason: string) {
+    const accessToken = currentAccessToken;
+
+    if (!accessToken || intentionalDisconnect) {
+        return;
+    }
+
+    if (retryAttempt >= SOCKET_RETRY_DELAYS_MS.length) {
+        clearRetryTimer();
+        const payload = createRetryExhaustedPayload();
+        const signature = `${currentGeneration}:${payload.code}:${payload.action}`;
+
+        setSocketError(payload, signature);
+        useSocketStore.setState({
+            connectionStatus: 'disconnected',
+        });
+        return;
+    }
+
+    const delayMs = SOCKET_RETRY_DELAYS_MS[retryAttempt];
+    retryAttempt += 1;
+    clearRetryTimer();
+
+    console.info('[Socket] 제한 재연결 예약:', {
+        reason,
+        attempt: retryAttempt,
+        delayMs,
+    });
+
+    useSocketStore.setState({
+        connectionStatus: 'connecting',
+    });
+
+    retryTimer = setTimeout(() => {
+        retryTimer = null;
+
+        const retryAccessToken = currentAccessToken;
+
+        if (!retryAccessToken || intentionalDisconnect) {
+            return;
+        }
+
+        void enqueueLifecycle(() =>
+            replaceClient(retryAccessToken, {
+                preserveRetryAttempt: true,
+            }),
+        );
+    }, delayMs);
+}
+
+async function retryWithBackoff(reason: string) {
+    if (!currentAccessToken) {
+        return;
+    }
+
+    await deactivateCurrentClient({
+        clearState: false,
+        preserveToken: true,
+        intentional: false,
+    });
+
+    scheduleRetryWithCurrentToken(reason);
+}
+
+async function replaceClient(
+    accessToken: string,
+    options: ReplaceClientOptions = {},
+) {
+    if (!accessToken) {
+        await deactivateCurrentClient();
+        return;
+    }
+
+    clearRetryTimer();
+
+    if (!options.preserveRetryAttempt) {
+        retryAttempt = 0;
+    }
+
+    await deactivateCurrentClient({
+        clearState: false,
+        preserveToken: false,
+        intentional: true,
+    });
+
+    const generation = currentGeneration + 1;
+    const client = dependencies.createClient({
+        webSocketFactory: () => new SockJS(WS_ENDPOINT) as WebSocket,
+        connectHeaders: {
+            [AUTHORIZATION_HEADER]: `${AUTH_HEADER_PREFIX} ${accessToken}`,
+        },
+        reconnectDelay: 0,
+        onConnect: () => {
+            if (!isCurrentGeneration(generation, client)) {
+                return;
+            }
+
+            retryAttempt = 0;
+            clearRetryTimer();
+            console.info('[Socket] 연결 성공');
+
+            useSocketStore.setState({
+                connectionStatus: 'connected',
+            });
+        },
+        onDisconnect: () => {
+            if (!isCurrentGeneration(generation, client)) {
+                return;
+            }
+
+            useSocketStore.setState({
+                connectionStatus: intentionalDisconnect
+                    ? 'disconnected'
+                    : 'connecting',
+            });
+        },
+        onStompError: (frame: IFrame) => {
+            if (!isCurrentGeneration(generation, client)) {
+                return;
+            }
+
+            void handleStompError(frame, generation);
+        },
+        onWebSocketError: () => {
+            if (!isCurrentGeneration(generation, client)) {
+                return;
+            }
+
+            console.warn('[Socket] WebSocket 오류 발생');
+        },
+        onWebSocketClose: () => {
+            if (!isCurrentGeneration(generation, client)) {
+                return;
+            }
+
+            if (intentionalDisconnect) {
+                useSocketStore.setState({
+                    connectionStatus: 'disconnected',
+                });
+                return;
+            }
+
+            const payload: StompErrorPayload = {
+                type: 'STOMP_ERROR',
+                code: 'WEBSOCKET_CLOSED',
+                message: SOCKET_GENERIC_RETRY_MESSAGE,
+                action: 'RETRY_CONNECT',
+                recoverable: true,
+                timestamp: new Date().toISOString(),
+            };
+            const signature = `${generation}:${payload.code}:${payload.action}`;
+
+            setSocketError(payload, signature);
+            scheduleRetryWithCurrentToken(payload.code);
+        },
+    });
+
+    currentGeneration = generation;
+    currentClient = client;
+    currentAccessToken = accessToken;
+    intentionalDisconnect = false;
+
+    useSocketStore.setState({
+        stompClient: client,
+        connectionStatus: 'connecting',
+    });
+
+    client.activate();
+}
+
+async function handleRefreshTokenAction() {
+    clearRetryTimer();
+    await deactivateCurrentClient({
+        clearState: false,
+        preserveToken: true,
+        intentional: true,
+    });
+
+    try {
+        const nextSession = await dependencies.refreshSession();
+
+        await replaceClient(nextSession.accessToken);
+    } catch {
+        await handleReloginAction();
+    }
+}
+
+async function handleReloginAction() {
+    clearRetryTimer();
+    await deactivateCurrentClient();
+    dependencies.clearSession();
+    dependencies.resetGame();
+    dependencies.replaceLocation(AUTH_ENTRY_PATH);
+}
+
+async function handleReturnToLobbyListAction() {
+    const accessToken = currentAccessToken ?? useAuthStore.getState().accessToken;
+
+    clearRetryTimer();
+    await deactivateCurrentClient({
+        clearState: false,
+        preserveToken: true,
+        intentional: true,
+    });
+    dependencies.resetGame();
+    dependencies.replaceLocation(LOBBY_ROUTES.LIST);
+    await dependencies.defer();
+
+    if (accessToken) {
+        await replaceClient(accessToken);
+    } else {
+        await deactivateCurrentClient();
+    }
+}
+
+async function handleRefreshAndRetryAction() {
+    await dependencies.invalidateQueries();
+    await retryWithBackoff('REFRESH_AND_RETRY');
+}
+
+async function runRecovery(payload: StompErrorPayload) {
+    switch (payload.action) {
+        case 'REFRESH_TOKEN':
+            await handleRefreshTokenAction();
+            return;
+        case 'RELOGIN':
+            await handleReloginAction();
+            return;
+        case 'RETURN_TO_LOBBY_LIST':
+            await handleReturnToLobbyListAction();
+            return;
+        case 'RECONNECT':
+            await retryWithBackoff(payload.code);
+            return;
+        case 'RETRY_CONNECT':
+            await retryWithBackoff(payload.code);
+            return;
+        case 'REFRESH_AND_RETRY':
+            await handleRefreshAndRetryAction();
+            return;
+        case 'NONE':
+            if (!payload.recoverable) {
+                clearRetryTimer();
+                await deactivateCurrentClient({
+                    clearState: false,
+                    preserveToken: true,
+                    intentional: true,
+                });
+                useSocketStore.setState({
+                    connectionStatus: 'disconnected',
+                });
+            }
+            return;
+    }
+}
+
+async function handleStompError(frame: IFrame, generation: number) {
+    const payload = parseStompErrorPayload(frame.body);
+    const signature = `${generation}:${payload.code}:${payload.action}`;
+    const now = Date.now();
+
+    if (
+        lastHandledError?.signature === signature &&
+        now - lastHandledError.handledAt < SOCKET_ERROR_DEDUPE_WINDOW_MS
+    ) {
+        return;
+    }
+
+    lastHandledError = {
+        signature,
+        handledAt: now,
+    };
+
+    console.warn('[Socket] STOMP 오류 수신:', {
+        code: payload.code,
+        action: payload.action,
+        recoverable: payload.recoverable,
+    });
+
+    setSocketError(payload, signature);
+
+    if (!payload.recoverable && payload.action === 'NONE') {
+        clearRetryTimer();
+    }
+
+    if (recoveryPromise) {
+        return recoveryPromise;
+    }
+
+    recoveryPromise = enqueueLifecycle(() => runRecovery(payload)).finally(() => {
+        recoveryPromise = null;
+    });
+
+    return recoveryPromise;
+}
 
 export const useSocketStore = create<SocketState>((set, get) => ({
     stompClient: null,
     connectionStatus: 'disconnected',
-    shouldReconnect: false,
+    lastError: null,
 
-    connect: (uuid: string) => {
-        const { connectionStatus, stompClient: existingClient } = get();
+    connect: (accessToken) =>
+        enqueueLifecycle(async () => {
+            if (!accessToken) {
+                await deactivateCurrentClient();
+                return;
+            }
 
-        if (connectionStatus === 'connecting' || connectionStatus === 'connected') {
-            console.warn('[Socket] 이미 연결 중이거나 연결된 상태입니다.');
-            return;
-        }
+            const {
+                stompClient: existingClient,
+                connectionStatus,
+            } = get();
 
-        if (existingClient) {
-            existingClient.reconnectDelay = 0;
-            void existingClient.deactivate();
+            if (
+                currentAccessToken === accessToken &&
+                existingClient === currentClient &&
+                (connectionStatus === 'connecting' ||
+                    connectionStatus === 'connected')
+            ) {
+                return;
+            }
 
-            set({
-                stompClient: null,
-                connectionStatus: 'disconnected',
-                shouldReconnect: false,
-            });
-        }
+            await replaceClient(accessToken);
+        }),
 
-        const client = new Client({
-            webSocketFactory: () => new SockJS(WS_ENDPOINT) as WebSocket,
+    disconnect: () =>
+        enqueueLifecycle(async () => {
+            retryAttempt = 0;
+            recoveryPromise = null;
+            await deactivateCurrentClient();
+        }),
 
-            connectHeaders: {
-                userIdentifier: uuid,
-            },
-
-            reconnectDelay: RECONNECT_DELAY_MS,
-
-            onConnect: () => {
-                console.info('[Socket] 연결 성공');
-
-                set({
-                    connectionStatus: 'connected',
-                    shouldReconnect: true,
-                });
-            },
-
-            onDisconnect: () => {
-                console.info('[Socket] STOMP 연결 종료');
-
-                const { shouldReconnect } = get();
-
-                set({
-                    connectionStatus: shouldReconnect ? 'connecting' : 'disconnected',
-                });
-            },
-
-            onStompError: (frame) => {
-                console.error('[Socket] STOMP 에러 발생:', frame.headers['message']);
-
-                set({
-                    connectionStatus: 'connecting',
-                    shouldReconnect: true,
-                });
-            },
-
-            onWebSocketError: (event) => {
-                console.error('[Socket] WebSocket 에러 발생:', event);
-
-                set({
-                    connectionStatus: 'connecting',
-                    shouldReconnect: true,
-                });
-            },
-
-            onWebSocketClose: () => {
-                const { shouldReconnect } = get();
-
-                if (!shouldReconnect) {
-                    console.info('[Socket] WebSocket 연결 종료');
-
-                    set({
-                        connectionStatus: 'disconnected',
-                    });
-
-                    return;
-                }
-
-                console.info('[Socket] WebSocket 연결 종료 - 재연결 대기');
-
-                set({
-                    connectionStatus: 'connecting',
-                });
-            },
-        });
-
-        set({
-            stompClient: client,
-            connectionStatus: 'connecting',
-            shouldReconnect: true,
-        });
-
-        client.activate();
-    },
-
-    disconnect: async () => {
-        const { stompClient } = get();
-
-        set({
-            shouldReconnect: false,
-        });
-
-        if (!stompClient) {
-            set({
-                connectionStatus: 'disconnected',
-            });
-            return;
-        }
-
-        stompClient.reconnectDelay = 0;
-
-        if (stompClient.active) {
-            await stompClient.deactivate();
-        }
-
-        set({
-            stompClient: null,
-            connectionStatus: 'disconnected',
-            shouldReconnect: false,
-        });
-
-        console.info('[Socket] 소켓 연결 해제 완료');
+    dismissError: () => {
+        set({ lastError: null });
     },
 }));
+
+export function configureSocketStoreForTest(
+    nextDependencies: Partial<SocketRuntimeDependencies>,
+) {
+    dependencies = {
+        ...defaultDependencies,
+        ...nextDependencies,
+    };
+}
+
+export function resetSocketStoreForTest() {
+    clearRetryTimer();
+    dependencies = defaultDependencies;
+    currentClient = null;
+    currentAccessToken = null;
+    currentGeneration = 0;
+    intentionalDisconnect = true;
+    retryAttempt = 0;
+    lifecyclePromise = Promise.resolve();
+    recoveryPromise = null;
+    lastHandledError = null;
+    useSocketStore.setState({
+        stompClient: null,
+        connectionStatus: 'disconnected',
+        lastError: null,
+    });
+}

--- a/src/store/useSocketStore.ts
+++ b/src/store/useSocketStore.ts
@@ -90,6 +90,7 @@ let retryAttempt = 0;
 let retryTimer: ReturnType<typeof setTimeout> | null = null;
 let lifecyclePromise: Promise<void> = Promise.resolve();
 let recoveryPromise: Promise<void> | null = null;
+let suppressCloseRetryGeneration: number | null = null;
 let lastHandledError:
     | {
         signature: string;
@@ -156,6 +157,7 @@ async function deactivateCurrentClient(options: DeactivateOptions = {}) {
     clearRetryTimer();
     intentionalDisconnect = intentional;
     currentGeneration += 1;
+    suppressCloseRetryGeneration = null;
     currentClient = null;
 
     if (!preserveToken) {
@@ -287,6 +289,7 @@ async function replaceClient(
 
             useSocketStore.setState({
                 connectionStatus: 'connected',
+                lastError: null,
             });
         },
         onDisconnect: () => {
@@ -326,6 +329,13 @@ async function replaceClient(
                 return;
             }
 
+            if (suppressCloseRetryGeneration === generation) {
+                useSocketStore.setState({
+                    connectionStatus: 'disconnected',
+                });
+                return;
+            }
+
             const payload: StompErrorPayload = {
                 type: 'STOMP_ERROR',
                 code: 'WEBSOCKET_CLOSED',
@@ -342,6 +352,7 @@ async function replaceClient(
     });
 
     currentGeneration = generation;
+    suppressCloseRetryGeneration = null;
     currentClient = client;
     currentAccessToken = accessToken;
     intentionalDisconnect = false;
@@ -465,6 +476,10 @@ async function handleStompError(frame: IFrame, generation: number) {
 
     setSocketError(payload, signature);
 
+    if (payload.action === 'NONE') {
+        suppressCloseRetryGeneration = generation;
+    }
+
     if (!payload.recoverable && payload.action === 'NONE') {
         clearRetryTimer();
     }
@@ -540,6 +555,7 @@ export function resetSocketStoreForTest() {
     retryAttempt = 0;
     lifecyclePromise = Promise.resolve();
     recoveryPromise = null;
+    suppressCloseRetryGeneration = null;
     lastHandledError = null;
     useSocketStore.setState({
         stompClient: null,

--- a/src/types/socket.ts
+++ b/src/types/socket.ts
@@ -1,0 +1,53 @@
+export const STOMP_ERROR_ACTIONS = [
+    'RETURN_TO_LOBBY_LIST',
+    'RETRY_CONNECT',
+    'REFRESH_AND_RETRY',
+    'RECONNECT',
+    'REFRESH_TOKEN',
+    'RELOGIN',
+    'NONE',
+] as const;
+
+export type StompErrorAction = typeof STOMP_ERROR_ACTIONS[number];
+
+export type StompErrorCode =
+    | 'ACCESS_TOKEN_MISSING'
+    | 'ACCESS_TOKEN_INVALID'
+    | 'ACCESS_TOKEN_EXPIRED'
+    | 'CONNECT_USER_IDENTIFIER_MISSING'
+    | 'CONNECT_USER_IDENTIFIER_INVALID'
+    | 'CONNECT_SESSION_SEQUENCE_FAILED'
+    | 'CONNECT_WS_SESSION_ID_MISSING'
+    | 'CONNECT_ONLINE_STATUS_FAILED'
+    | 'CONNECT_SESSION_REVOKED'
+    | 'SESSION_UNAUTHENTICATED'
+    | 'SESSION_REVOKED'
+    | 'LOBBY_ENTER_WS_SESSION_MISSING'
+    | 'LOBBY_ENTER_SESSION_ATTRIBUTES_MISSING'
+    | 'LOBBY_ENTER_SEQUENCE_MISSING'
+    | 'LOBBY_NOT_FOUND'
+    | 'LOBBY_FULL'
+    | 'LOBBY_NOT_WAITING'
+    | 'LOBBY_INVALID_CAPACITY'
+    | 'LOBBY_STALE_SESSION'
+    | 'LOBBY_KICKED_USER'
+    | 'LOBBY_INVALID_SEQUENCE'
+    | 'LOBBY_ENTER_UNKNOWN_RESULT'
+    | 'LOBBY_ENTER_TEMPORARILY_UNAVAILABLE'
+    | 'INTERNAL_STOMP_ERROR'
+    | 'MALFORMED_STOMP_ERROR'
+    | string;
+
+export interface StompErrorPayload {
+    type: 'STOMP_ERROR';
+    code: StompErrorCode;
+    message: string;
+    action: StompErrorAction;
+    recoverable: boolean;
+    timestamp: string;
+}
+
+export interface SocketErrorNotice extends StompErrorPayload {
+    signature: string;
+}
+

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -31,5 +31,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,5 @@
+/// <reference types="vitest/config" />
+
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
@@ -23,6 +25,13 @@ export default defineConfig({
         ws: true,
         changeOrigin: true,
       },
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    env: {
+      VITE_WS_URL: '/ws',
+      VITE_ENABLE_MSW: 'false',
     },
   },
 });


### PR DESCRIPTION
## 📣 Related Issue

- #150

## 📝 Summary

- REST 401 재시도와 STOMP 오류 복구가 같은 Refresh API single-flight를 공유하도록 인증 세션 갱신 로직을 분리했습니다.
- STOMP CONNECT 인증 방식을 `userIdentifier` 헤더에서 `Authorization: Bearer <accessToken>` 헤더로 변경했습니다.
- BE의 `StompErrorPayload`, `StompErrorAction`, `StompErrorCode` 계약에 맞춘 타입과 Zod 스키마를 추가했습니다.
- STOMP ERROR를 `message` 문자열이 아니라 `action`과 `recoverable` 기준으로 처리하도록 수정했습니다.
- STOMP Client 자체의 무한 자동 재연결을 비활성화하고, `[1000, 3000, 5000]ms` 제한 backoff 재시도 정책을 적용했습니다.
- generation, lifecycle Promise queue, recovery Promise, retry timer 정리로 토큰 변경·로그아웃·Strict Mode 상황의 Client 경쟁 상태를 방지했습니다.
- `REFRESH_TOKEN`, `RELOGIN`, `RETURN_TO_LOBBY_LIST`, `RECONNECT`, `RETRY_CONNECT`, `REFRESH_AND_RETRY`, `NONE` action별 복구 정책을 구현했습니다.
- WebSocket 오류 상태를 표시하는 작은 전역 알림 컴포넌트를 추가했습니다.
- Vitest 테스트 환경을 추가하고 STOMP 인증, 토큰 변경, 종료, 오류 복구, malformed ERROR, 중복 처리, React 생명주기 테스트를 작성했습니다.

## 🙏PR point

- `REFRESH_AND_RETRY` 처리를 위해 `QueryClient`를 `src/services/queryClient.ts`로 분리했습니다. 기존 React Query 옵션은 유지했습니다.
- STOMP 라이브러리의 `reconnectDelay`는 `0`으로 고정하고, 재시도는 `useSocketStore`에서 직접 관리합니다.
- `RETURN_TO_LOBBY_LIST`는 인증 세션은 유지하되 게임 상태를 초기화하고 `/lobbies`로 이동한 뒤 현재 Access Token으로 전역 소켓을 한 번만 복구합니다.
- `RELOGIN` 계열 오류는 세션과 게임 상태를 초기화하고 `/`로 이동합니다.
- `npm run lint`는 통과했지만 기존 `public/mockServiceWorker.js`의 unused eslint-disable warning 1개가 남아 있습니다.
- `npm run build`는 통과했지만 기존 번들 크기 관련 Vite chunk size warning이 남아 있습니다.

## 📬 Reference

- Monomat-BE `StompErrorPayload`
- Monomat-BE `StompErrorAction`
- Monomat-BE `StompErrorCode`